### PR TITLE
re-enable read covariates unit test

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/recalibration/CycleCovariateUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/recalibration/CycleCovariateUnitTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.recalibration;
 
 import htsjdk.samtools.SAMReadGroupRecord;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.TextCigarCodec;
 import org.broadinstitute.hellbender.tools.recalibration.covariates.CycleCovariate;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.ArtificialSAMUtils;
@@ -9,9 +10,12 @@ import org.broadinstitute.hellbender.utils.read.ReadUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import static java.lang.Math.abs;
 
 public final class CycleCovariateUnitTest {
+
     CycleCovariate covariate;
     RecalibrationArgumentCollection RAC;
 
@@ -29,8 +33,8 @@ public final class CycleCovariateUnitTest {
 
     @Test
     public void testSimpleCycles() {
-        short readLength = 10;
-        SAMRecord read = ArtificialSAMUtils.createRandomRead(readLength);
+        final short readLength = 10;
+        final SAMRecord read = ArtificialSAMUtils.createRandomRead(readLength);
         read.setReadPairedFlag(true);
         ReadUtils.setReadGroup(read, new SAMReadGroupRecord("MY.ID"));
         read.getReadGroup().setPlatform("illumina");
@@ -53,7 +57,7 @@ public final class CycleCovariateUnitTest {
     }
 
     private void verifyCovariateArray(int[][] values, int init, int increment) {
-        for (short i = 0; i < values.length; i++) {
+        for (int i = 0; i < values.length; i++) {
             short actual = Short.decode(covariate.formatKey(values[i][0]));
             int expected = init + (increment * i);
             Assert.assertEquals(actual, expected);
@@ -82,4 +86,98 @@ public final class CycleCovariateUnitTest {
         ReadCovariates readCovariates = new ReadCovariates(read.getReadLength(), 1);
         covariate.recordValues(read, readCovariates);
     }
+
+    public static int expectedCycle(SAMRecord read, final int baseNumber, final boolean indel, final int maxCycle) {
+        return CycleCovariate.cycleFromKey(CycleCovariate.cycleKey(baseNumber, read, indel, maxCycle));
+    }
+
+    @DataProvider(name="cycleKey")
+    public Object[][] cycleKey() {
+        return new Object[][]{
+                //positive strand
+                {"10M", false, false, 9, 20, false, (1+9)<<1},
+                {"10M", false, false, 1, 20, false, (1+1)<<1},
+                {"10M", false, false, 5, 20, false, (1+5)<<1},
+                {"10M", false, false, 9, 20, true,  -1}, //indels at the ends are -1
+                {"10M", false, false, 1, 20, true,  -1}, //indels at the ends are -1
+                {"10M", false, false, 5, 20, true,  (1+5)<<1},
+
+                //positive strand, second in pair
+                {"10M", false, true, 9, 20, false, (abs(-1-9)<<1)+1},
+                {"10M", false, true, 1, 20, false, (abs(-1-1)<<1)+1},
+                {"10M", false, true, 5, 20, false, (abs(-1-5)<<1)+1},
+                {"10M", false, true, 9, 20, true,  -1}, //indels at the ends are -1
+                {"10M", false, true, 1, 20, true,  -1}, //indels at the ends are -1
+                {"10M", false, true, 5, 20, true,  (abs(-1-5)<<1)+1},
+
+                //negative strand. Read is size 10
+                {"10M", true, false, 9, 20, false, (10-9)<<1},
+                {"10M", true, false, 1, 20, false, (10-1)<<1},
+                {"10M", true, false, 5, 20, false, (10-5)<<1},
+                {"10M", true, false, 9, 20, true,  -1}, //indels at the ends are -1
+                {"10M", true, false, 1, 20, true,  -1}, //indels at the ends are -1
+                {"10M", true, false, 5, 20, true,  (10-5)<<1},
+
+                //negative strand, second in pair. Read is size 10
+                {"10M", true, true, 9, 20, false, abs((-10 + 9) << 1) +1},
+                {"10M", true, true, 1, 20, false, abs((-10+1)<<1)+1},
+                {"10M", true, true, 5, 20, false, abs((-10 + 5) << 1)+1},
+                {"10M", true, true, 9, 20, true,  -1}, //indels at the ends are -1
+                {"10M", true, true, 1, 20, true,  -1}, //indels at the ends are -1
+                {"10M", true, true, 5, 20, true,  abs((-10+5)<<1)+1},
+        };
+    }
+
+    @Test(dataProvider = "cycleKey")
+    public void testCycleKey(final String cigar, final boolean isNegStrand, final boolean isSecondInPair, final int baseNumber, final int maxCycle, final boolean indel, final int expectedCycleKey){
+        final SAMRecord read = ArtificialSAMUtils.createArtificialRead(TextCigarCodec.decode(cigar));
+        read.setReadNegativeStrandFlag(isNegStrand);
+        read.setReadPairedFlag(isSecondInPair);
+        read.setSecondOfPairFlag(isSecondInPair);
+
+        final int cycleKey = CycleCovariate.cycleKey(baseNumber, read, indel, maxCycle);
+        Assert.assertEquals(expectedCycleKey, cycleKey);
+    }
+
+    @DataProvider(name="cycleFromKey")
+    public Object[][] cycleFromKey() {
+        return new Object[][]{
+                {0b100, 0b10},
+                {0b101, -0b10},
+                {0b110, 0b11},
+                {0b10,  0b1},
+                {0b11, -0b1},
+        };
+    }
+
+    @Test(dataProvider = "cycleFromKey")
+    public void testCycleFromKey(final int key, final int expectedCycle){
+        final int cycle = CycleCovariate.cycleFromKey(key);
+        Assert.assertEquals(expectedCycle, cycle);
+    }
+
+    @Test
+    public void testCycleToKeyAndBack(){
+        final int max = 1000000;
+        for (int cycle = -abs(max)+1; cycle <= abs(max)-1; cycle++) {
+            final int key = CycleCovariate.keyFromCycle(cycle, max);
+            final int cycleBack = CycleCovariate.cycleFromKey(key);
+            Assert.assertEquals(cycle, cycleBack);
+        }
+    }
+
+    @Test(expectedExceptions = UserException.class)
+    public void testCycleTooLow(){
+        final int max = 10;
+        final int cycle = -abs(max)-1;
+        final int key = CycleCovariate.keyFromCycle(cycle, max);
+    }
+
+    @Test(expectedExceptions = UserException.class)
+    public void testCycleTooHigh(){
+        final int max = 10;
+        final int cycle = abs(max)+1;
+        final int key = CycleCovariate.keyFromCycle(cycle, max);
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/recalibration/ReadCovariatesUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/recalibration/ReadCovariatesUnitTest.java
@@ -19,7 +19,7 @@ public final class ReadCovariatesUnitTest {
         ReadCovariates.clearKeysCache();
     }
 
-    @Test(enabled = false)
+    @Test
     public void testCovariateGeneration() {
         final RecalibrationArgumentCollection RAC = new RecalibrationArgumentCollection();
 
@@ -68,19 +68,21 @@ public final class ReadCovariatesUnitTest {
                     Assert.assertEquals(rgCov.formatKey(rc.getDeletionsKeySet(i)[0]), rgs);
 
                     // check quality score
-                    Assert.assertEquals(qsCov.formatKey(rc.getMismatchesKeySet(i)[1]), "" + mQuals[i]);
-                    Assert.assertEquals(qsCov.formatKey(rc.getInsertionsKeySet(i)[1]), "" + iQuals[i]);
-                    Assert.assertEquals(qsCov.formatKey(rc.getDeletionsKeySet(i)[1]), "" + dQuals[i]);
+                    Assert.assertEquals(qsCov.formatKey(rc.getMismatchesKeySet(i)[1]), String.valueOf(mQuals[i]));
+                    Assert.assertEquals(qsCov.formatKey(rc.getInsertionsKeySet(i)[1]), String.valueOf(iQuals[i]));
+                    Assert.assertEquals(qsCov.formatKey(rc.getDeletionsKeySet(i)[1]),  String.valueOf(dQuals[i]));
 
                     // check context
-                    Assert.assertEquals(coCov.formatKey(rc.getMismatchesKeySet(i)[2]), ContextCovariateUnitTest.expectedContext(read, i, RAC.MISMATCHES_CONTEXT_SIZE));
-                    Assert.assertEquals(coCov.formatKey(rc.getInsertionsKeySet(i)[2]), ContextCovariateUnitTest.expectedContext(read, i, RAC.INDELS_CONTEXT_SIZE));
-                    Assert.assertEquals(coCov.formatKey(rc.getDeletionsKeySet(i)[2]), ContextCovariateUnitTest.expectedContext(read, i, RAC.INDELS_CONTEXT_SIZE));
+                    Assert.assertEquals(coCov.formatKey(rc.getMismatchesKeySet(i)[2]), ContextCovariateUnitTest.expectedContext(read, i, RAC.MISMATCHES_CONTEXT_SIZE, RAC.LOW_QUAL_TAIL), "read: " +idx  + " readGroup:" + rgs + " context mismatch key at position:" + i);
+                    Assert.assertEquals(coCov.formatKey(rc.getInsertionsKeySet(i)[2]), ContextCovariateUnitTest.expectedContext(read, i, RAC.INDELS_CONTEXT_SIZE, RAC.LOW_QUAL_TAIL), "read: " +idx  + " readGroup:" + rgs + " context insertion key at position:" + i);
+                    Assert.assertEquals(coCov.formatKey(rc.getDeletionsKeySet(i)[2]),  ContextCovariateUnitTest.expectedContext(read, i, RAC.INDELS_CONTEXT_SIZE, RAC.LOW_QUAL_TAIL), "read: " +idx  + " readGroup:" + rgs + " context deletion key at position:" + i);
 
                     // check cycle
-                    Assert.assertEquals(cyCov.formatKey(rc.getMismatchesKeySet(i)[3]), "" + (i + 1));
-                    Assert.assertEquals(cyCov.formatKey(rc.getInsertionsKeySet(i)[3]), "" + (i + 1));
-                    Assert.assertEquals(cyCov.formatKey(rc.getDeletionsKeySet(i)[3]), "" + (i + 1));
+                    final int expectedCycleMismatch = CycleCovariateUnitTest.expectedCycle(read, i, false, RAC.MAXIMUM_CYCLE_VALUE);
+                    final int expectedCycleIndel = CycleCovariateUnitTest.expectedCycle(read, i, true, RAC.MAXIMUM_CYCLE_VALUE);
+                    Assert.assertEquals(cyCov.formatKey(rc.getMismatchesKeySet(i)[3]), String.valueOf(expectedCycleMismatch), "read: " + idx + " cycle mismatch key at position:" + i);
+                    Assert.assertEquals(cyCov.formatKey(rc.getInsertionsKeySet(i)[3]), String.valueOf(expectedCycleIndel),  "read: " +idx + " cycle insertion key at position:" + i);
+                    Assert.assertEquals(cyCov.formatKey(rc.getDeletionsKeySet(i)[3]), String.valueOf(expectedCycleIndel),  "read: " +idx + " cycle deletion key at position:" + i);
                 }
 
             }


### PR DESCRIPTION
I reenabled ReadCovariateUnit tests (disabled in GATK3 because it was failing) and added a bunch of code to make it tests the right thing. A lot of testing problems with reverse-strand reads is fixed now.

fixes #412