### PR TITLE
improve the handling of GATKTool optionally required arguments

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalFeatureInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalFeatureInputArgumentCollection.java
@@ -16,7 +16,7 @@ import java.util.List;
  */
 public class OptionalFeatureInputArgumentCollection implements ArgumentCollectionDefinition {
 
-    @Argument(fullName = StandardArgumentDefinitions.FEATURE_LONG_NAME, shortName = StandardArgumentDefinitions.FEATURE_SHORT_NAME, doc = "One or more files containing features", optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.FEATURE_LONG_NAME, shortName = StandardArgumentDefinitions.FEATURE_SHORT_NAME, doc = "File containing features", optional = true)
     public List<FeatureInput<Feature>> featureFiles;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalIntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalIntervalArgumentCollection.java
@@ -1,0 +1,27 @@
+
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.Argument;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An interval argument class that allows -L to be specified but does not require it.
+ */
+public final class OptionalIntervalArgumentCollection extends IntervalArgumentCollection {
+
+    @Argument(fullName = "intervals", shortName = "L", doc = "One or more genomic intervals over which to operate", optional = true)
+    final protected List<String> intervalStrings = new ArrayList<>();
+
+    @Override
+    protected List<String> getIntervalStrings() {
+        return intervalStrings;
+    }
+
+    @Override
+    protected void addToIntervalStrings(String newInterval) {
+        intervalStrings.add(newInterval);
+    }
+}
+

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReadInputArgumentCollection.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
-import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 
 import java.io.File;
@@ -11,9 +10,13 @@ import java.util.List;
  * An argument collection for use with tools that accept zero or more input files containing reads
  * (eg., BAM/SAM/CRAM files).
  */
-public class OptionalReadInputArgumentCollection implements ArgumentCollectionDefinition {
+public final class OptionalReadInputArgumentCollection extends ReadInputArgumentCollection {
 
-    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "One or more BAM/SAM/CRAM files containing reads", optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "BAM/SAM/CRAM file containing reads", optional = true)
     public List<File> readFiles;
 
+    @Override
+    public List<File> getReadFiles() {
+        return readFiles;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalReferenceInputArgumentCollection.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
-import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 
 import java.io.File;
@@ -9,9 +8,13 @@ import java.io.File;
 /**
  * An argument collection for use with tools that optionally accept a reference file as input.
  */
-public class OptionalReferenceInputArgumentCollection implements ArgumentCollectionDefinition {
+public final class OptionalReferenceInputArgumentCollection extends ReferenceInputArgumentCollection {
 
     @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence", optional = true)
-    public File referenceFile;
+    private File referenceFile;
 
+    @Override
+    public File getReferenceFile() {
+        return referenceFile;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalVariantInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/OptionalVariantInputArgumentCollection.java
@@ -15,7 +15,7 @@ import java.util.List;
  */
 public class OptionalVariantInputArgumentCollection implements ArgumentCollectionDefinition {
 
-    @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME, shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, doc = "One or more files containing variants", optional = true)
+    @Argument(fullName = StandardArgumentDefinitions.VARIANT_LONG_NAME, shortName = StandardArgumentDefinitions.VARIANT_SHORT_NAME, doc = "Variants file", optional = true)
     public List<FeatureInput<VariantContext>> variantFiles;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollection.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+
+import java.io.File;
+import java.util.List;
+
+
+/**
+ * An abstract argument collection for use with tools that accept input files containing reads
+ * (eg., BAM/SAM/CRAM files).
+ */
+public abstract class ReadInputArgumentCollection implements ArgumentCollectionDefinition {
+
+    /**
+     * Get the list of BAM/SAM/CRAM files specified at the command line
+     */
+    public abstract List<File> getReadFiles();
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollection.java
@@ -1,0 +1,15 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
+
+import java.io.File;
+
+/**
+ * An abstract ArgumentCollection for specifying a reference sequence file
+ */
+public abstract class ReferenceInputArgumentCollection implements ArgumentCollectionDefinition {
+    /**
+     * Get the reference file specified at the command line.
+     */
+    abstract public File getReferenceFile();
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredFeatureInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredFeatureInputArgumentCollection.java
@@ -16,7 +16,7 @@ import java.util.List;
  */
 public class RequiredFeatureInputArgumentCollection implements ArgumentCollectionDefinition {
 
-    @Argument(fullName = StandardArgumentDefinitions.FEATURE_LONG_NAME, shortName = StandardArgumentDefinitions.FEATURE_SHORT_NAME, doc = "One or more files containing features", optional = false)
+    @Argument(fullName = StandardArgumentDefinitions.FEATURE_LONG_NAME, shortName = StandardArgumentDefinitions.FEATURE_SHORT_NAME, doc = "File containing features", optional = false)
     public List<FeatureInput<Feature>> featureFiles;
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredIntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredIntervalArgumentCollection.java
@@ -1,0 +1,27 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+
+import org.broadinstitute.hellbender.cmdline.Argument;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * An ArgumentCollection that requires one or more intervals be specified with -L at the command line
+ */
+public final class RequiredIntervalArgumentCollection extends IntervalArgumentCollection {
+
+    @Argument(fullName = "intervals", shortName = "L", doc = "One or more genomic intervals over which to operate", optional = false)
+    final protected List<String> intervalStrings = new ArrayList<>();
+
+    @Override
+    protected List<String> getIntervalStrings() {
+        return intervalStrings;
+    }
+
+    @Override
+    protected void addToIntervalStrings(String newInterval) {
+        intervalStrings.add(newInterval);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReadInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReadInputArgumentCollection.java
@@ -1,20 +1,22 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
-import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * An argument collection for use with tools that accept one or more input files containing reads
  * (eg., BAM/SAM/CRAM files), and require at least one such input.
  */
-public class RequiredReadInputArgumentCollection implements ArgumentCollectionDefinition {
+public class RequiredReadInputArgumentCollection extends ReadInputArgumentCollection {
 
-    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "One or more BAM/SAM/CRAM files containing reads", optional = false)
-    public List<File> readFiles = new ArrayList<>();
+    @Argument(fullName = StandardArgumentDefinitions.INPUT_LONG_NAME, shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, doc = "BAM/SAM/CRAM file containing reads", optional = false)
+    private List<File> readFiles;
 
+    @Override
+    public List<File> getReadFiles() {
+        return readFiles;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReferenceInputArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/RequiredReferenceInputArgumentCollection.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
 import org.broadinstitute.hellbender.cmdline.Argument;
-import org.broadinstitute.hellbender.cmdline.ArgumentCollectionDefinition;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 
 import java.io.File;
@@ -9,9 +8,10 @@ import java.io.File;
 /**
  * An argument collection for use with tools that require a reference file as input.
  */
-public class RequiredReferenceInputArgumentCollection implements ArgumentCollectionDefinition {
+public class RequiredReferenceInputArgumentCollection extends ReferenceInputArgumentCollection {
 
-    @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence", optional = false)
-    public File referenceFile;
+    @Argument(fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME, doc = "Reference sequence file", optional = false)
+    private File referenceFile;
 
+    public File getReferenceFile(){ return referenceFile;}
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSR.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/ApplyBQSR.java
@@ -86,7 +86,7 @@ public final class ApplyBQSR extends ReadWalker{
     @Override
     public void onTraversalStart() {
         final SAMFileHeader outputHeader = ReadUtils.clone(getHeaderForReads());
-        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, referenceArguments.referenceFile);
+        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, referenceArguments.getReferenceFile());
         transform = new BQSRReadTransformer(BQSR_RECAL_FILE, quantizationLevels, disableIndelQuals, PRESERVE_QSCORES_LESS_THAN, emitOriginalQuals, globalQScorePrior);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/ClipReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/ClipReads.java
@@ -279,7 +279,7 @@ public final class ClipReads extends ReadWalker {
 
         final boolean presorted = EnumSet.of(ClippingRepresentation.WRITE_NS, ClippingRepresentation.WRITE_NS_Q0S, ClippingRepresentation.WRITE_Q0S).contains(clippingRepresentation);
         final SAMFileHeader outputHeader = ReadUtils.clone(getHeaderForReads());
-        outputBam = new SAMFileWriterFactory().makeWriter(outputHeader, presorted, OUTPUT, referenceArguments.referenceFile);
+        outputBam = new SAMFileWriterFactory().makeWriter(outputHeader, presorted, OUTPUT, referenceArguments.getReferenceFile());
 
         accumulator = new ClippingData(sequencesToClip);
         try {

--- a/src/main/java/org/broadinstitute/hellbender/tools/FixMisencodedBaseQualityReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/FixMisencodedBaseQualityReads.java
@@ -34,7 +34,7 @@ public class FixMisencodedBaseQualityReads extends ReadWalker {
     @Override
     public void onTraversalStart() {
         final SAMFileHeader outputHeader = getHeaderForReads().clone();
-        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, referenceArguments.referenceFile);
+        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, referenceArguments.getReferenceFile());
         transform = new MisencodedBaseQualityReadTransformer();
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/LeftAlignIndels.java
@@ -2,8 +2,8 @@ package org.broadinstitute.hellbender.tools;
 
 
 import htsjdk.samtools.*;
-import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
@@ -63,7 +63,7 @@ public class LeftAlignIndels extends ReadWalker {
     @Override
     public void onTraversalStart() {
         final SAMFileHeader outputHeader = ReadUtils.clone(getHeaderForReads());
-        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, referenceArguments.referenceFile);
+        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, referenceArguments.getReferenceFile());
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/PrintReads.java
@@ -26,7 +26,7 @@ public class PrintReads extends ReadWalker {
     @Override
     public void onTraversalStart() {
         final SAMFileHeader outputHeader = ReadUtils.clone(getHeaderForReads());
-        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, referenceArguments.referenceFile);
+        outputWriter = new SAMFileWriterFactory().makeWriter(outputHeader, true, OUTPUT, referenceArguments.getReferenceFile());
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/SplitReads.java
@@ -51,7 +51,7 @@ public class SplitReads extends ReadWalker {
     @Override
     public void onTraversalStart() {
         IOUtil.assertDirectoryIsWritable(OUTPUT_DIRECTORY);
-        if ( readArguments.readFiles.size() != 1 ) {
+        if ( readArguments.getReadFiles().size() != 1 ) {
             throw new UserException("This tool only accepts a single SAM/BAM as input");
         }
 
@@ -86,8 +86,8 @@ public class SplitReads extends ReadWalker {
         final SAMFileWriterFactory samFileWriterFactory = new SAMFileWriterFactory();
 
         final SAMFileHeader samFileHeaderIn = getHeaderForReads();
-        final String base = FilenameUtils.getBaseName(readArguments.readFiles.get(0).getName());
-        final String extension = "." + FilenameUtils.getExtension(readArguments.readFiles.get(0).getName());
+        final String base = FilenameUtils.getBaseName(readArguments.getReadFiles().get(0).getName());
+        final String extension = "." + FilenameUtils.getExtension(readArguments.getReadFiles().get(0).getName());
 
         // Build up a list of key options at each level.
         final List<List<?>> splitKeys = splitters.stream()
@@ -98,7 +98,7 @@ public class SplitReads extends ReadWalker {
         addKey(splitKeys, 0, "", key -> {
             final SAMFileHeader samFileHeaderOut = ReadUtils.clone(samFileHeaderIn);
             final File outFile = new File(OUTPUT_DIRECTORY, base + key + extension);
-            outs.put(key, samFileWriterFactory.makeWriter(samFileHeaderOut, true, outFile, referenceArguments.referenceFile));
+            outs.put(key, samFileWriterFactory.makeWriter(samFileHeaderOut, true, outFile, referenceArguments.getReferenceFile()));
         });
 
         return outs;

--- a/src/main/java/org/broadinstitute/hellbender/tools/examples/PrintReadsWithReference.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/examples/PrintReadsWithReference.java
@@ -31,6 +31,11 @@ public class PrintReadsWithReference extends ReadWalker {
     private PrintStream outputStream = null;
 
     @Override
+    public boolean requiresReference(){
+        return true;
+    }
+
+    @Override
     public void onTraversalStart() {
         try {
             outputStream = OUTPUT_FILE != null ? new PrintStream(OUTPUT_FILE) : System.out;

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
@@ -193,7 +193,7 @@ public class BaseRecalibrator extends ReadWalker {
         initializeRecalibrationEngine();
         minimumQToUse = PRESERVE_QSCORES_LESS_THAN;
 
-        referenceDataSource = new ReferenceDataSource(referenceArguments.referenceFile);
+        referenceDataSource = new ReferenceDataSource(referenceArguments.getReferenceFile());
     }
 
     private Covariate[] getCovariatesArray() {

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
@@ -1,83 +1,113 @@
 package org.broadinstitute.hellbender.cmdline.argumentcollections;
 
-import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.CommandLineParser;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.GenomeLoc;
 import org.broadinstitute.hellbender.utils.IntervalSetRule;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 
 public class IntervalArgumentCollectionTest extends BaseTest{
 
-    @Test(expectedExceptions = GATKException.class)
-    public void emptyIntervalsTest(){
-        IntervalArgumentCollection iac = new IntervalArgumentCollection();
+    @DataProvider(name = "optionalOrNot")
+    public Object[][] optionalOrNot(){
+        return new Object[][]{
+                { new OptionalIntervalArgumentCollection()},
+                { new RequiredIntervalArgumentCollection()}
+        };
+    }
+
+    private static class WithOptionalIntervals{
+        @ArgumentCollection
+        IntervalArgumentCollection iac = new OptionalIntervalArgumentCollection();
+    }
+
+    private static class WithRequiredIntervals{
+        @ArgumentCollection
+        IntervalArgumentCollection iac = new RequiredIntervalArgumentCollection();
+    }
+
+    @Test
+    public void testOptionalIsOptional(){
+        WithOptionalIntervals opt = new WithOptionalIntervals();
+        CommandLineParser clp = new CommandLineParser(opt);
+        String[] args = {};
+        clp.parseArguments(System.out, args);
+    }
+
+    @Test(expectedExceptions = UserException.class)
+    public void testRequiredIsRequired(){
+        WithRequiredIntervals opt = new WithRequiredIntervals();
+        CommandLineParser clp = new CommandLineParser(opt);
+        String[] args = {};
+        clp.parseArguments(System.out, args);
+    }
+
+
+    @Test(dataProvider = "optionalOrNot",expectedExceptions = GATKException.class)
+    public void emptyIntervalsTest(IntervalArgumentCollection iac){
         Assert.assertFalse(iac.intervalsSpecified());
         iac.getIntervals(hg19GenomeLocParser);  //should throw an exception
     }
 
-    @Test
-    public void testExcludeWithNoIncludes(){
-        IntervalArgumentCollection iac = new IntervalArgumentCollection();
+    @Test(dataProvider = "optionalOrNot")
+    public void testExcludeWithNoIncludes(IntervalArgumentCollection iac){
         iac.excludeIntervalStrings.addAll(Arrays.asList("1", "2", "3"));
         Assert.assertTrue(iac.intervalsSpecified());
         GenomeLoc chr4GenomeLoc = hg19GenomeLocParser.createOverEntireContig("4");
         Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser), Arrays.asList(new SimpleInterval(chr4GenomeLoc)));
     }
 
-    @Test
-    public void testIncludeWithExclude(){
-        IntervalArgumentCollection iac = new IntervalArgumentCollection();
-        iac.intervalStrings.add("1:1-100");
+    @Test(dataProvider = "optionalOrNot")
+    public void testIncludeWithExclude(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("1:1-100");
         iac.excludeIntervalStrings.add("1:90-200");
         Assert.assertTrue(iac.intervalsSpecified());
         Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser), Arrays.asList(new SimpleInterval("1", 1, 89)));
     }
 
-    @Test
-    public void testIntervalSetRule(){
-        IntervalArgumentCollection iac = new IntervalArgumentCollection();
-        iac.intervalStrings.add("1:1-100");
-        iac.intervalStrings.add("1:90-200");
+    @Test(dataProvider = "optionalOrNot")
+    public void testIntervalSetRule(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("1:1-100");
+        iac.addToIntervalStrings("1:90-200");
         iac.intervalSetRule = IntervalSetRule.INTERSECTION;
         Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser), Arrays.asList(new SimpleInterval("1", 90, 100)));
         iac.intervalSetRule = IntervalSetRule.UNION;
         Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser), Arrays.asList(new SimpleInterval("1", 1, 200)));
     }
 
-    @Test
-    public void testPadding(){
-        IntervalArgumentCollection iac = new IntervalArgumentCollection();
-        iac.intervalStrings.add("1:20-30");
+    @Test(dataProvider = "optionalOrNot")
+    public void testPadding(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("1:20-30");
         iac.intervalPadding = 10;
         Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser), Arrays.asList(new SimpleInterval("1", 10, 40)));
     }
 
-    @Test( expectedExceptions = UserException.BadArgumentValue.class)
-    public void testAllExcluded(){
-        IntervalArgumentCollection iac = new IntervalArgumentCollection();
-        iac.intervalStrings.add("1:10-20");
+    @Test(dataProvider = "optionalOrNot", expectedExceptions = UserException.BadArgumentValue.class)
+    public void testAllExcluded(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("1:10-20");
         iac.excludeIntervalStrings.add("1:1-200");
         iac.getIntervals(hg19GenomeLocParser);
     }
 
-    @Test( expectedExceptions= UserException.BadArgumentValue.class)
-    public void testNoIntersection(){
-        IntervalArgumentCollection iac = new IntervalArgumentCollection();
-        iac.intervalStrings.add("1:10-20");
-        iac.intervalStrings.add("1:50-200");
+    @Test(dataProvider = "optionalOrNot", expectedExceptions= UserException.BadArgumentValue.class)
+    public void testNoIntersection(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("1:10-20");
+        iac.addToIntervalStrings("1:50-200");
         iac.intervalSetRule = IntervalSetRule.INTERSECTION;
         iac.getIntervals(hg19GenomeLocParser);
     }
 
-    @Test( expectedExceptions = UserException.BadArgumentValue.class)
-    public void testUmapped(){
-        IntervalArgumentCollection iac = new IntervalArgumentCollection();
-        iac.intervalStrings.add("unmapped");
+    @Test(dataProvider = "optionalOrNot", expectedExceptions = UserException.BadArgumentValue.class)
+    public void testUmapped(IntervalArgumentCollection iac){
+        iac.addToIntervalStrings("unmapped");
         iac.getIntervals(hg19GenomeLocParser);
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReadInputArgumentCollectionTest.java
@@ -1,0 +1,33 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class ReadInputArgumentCollectionTest {
+
+    @Test(expectedExceptions = UserException.CommandLineException.class)
+    public void testRequiredIsRequired(){
+        Object req = new Object(){
+            @ArgumentCollection
+            private ReadInputArgumentCollection ric = new RequiredReadInputArgumentCollection();
+        };
+        CommandLineParser clp = new CommandLineParser(req);
+        String[] args = {};
+        clp.parseArguments(System.out, args);
+    }
+
+    @Test
+    public void testOptionalIsOptional(){
+        Object req = new Object(){
+            @ArgumentCollection
+            private ReadInputArgumentCollection ric = new OptionalReadInputArgumentCollection();
+        };
+        CommandLineParser clp = new CommandLineParser(req);
+        String[] args = {};
+        clp.parseArguments(System.out, args);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/ReferenceInputArgumentCollectionTest.java
@@ -1,0 +1,35 @@
+package org.broadinstitute.hellbender.cmdline.argumentcollections;
+
+
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.CommandLineParser;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.testng.annotations.Test;
+
+public class ReferenceInputArgumentCollectionTest {
+    private static class WithOptionalReferenceCollection {
+        @ArgumentCollection
+        ReferenceInputArgumentCollection ric = new OptionalReferenceInputArgumentCollection();
+    }
+
+    private static class WithRequiredReferenceCollection {
+        @ArgumentCollection
+        ReferenceInputArgumentCollection ric = new RequiredReferenceInputArgumentCollection();
+    }
+
+    @Test
+    public void testOptionalIsOptional(){
+        String[] args = {};
+        WithOptionalReferenceCollection optional = new WithOptionalReferenceCollection();
+        CommandLineParser clp = new CommandLineParser(optional);
+        clp.parseArguments(System.out, args);
+    }
+
+    @Test(expectedExceptions = UserException.CommandLineException.class)
+    public void testRequiredIsRequired(){
+        String[] args = {};
+        WithRequiredReferenceCollection required = new WithRequiredReferenceCollection();
+        CommandLineParser clp = new CommandLineParser(required);
+        clp.parseArguments(System.out, args);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/CountReadsDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/CountReadsDataflowIntegrationTest.java
@@ -15,6 +15,7 @@ public class CountReadsDataflowIntegrationTest extends CommandLineProgramTest{
     @DataProvider(name="intervals")
     public Object[][] intervals(){
         return new Object[][]{
+                new Object[]{"",7L}, // no intervals specified, see all reads that are aligned
                 new Object[]{"-L chr7:1", 3l},
                 new Object[]{"-L chr7:1-20", 4l},
                 new Object[]{"-L chr1", 0l},


### PR DESCRIPTION
GATKTool now instantiates appropriate argument collections based on the value of requiresReads, requieresReference, and requiresIntervals
these use the standard argument parsing system and show up in help instead of being a special case
Features/variants are still handled specially because they are handled differently
added Optional/Required versions of these and Feature/Variant argument collections

addresses a special case of #149 