### PR TITLE
disable all broken picard tests

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/illumina/IlluminaBasecallsToFastqTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/illumina/IlluminaBasecallsToFastqTest.java
@@ -1,10 +1,7 @@
 package org.broadinstitute.hellbender.tools.picard.illumina;
 
 import htsjdk.samtools.util.BufferedLineReader;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.LineReader;
-import htsjdk.samtools.util.StringUtil;
-import htsjdk.samtools.util.TestUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.tools.picard.illumina.parser.ReadStructure;
 import org.testng.annotations.Test;
@@ -12,13 +9,13 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.PrintWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import static htsjdk.samtools.util.IOUtil.assertFilesEqual;
 import static htsjdk.samtools.util.StringUtil.join;
 import static htsjdk.samtools.util.TestUtil.recursiveDelete;
 import static java.util.Arrays.copyOfRange;
-import static org.broadinstitute.hellbender.tools.picard.illumina.IlluminaBasecallsToFastq.ReadNameFormat;
 import static org.broadinstitute.hellbender.tools.picard.illumina.IlluminaBasecallsToFastq.ReadNameFormat.ILLUMINA;
 
 public class IlluminaBasecallsToFastqTest extends CommandLineProgramTest {
@@ -32,7 +29,7 @@ public class IlluminaBasecallsToFastqTest extends CommandLineProgramTest {
         return IlluminaBasecallsToFastq.class.getSimpleName();
     }
 
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testNonBarcoded() throws Exception {
         final String suffix = ".1.fastq";
         final File outputFastq1 = File.createTempFile("nonBarcoded.", suffix);
@@ -54,7 +51,7 @@ public class IlluminaBasecallsToFastqTest extends CommandLineProgramTest {
         assertFilesEqual(outputFastq2, new File(TEST_DATA_DIR, "nonBarcoded.2.fastq"));
     }
 
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testMultiplexWithIlluminaReadNameHeaders() throws Exception {
         final File outputDir = File.createTempFile("testMultiplexRH.", ".dir");
         try {
@@ -89,12 +86,12 @@ public class IlluminaBasecallsToFastqTest extends CommandLineProgramTest {
         }
     }
 
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testDeMultiplexed() throws Exception {
         runStandardTest(1, "multiplexedBarcode.", "mp_barcode.params", 1, "25T8B25T", BASECALLS_DIR, TEST_DATA_DIR);
     }
 
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testDualBarcodes() throws Exception {
         runStandardTest(1, "dualBarcode.", "barcode_double.params", 2, "25T8B8B25T", DUAL_BASECALLS_DIR, DUAL_TEST_DATA_DIR);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/illumina/IlluminaBasecallsToSamTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/illumina/IlluminaBasecallsToSamTest.java
@@ -32,7 +32,7 @@ public class IlluminaBasecallsToSamTest extends CommandLineProgramTest {
         return IlluminaBasecallsToSam.class.getSimpleName();
     }
 
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testTileNumberComparator() {
         assertTrue(TILE_NUMBER_COMPARATOR.compare(100, 10) < 0, "");
         assertTrue(TILE_NUMBER_COMPARATOR.compare(20, 200) > 0, "");
@@ -40,23 +40,23 @@ public class IlluminaBasecallsToSamTest extends CommandLineProgramTest {
     }
 
 
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testNonBarcoded() throws Exception {
         runStandardTest(1, "nonBarcode.", "non_barcoded.params", 1, "25S8S25T", BASECALLS_DIR, TEST_DATA_DIR);
     }
 
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testMultiplexed() throws Exception {
         runStandardTest(1, "multiplexedBarcode.", "barcode.params", 1, "25T8B25T", BASECALLS_DIR, TEST_DATA_DIR);
     }
 
     //Same as testMultiplexed except we use BARCODE_1 instead of BARCODE
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testMultiplexedWithAlternateBarcodeName() throws Exception {
         runStandardTest(1, "singleBarcodeAltName.", "multiplexed_positive_rgtags.params", 1, "25T8B25T", BASECALLS_DIR, TEST_DATA_DIR);
     }
 
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testDualBarcodes() throws Exception {
         runStandardTest(1, "dualBarcode.", "barcode_double.params", 2, "25T8B8B25T", DUAL_BASECALLS_DIR, DUAL_TEST_DATA_DIR);
     }
@@ -67,7 +67,7 @@ public class IlluminaBasecallsToSamTest extends CommandLineProgramTest {
      * TODO: This testcase isn't broken, but can spawn an issue with FileChannelJDKBugWorkAround since it expects
      * an exception to be thrown.
      */
-    @Test(groups = {"broken"})
+    @Test(groups = {"broken"}, enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testCorruptDataReturnCode() throws Exception {
         boolean exceptionThrown = false;
         try {

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/illumina/parser/IlluminaDataProviderTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/illumina/parser/IlluminaDataProviderTest.java
@@ -104,7 +104,7 @@ public class IlluminaDataProviderTest {
         dataProvider.close();
     }
 
-    @Test
+    @Test(enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void barcodeParsingTest() {
         runBarcodeParsingTest(new IlluminaDataProviderFactory(BINARY_TD_LOCATION, 1, new ReadStructure("25T8B25T"), bclQualityEvaluationStrategy, IlluminaDataType.BaseCalls,
                 IlluminaDataType.Barcodes));
@@ -156,7 +156,7 @@ public class IlluminaDataProviderTest {
         };
     }
 
-    @Test(dataProvider = "binaryData")
+    @Test(dataProvider = "binaryData", enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testIlluminaDataProviderBclMethod(
             final String testName, final int lane, final int size,
             final List<Integer> tiles,
@@ -224,7 +224,7 @@ public class IlluminaDataProviderTest {
         };
     }
 
-    @Test(dataProvider = "badData", expectedExceptions = {IlluminaParserException.class, IllegalArgumentException.class})
+    @Test(dataProvider = "badData", expectedExceptions = {IlluminaParserException.class, IllegalArgumentException.class}, enabled = false, description = "bug https://github.com/broadinstitute/hellbender/issues/364")
     public void testIlluminaDataProviderMissingDatas(final int lane,
                                                      final IlluminaDataType[] actualDts,
                                                      final String illuminaConfigStr,


### PR DESCRIPTION
due to broken picard tests, we need to disable them. https://github.com/broadinstitute/hellbender/issues/364

fixing them is the highest priority item for the next iteration. @lbergelson please review