### PR TITLE
Adding SimpleInterval(Locatable) constructor

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollection.java
@@ -128,7 +128,7 @@ public class IntervalArgumentCollection implements ArgumentCollectionDefinition 
                 throw new UserException("Unmapped intervals are not currently supported");
             }
 
-            convertedIntervals.add(new SimpleInterval(genomeLoc.getContig(), genomeLoc.getStart(), genomeLoc.getStop()));
+            convertedIntervals.add(new SimpleInterval(genomeLoc));
         }
         return convertedIntervals;
     }

--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -647,7 +647,7 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
          * @return true if we haven't seen the Feature before on this iteration, otherwise false
          */
         private boolean featureIsNovel( final T feature ) {
-            return previousInterval == null || ! previousInterval.overlaps(new SimpleInterval(feature.getContig(), feature.getStart(), feature.getEnd()));
+            return previousInterval == null || ! previousInterval.overlaps(new SimpleInterval(feature));
         }
 
         /**

--- a/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/ReadWalker.java
@@ -59,7 +59,7 @@ public abstract class ReadWalker extends GATKTool {
                 .filter(filter)
                 .forEach(read -> {
                     final SimpleInterval readInterval = read.getReadUnmappedFlag() ? null :
-                                                                                     new SimpleInterval(read.getReferenceName(), read.getAlignmentStart(), read.getAlignmentEnd());
+                                                                                     new SimpleInterval(read);
                     apply(read,
                           new ReferenceContext(reference, readInterval), // Will create an empty ReferenceContext if reference or readInterval == null
                           new FeatureContext(features, readInterval));   // Will create an empty FeatureContext if features or readInterval == null

--- a/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/VariantWalker.java
@@ -74,7 +74,7 @@ public abstract class VariantWalker extends GATKTool {
         StreamSupport.stream(drivingVariants.spliterator(), false)
                 .filter(filter)
                 .forEach(variant -> {
-                    final SimpleInterval variantInterval = new SimpleInterval(variant.getContig(), variant.getStart(), variant.getEnd());
+                    final SimpleInterval variantInterval = new SimpleInterval(variant);
                     apply(variant,
                           new ReadsContext(reads, variantInterval),
                           new ReferenceContext(reference, variantInterval),

--- a/src/main/java/org/broadinstitute/hellbender/utils/GenomeLoc.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/GenomeLoc.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils;
 
 import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 
 import java.io.Serializable;
@@ -11,7 +12,7 @@ import java.util.*;
  * can be any positive or negative number, by design.  Bound validation is a feature of the GenomeLocParser,
  * and not a fundamental constraint of the GenomeLoc
  */
-public class GenomeLoc implements Comparable<GenomeLoc>, Serializable, HasGenomeLocation {
+public class GenomeLoc implements Comparable<GenomeLoc>, Serializable, HasGenomeLocation, Locatable {
     private static final long serialVersionUID = 1L;
 
     /**
@@ -76,6 +77,12 @@ public class GenomeLoc implements Comparable<GenomeLoc>, Serializable, HasGenome
 
     public final int getContigIndex() { return this.contigIndex; }
     public final int getStart()    { return this.start; }
+
+    @Override
+    public int getEnd() {
+        return getStop();
+    }
+
     public final int getStop()     { return this.stop; }
 
     public final String toString()  {

--- a/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
@@ -1,12 +1,13 @@
-package org.broadinstitute.hellbender.utils;
+ package org.broadinstitute.hellbender.utils;
 
 
 import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.exceptions.UserException;
 
 import java.io.Serializable;
+import java.util.Objects;
 
-/**
+ /**
  * Minimal immutable class representing a 1-based closed ended genomic interval
  * SimpleInterval does not allow null contig names.  It cannot represent an unmapped Locatable.
  *
@@ -29,6 +30,27 @@ public final class SimpleInterval implements Locatable, Serializable {
      * @param end  1-based inclusive end position
      */
     public SimpleInterval(final String contig, final int start, final int end){
+        validatePositions(contig, start, end);
+        this.contig = contig;
+        this.start = start;
+        this.end = end;
+    }
+
+    /**
+     * Create a new SimpleInterval from a {@link Locatable}
+     * @param locatable any Locatable
+     * @throws IllegalArgumentException if locatable violates any of the SimpleInterval constraints or is null
+     */
+    public SimpleInterval(final Locatable locatable){
+        this(Objects.requireNonNull(locatable, () -> {throw new IllegalArgumentException();}).getContig(),
+                locatable.getStart(), locatable.getEnd());
+    }
+
+    /**
+     * Test that these are valid values for constructing a SimpleInterval
+     * @throws IllegalArgumentException if it is invalid
+     */
+    private static void validatePositions(final String contig, final int start, final int end) {
         if ( contig == null ) {
             throw new IllegalArgumentException("contig cannot be null");
         }
@@ -38,15 +60,12 @@ public final class SimpleInterval implements Locatable, Serializable {
         if ( end < start ) {
             throw new IllegalArgumentException(String.format("end must be >= start. start:%d end:%d", start, end));
         }
-        this.contig = contig;
-        this.start = start;
-        this.end = end;
     }
 
     /**
      * Makes an interval by parsing the string.
      *
-     * @Warning this method does not fill in the true contig end values
+     * @warning this method does not fill in the true contig end values
      * for intervals that reach to the end of their contig,
      * uses {@link Integer#MAX_VALUE} instead.
      *
@@ -97,6 +116,7 @@ public final class SimpleInterval implements Locatable, Serializable {
             }
         }
 
+        validatePositions(contig, start, end);
         this.contig = contig;
         this.start = start;
         this.end = end;

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/argumentcollections/IntervalArgumentCollectionTest.java
@@ -26,7 +26,7 @@ public class IntervalArgumentCollectionTest extends BaseTest{
         iac.excludeIntervalStrings.addAll(Arrays.asList("1", "2", "3"));
         Assert.assertTrue(iac.intervalsSpecified());
         GenomeLoc chr4GenomeLoc = hg19GenomeLocParser.createOverEntireContig("4");
-        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser), Arrays.asList(new SimpleInterval(chr4GenomeLoc.getContig(), chr4GenomeLoc.getStart(), chr4GenomeLoc.getStop())));
+        Assert.assertEquals(iac.getIntervals(hg19GenomeLocParser), Arrays.asList(new SimpleInterval(chr4GenomeLoc)));
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/utils/SimpleIntervalUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/SimpleIntervalUnitTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.utils;
 
+import htsjdk.samtools.util.Locatable;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -20,6 +21,18 @@ public class SimpleIntervalUnitTest extends BaseTest {
     @Test(dataProvider = "badIntervals", expectedExceptions = IllegalArgumentException.class)
     public void badIntervals(String contig, int start, int end, String name){
         SimpleInterval interval = new SimpleInterval(contig, start, end);
+
+    }
+
+    @Test(dataProvider = "badIntervals", expectedExceptions = IllegalArgumentException.class)
+    public void badIntervalsFromLocatable(String contig, int start, int end, String name){
+        Locatable l = getLocatable(contig, start, end);
+        new SimpleInterval(l);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void illegalArgumentExceptionFromNullLocatable(){
+        new SimpleInterval((Locatable)null);
     }
 
     @DataProvider(name = "goodIntervals")
@@ -42,6 +55,35 @@ public class SimpleIntervalUnitTest extends BaseTest {
         Assert.assertEquals(interval.getContig(), contig, "contig");
         Assert.assertEquals(interval.getStart(), start, "start");
         Assert.assertEquals(interval.getEnd(), end, "end");
+    }
+
+    @Test(dataProvider = "goodIntervals")
+    public void testGoodIntervalsFromLocatable(String ignoreMe, String contig, int start, int end){
+        Locatable l = getLocatable(contig, start, end);
+
+        SimpleInterval interval = new SimpleInterval(l);
+        Assert.assertEquals(interval.getContig(), contig, "contig");
+        Assert.assertEquals(interval.getStart(), start, "start");
+        Assert.assertEquals(interval.getEnd(), end, "end");
+    }
+
+    private static Locatable getLocatable(final String contig, final int start, final int end) {
+        return new Locatable() {
+            @Override
+            public String getContig() {
+                return contig;
+            }
+
+            @Override
+            public int getStart() {
+                return start;
+            }
+
+            @Override
+            public int getEnd() {
+                return end;
+            }
+        };
     }
 
     @Test
@@ -150,6 +192,7 @@ public class SimpleIntervalUnitTest extends BaseTest {
                 { containingInterval, containingInterval, true }
         };
     }
+
 
     @Test(dataProvider = "IntervalContainsData")
     public void testContains( final SimpleInterval firstInterval, final SimpleInterval secondInterval, final boolean expectedContainsResult ) {


### PR DESCRIPTION
Adding validation to the SimpleInterval(String) constructor
Making GenomeLoc implement Locatable
Replacing all instances of SimpleInterval( locatable.getContig(), locatable.getStart(), locatable.getEnd()) with the new constructor

fixes #438  and #436 