### PR TITLE
Output log messages during engine operations that may be time-consuming.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -7,6 +7,8 @@ import htsjdk.samtools.metrics.StringHeader;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.zip.DeflaterFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.net.InetAddress;
@@ -32,6 +34,7 @@ import java.util.List;
  *
  */
 public abstract class CommandLineProgram {
+    protected static final Logger logger = LogManager.getLogger(CommandLineProgram.class);
 
     @Argument(common=true, optional=true)
     public List<File> TMP_DIR = new ArrayList<>();
@@ -85,9 +88,12 @@ public abstract class CommandLineProgram {
      */
     public final Object runTool(){
         try {
+            logger.info("Initializing engine");
             onStartup();
+            logger.info("Done initializing engine");
             return doWork();
         } finally {
+            logger.info("Shutting down engine");
             onShutdown();
         }
     }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="FRED %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
   <Loggers>


### PR DESCRIPTION
This includes general engine initialization, interval processing, and
SAM/BAM reader querying.

Also remove puzzling "FRED" prefix from our log output :)

Resolves #250