### PR TITLE
porting of pileups infrastructure. keeping LIBS out for now

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -509,4 +509,23 @@ public class Utils {
         return new String(big).endsWith(new String(suffix));
     }
 
+    /**
+     * Concatenates byte arrays
+     * @return a concat of all bytes in allBytes in order
+     */
+    public static byte[] concat(final byte[] ... allBytes) {
+        int size = 0;
+        for ( final byte[] bytes : allBytes ) {
+            size += bytes.length;
+        }
+
+        final byte[] c = new byte[size];
+        int offset = 0;
+        for ( final byte[] bytes : allBytes ) {
+            System.arraycopy(bytes, 0, c, offset, bytes.length);
+            offset += bytes.length;
+        }
+
+        return c;
+    }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentCollection.java
@@ -1,0 +1,144 @@
+package org.broadinstitute.hellbender.utils.fragments;
+
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.utils.pileup.PileupElement;
+import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
+
+import java.util.*;
+import java.util.function.Function;
+
+/**
+ * Represents the results of the reads -> fragment calculation.
+ *
+ * Contains singleton -- objects whose underlying reads do not overlap their mate pair
+ * Contains overlappingPairs -- objects whose underlying reads do overlap their mate pair
+ */
+public final class FragmentCollection<T> {
+
+    private final Collection<T> singletons;
+    private final Collection<List<T>> overlappingPairs;
+
+    /**
+     * Makes a new collection.
+     * Note: this collection stores live pointers to the argument collections.
+     * The callers must not modify those arguments after handing them off to this collection.
+     *
+     * The constructor is private - use the factory method if you need an object.
+     */
+    private FragmentCollection(final Collection<T> singletons, final Collection<List<T>> overlappingPairs) {
+        this.singletons = singletons == null ? Collections.emptyList() : singletons;
+        this.overlappingPairs = overlappingPairs == null ? Collections.emptyList() : overlappingPairs;
+    }
+
+    /**
+     * Gets the T elements not containing overlapping elements, in no particular order.
+     * The returned collection is unmodifiable.
+     */
+    public Collection<T> getSingletonReads() {
+        return Collections.unmodifiableCollection(singletons);
+    }
+
+    /**
+     * Gets the T elements containing overlapping elements, in no particular order
+     * The returned collection is unmodifiable.
+     */
+    public Collection<List<T>> getOverlappingPairs() {
+        return Collections.unmodifiableCollection(overlappingPairs);
+    }
+
+    /**
+     * Generic algorithm that takes an iterable over T objects, a getter routine to extract the reads in T,
+     * and returns a FragmentCollection that contains the T objects whose underlying reads either overlap (or
+     * not) with their mate pairs.
+     *
+     * @param readContainingObjects An iterator of objects that contain SAMRecords
+     * @param nElements the number of elements to be provided by the iterator, which is usually known upfront and
+     *                  greatly improves the efficiency of the fragment calculation
+     * @param getter a helper function that takes an object of type T and returns is associated SAMRecord
+     * @param <T>
+     * @return a fragment collection
+     */
+    private static <T> FragmentCollection<T> create(final Iterable<T> readContainingObjects, final int nElements, final Function<T, SAMRecord> getter) {
+        Collection<T> singletons = null;
+        Collection<List<T>> overlapping = null;
+        Map<String, T> nameMap = null;
+
+        int lastStart = -1;
+
+        // build an initial map, grabbing all of the multi-read fragments
+        for ( final T p : readContainingObjects ) {
+            final SAMRecord read = getter.apply(p);
+
+            if ( read.getAlignmentStart() < lastStart ) {
+                throw new IllegalArgumentException(String.format(
+                        "FragmentUtils.create assumes that the incoming objects are ordered by " +
+                                "SAMRecord alignment start, but saw a read %s with alignment start " +
+                                "%d before the previous start %d", read.getSAMString(), read.getAlignmentStart(), lastStart));
+            }
+            lastStart = read.getAlignmentStart();
+
+            final int mateStart = read.getMateAlignmentStart();
+            if ( mateStart == 0 || mateStart > read.getAlignmentEnd() ) {
+                // if we know that this read won't overlap its mate, or doesn't have one, jump out early
+                if ( singletons == null ) {
+                    singletons = new ArrayList<>(nElements); // lazy init
+                }
+                singletons.add(p);
+            } else {
+                // the read might overlap it's mate, or is the rightmost read of a pair
+                final String readName = read.getReadName();
+                final T pe1 = nameMap == null ? null : nameMap.get(readName);
+                if ( pe1 != null ) {
+                    // assumes we have at most 2 reads per fragment
+                    if ( overlapping == null ) {
+                        overlapping = new ArrayList<>(); // lazy init
+                    }
+                    overlapping.add(Arrays.asList(pe1, p));
+                    nameMap.remove(readName);
+                } else {
+                    if ( nameMap == null ) {
+                        nameMap = new HashMap<>(nElements); // lazy init
+                    }
+                    nameMap.put(readName, p);
+                }
+            }
+        }
+
+        // add all of the reads that are potentially overlapping but whose mate never showed
+        // up to the oneReadPile
+        if ( nameMap != null && ! nameMap.isEmpty() ) {
+            if ( singletons == null ) {
+                singletons = nameMap.values();
+            } else {
+                singletons.addAll(nameMap.values());
+            }
+        }
+
+        return new FragmentCollection<>(singletons, overlapping);
+    }
+
+    /**
+     * Create a FragmentCollection containing PileupElements from the ReadBackedPileup rbp
+     * @param rbp a non-null read-backed pileup.  The elements in this ReadBackedPileup must be ordered
+     * @return a non-null FragmentCollection
+     */
+    public static FragmentCollection<PileupElement> create(final ReadPileup rbp) {
+        if ( rbp == null ) {
+            throw new IllegalArgumentException("Pileup cannot be null");
+        }
+        return create(rbp, rbp.size(), pileup -> pileup.getRead());
+    }
+
+    /**
+     * Create a FragmentCollection containing SAMRecords from a list of reads
+     *
+     * @param reads a non-null list of reads, ordered by their start location
+     * @return a non-null FragmentCollection
+     */
+    public static FragmentCollection<SAMRecord> create(final List<SAMRecord> reads) {
+        if ( reads == null ) {
+            throw new IllegalArgumentException("Pileup cannot be null");
+        }
+        return create(reads, reads.size(), read -> read);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtils.java
@@ -1,0 +1,96 @@
+package org.broadinstitute.hellbender.utils.fragments;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.util.QualityUtil;
+import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+
+/**
+ * Set of utilities that deal with reads that came (or are assumed to come) from the same fragment.
+ */
+public final class FragmentUtils {
+
+    private FragmentUtils() {} // no instances
+
+    public final static double DEFAULT_PCR_ERROR_RATE = 1e-4;
+    public final static int DEFAULT_PCR_ERROR_QUAL = QualityUtil.getPhredScoreFromErrorProbability(DEFAULT_PCR_ERROR_RATE);
+    public final static int HALF_OF_DEFAULT_PCR_ERROR_QUAL = DEFAULT_PCR_ERROR_QUAL / 2;
+
+    /**
+     * Fix two overlapping reads from the same fragment by adjusting base qualities, if possible.
+     *
+     * firstRead and secondRead must be part of the same fragment (though this isn't checked).  Looks
+     * at the bases and alignment, and tries its best to create adjusted base qualities so that the observations
+     * are not treated independently.
+     *
+     * This method does NOT assumes that firstRead starts before secondRead (according to their soft clipped starts).
+     * Rather it checks which read starts first and calls {@link adjustQualsOfOverlappingPairedFragments} with the appropriate order.
+     */
+    public static void adjustQualsOfOverlappingPairedFragments(final Pair<SAMRecord, SAMRecord> overlappingPair) {
+        final SAMRecord firstRead = overlappingPair.getLeft();
+        final SAMRecord secondRead = overlappingPair.getRight();
+
+        if (ReadUtils.getSoftStart(secondRead) < ReadUtils.getSoftStart(firstRead) ) {
+            adjustQualsOfOverlappingPairedFragments(secondRead, firstRead);
+        } else {
+            adjustQualsOfOverlappingPairedFragments(firstRead, secondRead);
+        }
+    }
+
+    /**
+     * Fix two overlapping reads from the same fragment by adjusting base qualities, if possible
+     *
+     * firstRead and secondRead must be part of the same fragment (though this isn't checked).  Looks
+     * at the bases and alignment, and tries its best to create adjusted base qualities so that the observations
+     * are not treated independently.
+     *
+     * Assumes that firstRead starts before secondRead (according to their soft clipped starts)
+     *
+     * @param clippedFirstRead the left most read
+     * @param clippedSecondRead the right most read
+     */
+    public static void adjustQualsOfOverlappingPairedFragments(final SAMRecord clippedFirstRead, final SAMRecord clippedSecondRead) {
+        if ( clippedFirstRead == null ) {
+            throw new IllegalArgumentException("clippedFirstRead cannot be null");
+        }
+        if ( clippedSecondRead == null ) {
+            throw new IllegalArgumentException("clippedSecondRead cannot be null");
+        }
+        if ( ! clippedFirstRead.getReadName().equals(clippedSecondRead.getReadName()) ) {
+            throw new IllegalArgumentException("attempting to merge two reads with different names " + clippedFirstRead + " and " + clippedSecondRead);
+        }
+
+        // don't adjust fragments that do not overlap
+        final boolean overlap = clippedFirstRead.getReferenceIndex().equals(clippedSecondRead.getReferenceIndex()) && clippedFirstRead.getAlignmentEnd() >= clippedSecondRead.getAlignmentStart();
+        if ( !overlap ) {
+            return;
+        }
+
+        final Pair<Integer, Boolean> pair = ReadUtils.getReadCoordinateForReferenceCoordinate(clippedFirstRead, clippedSecondRead.getAlignmentStart());
+        final int firstReadStop = ( pair.getRight() ? pair.getLeft() + 1 : pair.getLeft() );
+        final int numOverlappingBases = Math.min(clippedFirstRead.getReadLength() - firstReadStop, clippedSecondRead.getReadLength());
+
+        final byte[] firstReadBases = clippedFirstRead.getReadBases();
+        final byte[] firstReadQuals = clippedFirstRead.getBaseQualities();
+        final byte[] secondReadBases = clippedSecondRead.getReadBases();
+        final byte[] secondReadQuals = clippedSecondRead.getBaseQualities();
+
+        for ( int i = 0; i < numOverlappingBases; i++ ) {
+            final int firstReadIndex = firstReadStop + i;
+            final byte firstReadBase = firstReadBases[firstReadIndex];
+            final byte secondReadBase = secondReadBases[i];
+
+            if ( firstReadBase == secondReadBase ) {
+                firstReadQuals[firstReadIndex] = (byte) Math.min(firstReadQuals[firstReadIndex], HALF_OF_DEFAULT_PCR_ERROR_QUAL);
+                secondReadQuals[i] = (byte) Math.min(secondReadQuals[i], HALF_OF_DEFAULT_PCR_ERROR_QUAL);
+            } else {
+                // TODO -- use the proper statistical treatment of the quals from DiploidSNPGenotypeLikelihoods.java
+                firstReadQuals[firstReadIndex] = 0;
+                secondReadQuals[i] = 0;
+            }
+        }
+
+        clippedFirstRead.setBaseQualities(firstReadQuals);
+        clippedSecondRead.setBaseQualities(secondReadQuals);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pileup/ReadPileup.java
@@ -1,0 +1,390 @@
+package org.broadinstitute.hellbender.utils.pileup;
+
+import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.util.Locatable;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.fragments.FragmentCollection;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a pileup of reads at a given position.
+ */
+public final class ReadPileup implements Iterable<PileupElement>{
+    private final Locatable loc;
+    private final List<PileupElement> pileupElements;
+
+    /**
+     * Create a new version of a read backed pileup at loc, using the reads and their corresponding
+     * offsets.
+     * Note: This internal-use constructor keeps an alias pointer to the given list.
+     */
+    @VisibleForTesting
+    ReadPileup(final Locatable loc, final List<PileupElement> pileup) {
+        this.loc = loc;
+        this.pileupElements = pileup;
+    }
+
+    /**
+     * Create a new pileup without any aligned reads
+     */
+    public ReadPileup(final Locatable loc) {
+        this(loc, Collections.emptyList());
+    }
+
+    /**
+     * Create a new pileup with the given reads.
+     */
+    public ReadPileup(final Locatable loc, final List<SAMRecord> reads, final int offset) {
+        this(loc, readsOffsets2Pileup(reads, offset));
+    }
+
+
+    /**
+     * Create a new pileup with the given reads.
+     */
+    public ReadPileup(final Locatable loc, final List<SAMRecord> reads, final List<Integer> offsets) {
+        this(loc, readsOffsets2Pileup(reads, offsets));
+    }
+
+    /**
+     * Helper routine for converting reads and offset lists to a PileupElement list.
+     */
+    private static List<PileupElement> readsOffsets2Pileup(final List<SAMRecord> reads, final List<Integer> offsets) {
+        if (reads == null) {
+            throw new GATKException("Illegal null read list in UnifiedReadBackedPileup");
+        }
+        if (offsets == null) {
+            throw new GATKException("Illegal null offsets list in UnifiedReadBackedPileup");
+        }
+        if (reads.size() != offsets.size()) {
+            throw new GATKException("Reads and offset lists have different sizes!");
+        }
+
+        final List<PileupElement> pileup = new LinkedList<>();
+        for (int i = 0; i < reads.size(); i++) {
+            pileup.add(PileupElement.createPileupForReadAndOffset(reads.get(i), offsets.get(i)));
+        }
+
+        return pileup;
+    }
+
+    /**
+     * Helper routine for converting reads and a single offset to a PileupElement list.
+     */
+    private static List<PileupElement> readsOffsets2Pileup(final List<SAMRecord> reads, final int offset) {
+        if (reads == null) {
+            throw new GATKException("Illegal null read list in UnifiedReadBackedPileup");
+        }
+        if (offset < 0) {
+            throw new GATKException("Illegal offset < 0 UnifiedReadBackedPileup");
+        }
+
+        final List<PileupElement> pileup = new LinkedList<>();
+        for (SAMRecord read : reads) {
+            pileup.add(PileupElement.createPileupForReadAndOffset(read, offset));
+        }
+
+        return pileup;
+    }
+
+    /**
+     * Make a new pileup consisting of elements of this pileup that satisfy the predicate.
+     */
+    public ReadPileup makeFilteredPileup(final Predicate<PileupElement> filter){
+        return new ReadPileup(loc, pileupElements.stream().filter(filter).collect(Collectors.toList()));
+    }
+
+    /**
+     * Make a new pileup consisting of only reads on the negative strand.
+     */
+    public ReadPileup getPositiveStrandPileup() {
+        return makeFilteredPileup(p -> !p.getRead().getReadNegativeStrandFlag());
+    }
+
+    /**
+     * Make a new pileup consisting of only reads on the negative strand.
+     */
+    public ReadPileup getNegativeStrandPileup() {
+        return makeFilteredPileup(p -> p.getRead().getReadNegativeStrandFlag());
+    }
+
+    /**
+     * Make a new pileup that contains of only bases with quality >= minBaseQ, coming from
+     * reads with mapping qualities >= minMapQ.
+     */
+    public ReadPileup getBaseAndMappingFilteredPileup(int minBaseQ, int minMapQ) {
+        return makeFilteredPileup(p -> p.getRead().getMappingQuality() >= minMapQ && (p.isDeletion() || p.getQual() >= minBaseQ));
+    }
+
+    /**
+     * Make a new pileup that contains of only bases with quality >= minBaseQ.
+     */
+    public ReadPileup getBaseFilteredPileup(int minBaseQ) {
+        return makeFilteredPileup(p -> (p.isDeletion() || p.getQual() >= minBaseQ));
+    }
+
+    /**
+     * Make a new pileup that contains of only bases coming from reads with mapping quality >= minMapQ.
+     */
+    public ReadPileup getMappingFilteredPileup(int minMapQ) {
+        return makeFilteredPileup(p -> p.getRead().getMappingQuality() >= minMapQ);
+    }
+
+    /**
+     * Makes a new pileup by subsetting reads from a given read group.
+     * Returns null if no reads are from the given read group.
+     * @param targetReadGroupId Identifier for the read group.
+     * @return A read-backed pileup containing only the reads in the given read group.
+     */
+    public ReadPileup getPileupForReadGroup(String targetReadGroupId) {
+        final ReadPileup pu = makeFilteredPileup(p -> {
+            SAMRecord read = p.getRead();
+            if (targetReadGroupId != null) {
+                if (read.getReadGroup() != null && targetReadGroupId.equals(read.getReadGroup().getReadGroupId())) {
+                    return true;
+                }
+            } else {
+                if (read.getReadGroup() == null || read.getReadGroup().getReadGroupId() == null) {
+                    return true;
+                }
+            }
+            return false;
+        });
+        return pu.isEmpty() ? null: pu;
+    }
+
+    /**
+     * Make a new pileup from elements whose reads have read groups that agree with the given ID.
+     * (it they have a name equal to the ID or starting with ID followed by a period ".").
+     * Retrurns null if no suitable elements are found.
+     */
+    public ReadPileup getPileupForLane(String laneID) {
+        List<PileupElement> filteredTracker = new LinkedList<>();
+        for (PileupElement p : pileupElements) {
+            SAMRecord read = p.getRead();
+            final SAMReadGroupRecord readGroup = read.getReadGroup();
+            if (laneID != null) {
+                if (readGroup != null &&
+                        (readGroup.getReadGroupId().startsWith(laneID + ".") ||   // lane is the same, but sample identifier is different
+                         readGroup.getReadGroupId().equals(laneID)))               // in case there is no sample identifier, they have to be exactly the same
+                {
+                    filteredTracker.add(p);
+                }
+            } else {
+                if (readGroup == null || readGroup.getReadGroupId() == null) {
+                    filteredTracker.add(p);
+                }
+            }
+        }
+        return filteredTracker.size() > 0 ? new ReadPileup(loc, filteredTracker) : null;
+    }
+
+    /**
+     * Gets a set of the read groups represented in this pileup.
+     * Note: contains null if a read has a null read group.
+     */
+    public Set<SAMReadGroupRecord> getReadGroupIDs() {
+        return pileupElements.stream().map(pe -> pe.getRead().getReadGroup()).collect(Collectors.toSet());
+    }
+
+    /**
+     * Gets a set of the samples represented in this pileup.
+     * Note: contains null if a read has a null read group or a null sample name.
+     */
+    public Set<String> getSamples() {
+        return pileupElements.stream().map(pe -> pe.getRead()).map(r -> r.getReadGroup() == null ? null: r.getReadGroup().getSample()).collect(Collectors.toSet());
+    }
+
+
+    /**
+     * The best way to access PileupElements where you only care about the bases and quals in the pileup.
+     * <p/>
+     * for (PileupElement p : this) { doSomething(p); }
+     * <p/>
+     * Provides efficient iteration of the data.
+     */
+    public Iterator<PileupElement> iterator() {
+        return Collections.unmodifiableList(pileupElements).iterator();
+   }
+
+    /**
+     * The number of elements in this pileup.
+     */
+    public int size() {
+        return pileupElements.size();
+    }
+
+    /**
+     * @return true if there are 0 elements in the pileup, false otherwise
+     */
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    /**
+     * @return the location of this pileup
+     */
+    public Locatable getLocation() {
+        return loc;
+    }
+
+    /**
+     * Get counts of A, C, G, T in order, which returns a int[4] vector with counts according
+     * to BaseUtils.simpleBaseToBaseIndex for each base.
+     */
+    public int[] getBaseCounts() {
+        final int[] counts = new int[4];
+
+        for (final PileupElement pile : this) {
+            // skip deletion sites
+            if (!pile.isDeletion()) {
+                int index = BaseUtils.simpleBaseToBaseIndex(pile.getBase());
+                if (index != -1) {
+                    counts[index]++;
+                }
+            }
+        }
+
+        return counts;
+    }
+
+    /**
+     * Creates a pileup formar string.
+     * In the pileup format, each line represents a genomic position, consisting of chromosome name,
+     * coordinate, reference base, read bases, read qualities and alignment mapping qualities.
+     */
+    public String getPileupString(final Character ref) {
+        return String.format("%s %s %c %s %s",
+                getLocation().getContig(), getLocation().getStart(),    // chromosome name and coordinate
+                ref,                                                     // reference base
+                new String(getBases()),
+                getQualsString());
+    }
+
+    /**
+     * Returns a list of the reads in this pileup. Note this call costs O(n) and allocates fresh lists each time
+     */
+    public List<SAMRecord> getReads() {
+        return pileupElements.stream().map(pe -> pe.getRead()).collect(Collectors.toList());
+    }
+
+    /**
+     * The number of deletion bases in this pileup.
+     */
+    public int getNumberOfDeletions() {
+        //Note: pileups are small so int is fine.
+        return (int)pileupElements.stream().filter(p -> p.isDeletion()).count();
+    }
+
+    /**
+     * The number of reads with mapping quality 0 in this pileup.
+     */
+    public int getNumberOfMappingQualityZeroReads() {
+        //Note: pileups are small so int is fine.
+        return (int)pileupElements.stream().filter(p -> p.getRead().getMappingQuality() == 0).count();
+    }
+
+    /**
+     * The number of reads with deletions after this element.
+     */
+    public int getNumberOfDeletionsAfterThisElement() {
+        //Note: pileups are small so int is fine.
+        return (int)pileupElements.stream().filter(pe -> pe.isBeforeDeletionStart()).count();
+    }
+
+    /**
+     * The number of reads with insertions after this element.
+     */
+    public int getNumberOfInsertionsAfterThisElement() {
+        //Note: pileups are small so int is fine.
+        return (int)pileupElements.stream().filter(pe -> pe.isBeforeInsertion()).count();
+    }
+
+    /**
+     * Returns a list of the offsets in this pileup.
+     * Note: this call costs O(n) and allocates fresh lists each time
+     */
+    public List<Integer> getOffsets() {
+        return pileupElements.stream().map(pe -> pe.getOffset()).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns an array of the bases in this pileup.
+     * Note: this call costs O(n) and allocates fresh array each time
+     */
+    public byte[] getBases() {
+        final byte[] v = new byte[size()];
+        int pos = 0;
+        for (final PileupElement pile : pileupElements) {
+            v[pos++] = pile.getBase();
+        }
+        return v;
+    }
+
+    /**
+     * Returns an array of the quals in this pileup.
+     * Note: this call costs O(n) and allocates fresh array each time
+     */
+    public byte[] getQuals() {
+        final byte[] v = new byte[size()];
+        int pos = 0;
+        for (final PileupElement pile : pileupElements) {
+            v[pos++] = pile.getQual();
+        }
+        return v;
+    }
+
+    /**
+     * Get an array of the mapping qualities.
+     */
+    public int[] getMappingQuals() {
+        final int[] v = new int[size()];
+        int pos = 0;
+        for (final PileupElement pile : pileupElements) {
+            v[pos++] = pile.getRead().getMappingQuality();
+        }
+        return v;
+    }
+
+    private static String quals2String(byte[] quals) {
+        final StringBuilder qualStr = new StringBuilder();
+        for (int qual : quals) {
+            qual = Math.min(qual, 63);              // todo: fixme, this isn't a good idea
+            char qualChar = (char) (33 + qual);     // todo: warning, this is illegal for qual > 63
+            qualStr.append(qualChar);
+        }
+
+        return qualStr.toString();
+    }
+
+    private String getQualsString() {
+        return quals2String(getQuals());
+    }
+
+    /**
+     * Returns a new ReadBackedPileup that is sorted by start coordinate of the reads.
+     */
+    public ReadPileup getStartSortedPileup() {
+
+        final TreeSet<PileupElement> sortedElements = new TreeSet<>(new Comparator<PileupElement>() {
+            @Override
+            public int compare(PileupElement element1, PileupElement element2) {
+                final int difference = element1.getRead().getAlignmentStart() - element2.getRead().getAlignmentStart();
+                return difference != 0 ? difference : element1.getRead().getReadName().compareTo(element2.getRead().getReadName());
+            }
+        });
+
+        sortedElements.addAll(pileupElements);
+        return new ReadPileup(loc, new LinkedList<>(sortedElements));
+    }
+
+    public FragmentCollection<PileupElement> toFragments() {
+        return FragmentCollection.create(this);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialSAMUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialSAMUtils.java
@@ -288,4 +288,35 @@ public class ArtificialSAMUtils {
         header.setSequenceDictionary(dict);
         return header;
     }
+
+    public final static List<SAMRecord> createPair(SAMFileHeader header, String name, int readLen, int leftStart, int rightStart, boolean leftIsFirst, boolean leftIsNegative) {
+        SAMRecord left = ArtificialSAMUtils.createArtificialRead(header, name, 0, leftStart, readLen);
+        SAMRecord right = ArtificialSAMUtils.createArtificialRead(header, name, 0, rightStart, readLen);
+
+        left.setReadPairedFlag(true);
+        right.setReadPairedFlag(true);
+
+        left.setProperPairFlag(true);
+        right.setProperPairFlag(true);
+
+        left.setFirstOfPairFlag(leftIsFirst);
+        right.setFirstOfPairFlag(!leftIsFirst);
+
+        left.setReadNegativeStrandFlag(leftIsNegative);
+        left.setMateNegativeStrandFlag(!leftIsNegative);
+        right.setReadNegativeStrandFlag(!leftIsNegative);
+        right.setMateNegativeStrandFlag(leftIsNegative);
+
+        left.setMateAlignmentStart(right.getAlignmentStart());
+        right.setMateAlignmentStart(left.getAlignmentStart());
+
+        left.setMateReferenceIndex(0);
+        right.setMateReferenceIndex(0);
+
+        int isize = rightStart + readLen - leftStart;
+        left.setInferredInsertSize(isize);
+        right.setInferredInsertSize(-isize);
+
+        return Arrays.asList(left, right);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -65,7 +65,7 @@ public class UtilsUnitTest extends BaseTest {
         Assert.assertEquals(Utils.join(",", new Object[] { true , -12, "Blah", this.getClass() }),
                 "true,-12,Blah," + this.getClass().toString());
         Assert.assertEquals(Utils.join(",", true, -13, "Blah", this.getClass()),"true,-13,Blah," + this.getClass().toString());
-        Assert.assertEquals(Utils.join(",",Boolean.TRUE),"true");
+        Assert.assertEquals(Utils.join(",", Boolean.TRUE),"true");
     }
 
     @Test
@@ -203,5 +203,18 @@ public class UtilsUnitTest extends BaseTest {
 
         final String sourceString = FileUtils.readFileToString(source);
         Assert.assertEquals(Utils.calcMD5(sourceString), sourceMD5);
+    }
+
+    @Test
+    public void testConcat() {
+        final String s1 = "A";
+        final String s2 = "CC";
+        final String s3 = "TTT";
+        final String s4 = "GGGG";
+        Assert.assertEquals(new String(Utils.concat()), "");
+        Assert.assertEquals(new String(Utils.concat(s1.getBytes())), s1);
+        Assert.assertEquals(new String(Utils.concat(s1.getBytes(), s2.getBytes())), s1 + s2);
+        Assert.assertEquals(new String(Utils.concat(s1.getBytes(), s2.getBytes(), s3.getBytes())), s1 + s2 + s3);
+        Assert.assertEquals(new String(Utils.concat(s1.getBytes(), s2.getBytes(), s3.getBytes(), s4.getBytes())), s1 + s2 + s3 + s4);
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/fragments/FragmentUtilsUnitTest.java
@@ -1,0 +1,262 @@
+package org.broadinstitute.hellbender.utils.fragments;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import org.apache.commons.lang3.tuple.Pair;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.pileup.PileupElement;
+import org.broadinstitute.hellbender.utils.pileup.ReadPileup;
+import org.broadinstitute.hellbender.utils.read.ArtificialSAMUtils;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Test routines for fragments and their collections.
+ */
+public class FragmentUtilsUnitTest extends BaseTest {
+    private static SAMFileHeader header;
+    private static SAMReadGroupRecord rgForMerged;
+
+    private class FragmentUtilsTest extends TestDataProvider {
+        List<TestState> statesForPileup = new ArrayList<>();
+        List<TestState> statesForReads = new ArrayList<>();
+
+        private FragmentUtilsTest(String name, int readLen, int leftStart, int rightStart,
+                                  boolean leftIsFirst, boolean leftIsNegative) {
+            super(FragmentUtilsTest.class, String.format("%s-leftIsFirst:%b-leftIsNegative:%b", name, leftIsFirst, leftIsNegative));
+
+            List<SAMRecord> pair = ArtificialSAMUtils.createPair(header, "readpair", readLen, leftStart, rightStart, leftIsFirst, leftIsNegative);
+            SAMRecord left = pair.get(0);
+            SAMRecord right = pair.get(1);
+
+            for ( int pos = leftStart; pos < rightStart + readLen; pos++) {
+                boolean posCoveredByLeft = pos >= left.getAlignmentStart() && pos <= left.getAlignmentEnd();
+                boolean posCoveredByRight = pos >= right.getAlignmentStart() && pos <= right.getAlignmentEnd();
+
+                if ( posCoveredByLeft || posCoveredByRight ) {
+                    List<SAMRecord> reads = new ArrayList<>();
+                    List<Integer> offsets = new ArrayList<>();
+
+                    if ( posCoveredByLeft ) {
+                        reads.add(left);
+                        offsets.add(pos - left.getAlignmentStart());
+                    }
+
+                    if ( posCoveredByRight ) {
+                        reads.add(right);
+                        offsets.add(pos - right.getAlignmentStart());
+                    }
+
+                    boolean shouldBeFragment = posCoveredByLeft && posCoveredByRight;
+                    ReadPileup pileup = new ReadPileup(null, reads, offsets);
+                    TestState testState = new TestState(shouldBeFragment ? 0 : 1, shouldBeFragment ? 1 : 0, pileup, null);
+                    statesForPileup.add(testState);
+                }
+
+                TestState testState = left.getAlignmentEnd() >= right.getAlignmentStart() ? new TestState(0, 1, null, pair) : new TestState(2, 0, null, pair);
+                statesForReads.add(testState);
+            }
+        }
+    }
+
+    private class TestState {
+        int expectedSingletons, expectedPairs;
+        ReadPileup pileup;
+        List<SAMRecord> rawReads;
+
+        private TestState(final int expectedSingletons, final int expectedPairs, final ReadPileup pileup, final List<SAMRecord> rawReads) {
+            this.expectedSingletons = expectedSingletons;
+            this.expectedPairs = expectedPairs;
+            this.pileup = pileup;
+            this.rawReads = rawReads;
+        }
+    }
+
+    @DataProvider(name = "fragmentUtilsTest")
+    public Object[][] createTests() {
+        for ( boolean leftIsFirst : Arrays.asList(true, false) ) {
+            for ( boolean leftIsNegative : Arrays.asList(true, false) ) {
+                // Overlapping pair
+                // ---->        [first]
+                //   <---       [second]
+                new FragmentUtilsTest("overlapping-pair", 10, 1, 5, leftIsFirst, leftIsNegative);
+
+                // Non-overlapping pair
+                // ---->
+                //          <----
+                new FragmentUtilsTest("nonoverlapping-pair", 10, 1, 15, leftIsFirst, leftIsNegative);
+            }
+        }
+
+        return FragmentUtilsTest.getTests(FragmentUtilsTest.class);
+    }
+
+    @Test(dataProvider = "fragmentUtilsTest")
+    public void testAsPileup(FragmentUtilsTest test) {
+        for ( TestState testState : test.statesForPileup ) {
+            ReadPileup rbp = testState.pileup;
+            FragmentCollection<PileupElement> fp = FragmentCollection.create(rbp);
+            Assert.assertEquals(fp.getOverlappingPairs().size(), testState.expectedPairs);
+            Assert.assertEquals(fp.getSingletonReads().size(), testState.expectedSingletons);
+        }
+    }
+
+    @Test(dataProvider = "fragmentUtilsTest")
+    public void testAsListOfReadsFromPileup(FragmentUtilsTest test) {
+        for ( TestState testState : test.statesForPileup ) {
+            FragmentCollection<SAMRecord> fp = FragmentCollection.create(testState.pileup.getReads());
+            Assert.assertEquals(fp.getOverlappingPairs().size(), testState.expectedPairs);
+            Assert.assertEquals(fp.getSingletonReads().size(), testState.expectedSingletons);
+        }
+    }
+
+    @Test(dataProvider = "fragmentUtilsTest")
+    public void testAsListOfReads(FragmentUtilsTest test) {
+        for ( TestState testState : test.statesForReads ) {
+            FragmentCollection<SAMRecord> fp = FragmentCollection.create(testState.rawReads);
+            Assert.assertEquals(fp.getOverlappingPairs().size(), testState.expectedPairs);
+            Assert.assertEquals(fp.getSingletonReads().size(), testState.expectedSingletons);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testOutOfOrder() {
+        final List<SAMRecord> pair = ArtificialSAMUtils.createPair(header, "readpair", 100, 1, 50, true, true);
+        final SAMRecord left = pair.get(0);
+        final SAMRecord right = pair.get(1);
+        final List<SAMRecord> reads = Arrays.asList(right, left); // OUT OF ORDER!
+        final List<Integer> offsets = Arrays.asList(0, 50);
+        final ReadPileup pileup = new ReadPileup(null, reads, offsets);
+        FragmentCollection.create(pileup); // should throw exception
+    }
+
+    @BeforeTest
+    public void setup() {
+        header = ArtificialSAMUtils.createArtificialSamHeader(1,1,1000);
+        rgForMerged = new SAMReadGroupRecord("RG1");
+    }
+
+    @DataProvider(name = "MergeFragmentsTest")
+    public Object[][] createMergeFragmentsTest() throws Exception {
+        List<Object[]> tests = new ArrayList<>();
+
+        final String leftFlank = "CCC";
+        final String rightFlank = "AAA";
+        final String allOverlappingBases = "ACGTACGTGGAACCTTAG";
+        for ( int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++ ) {
+            final String overlappingBases = allOverlappingBases.substring(0, overlapSize);
+            final byte[] overlappingBaseQuals = new byte[overlapSize];
+            for ( int i = 0; i < overlapSize; i++ ) overlappingBaseQuals[i] = (byte)(i + 30);
+            final SAMRecord read1  = makeOverlappingRead(leftFlank, 20, overlappingBases, overlappingBaseQuals, "", 30, 1);
+            final SAMRecord read2  = makeOverlappingRead("", 20, overlappingBases, overlappingBaseQuals, rightFlank, 30, leftFlank.length() + 1);
+            final SAMRecord merged = makeOverlappingRead(leftFlank, 20, overlappingBases, overlappingBaseQuals, rightFlank, 30, 1);
+            tests.add(new Object[]{"equalQuals", read1, read2, merged});
+
+            // test that the merged read base quality is the
+            tests.add(new Object[]{"lowQualLeft", modifyBaseQualities(read1, leftFlank.length(), overlapSize), read2, merged});
+            tests.add(new Object[]{"lowQualRight", read1, modifyBaseQualities(read2, 0, overlapSize), merged});
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    private SAMRecord modifyBaseQualities(final SAMRecord read, final int startOffset, final int length) throws Exception {
+        final SAMRecord readWithLowQuals = (SAMRecord)read.clone();
+        final byte[] withLowQuals = Arrays.copyOf(read.getBaseQualities(), read.getBaseQualities().length);
+        for ( int i = startOffset; i < startOffset + length; i++ )
+            withLowQuals[i] = (byte)(read.getBaseQualities()[i] + (i % 2 == 0 ? -1 : 0));
+        readWithLowQuals.setBaseQualities(withLowQuals);
+        return readWithLowQuals;
+    }
+
+    private SAMRecord makeOverlappingRead(final String leftFlank, final int leftQual, final String overlapBases,
+                                              final byte[] overlapQuals, final String rightFlank, final int rightQual,
+                                              final int alignmentStart) {
+        final String bases = leftFlank + overlapBases + rightFlank;
+        final int readLength = bases.length();
+        final SAMRecord read = ArtificialSAMUtils.createArtificialRead(header, "myRead", 0, alignmentStart, readLength);
+        final byte[] leftQuals = Utils.dupBytes((byte) leftQual, leftFlank.length());
+        final byte[] rightQuals = Utils.dupBytes((byte) rightQual, rightFlank.length());
+        final byte[] quals = Utils.concat(leftQuals, overlapQuals, rightQuals);
+        read.setCigarString(readLength + "M");
+        read.setReadBases(bases.getBytes());
+        read.setBaseQualities(quals);
+        ReadUtils.setInsertionBaseQualities(read, quals);
+        ReadUtils.setDeletionBaseQualities(read, quals);
+        ReadUtils.setReadGroup(read, rgForMerged);
+        read.setMappingQuality(60);
+        return read;
+    }
+
+    @DataProvider(name = "MergeFragmentsOffContig")
+    public Object[][] makeMergeFragmentsOffContig() throws Exception {
+        List<Object[]> tests = new ArrayList<>();
+
+        for ( final int pre1 : Arrays.asList(0, 50)) {
+            for ( final int post1 : Arrays.asList(0, 50)) {
+                for ( final int pre2 : Arrays.asList(0, 50)) {
+                    for ( final int post2 : Arrays.asList(0, 50)) {
+                        tests.add(new Object[]{pre1, post1, pre2, post2});
+                    }
+                }
+            }
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    private static final byte highQuality = 30;
+    private static final byte overlappingQuality = 20;
+
+    @DataProvider(name = "AdjustFragmentsTest")
+    public Object[][] createAdjustFragmentsTest() throws Exception {
+        List<Object[]> tests = new ArrayList<>();
+
+        final String leftFlank = "CCC";
+        final String rightFlank = "AAA";
+        final String allOverlappingBases = "ACGTACGTGGAACCTTAG";
+        for ( int overlapSize = 1; overlapSize < allOverlappingBases.length(); overlapSize++ ) {
+            final String overlappingBases = allOverlappingBases.substring(0, overlapSize);
+            final byte[] overlappingBaseQuals = new byte[overlapSize];
+            for ( int i = 0; i < overlapSize; i++ ) overlappingBaseQuals[i] = highQuality;
+            final SAMRecord read1  = makeOverlappingRead(leftFlank, highQuality, overlappingBases, overlappingBaseQuals, "", highQuality, 1);
+            final SAMRecord read2  = makeOverlappingRead("", highQuality, overlappingBases, overlappingBaseQuals, rightFlank, highQuality, leftFlank.length() + 1);
+            tests.add(new Object[]{read1, read2, overlapSize});
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "AdjustFragmentsTest")
+    public void testAdjustingTwoReads(final SAMRecord read1, final SAMRecord read2, final int overlapSize) {
+        FragmentUtils.adjustQualsOfOverlappingPairedFragments(Pair.of(read1, read2));
+        checkStuff(read1, read2, overlapSize);
+    }
+
+    @Test(dataProvider = "AdjustFragmentsTest")
+    public void testAdjustingTwoReadsReversed(final SAMRecord read1, final SAMRecord read2, final int overlapSize) {
+        FragmentUtils.adjustQualsOfOverlappingPairedFragments(Pair.of(read2, read1));
+        checkStuff(read1, read2, overlapSize);
+    }
+
+    public void checkStuff(SAMRecord read1, SAMRecord read2, int overlapSize) {
+        for ( int i = 0; i < read1.getReadLength() - overlapSize; i++ )
+            Assert.assertEquals(read1.getBaseQualities()[i], highQuality);
+        for ( int i = read1.getReadLength() - overlapSize; i < read1.getReadLength(); i++ )
+            Assert.assertEquals(read1.getBaseQualities()[i], overlappingQuality);
+
+        for ( int i = 0; i < overlapSize; i++ )
+            Assert.assertEquals(read2.getBaseQualities()[i], overlappingQuality);
+        for ( int i = overlapSize; i < read2.getReadLength(); i++ )
+            Assert.assertEquals(read2.getBaseQualities()[i], highQuality);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pileup/ReadPileupUnitTest.java
@@ -1,0 +1,340 @@
+package org.broadinstitute.hellbender.utils.pileup;
+
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.util.Locatable;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.read.ArtificialSAMUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static htsjdk.samtools.SAMRecord.NO_MAPPING_QUALITY;
+
+/**
+ * Test routines for read-backed pileup.
+ */
+public class ReadPileupUnitTest {
+    protected static SAMFileHeader header;
+    private Locatable loc;
+
+    @BeforeClass
+    public void beforeClass() {
+        header = ArtificialSAMUtils.createArtificialSamHeader(1, 1, 1000);
+        loc = new SimpleInterval("chr1", 1, 1);
+    }
+
+    /**
+     * Ensure that basic read group splitting works.
+     */
+    @Test
+    public void testSplitByReadGroup() {
+        SAMReadGroupRecord readGroupOne = new SAMReadGroupRecord("rg1");
+        SAMReadGroupRecord readGroupTwo = new SAMReadGroupRecord("rg2");
+
+        SAMFileHeader header = ArtificialSAMUtils.createArtificialSamHeader(1,1,1000);
+        header.addReadGroup(readGroupOne);
+        header.addReadGroup(readGroupTwo);
+
+        SAMRecord read1 = ArtificialSAMUtils.createArtificialRead(header,"read1",0,1,10);
+        read1.setAttribute("RG",readGroupOne.getId());
+        SAMRecord read2 = ArtificialSAMUtils.createArtificialRead(header,"read2",0,1,10);
+        read2.setAttribute("RG",readGroupTwo.getId());
+        SAMRecord read3 = ArtificialSAMUtils.createArtificialRead(header,"read3",0,1,10);
+        read3.setAttribute("RG",readGroupOne.getId());
+        SAMRecord read4 = ArtificialSAMUtils.createArtificialRead(header,"read4",0,1,10);
+        read4.setAttribute("RG",readGroupTwo.getId());
+        SAMRecord read5 = ArtificialSAMUtils.createArtificialRead(header,"read5",0,1,10);
+        read5.setAttribute("RG",readGroupTwo.getId());
+        SAMRecord read6 = ArtificialSAMUtils.createArtificialRead(header,"read6",0,1,10);
+        read6.setAttribute("RG",readGroupOne.getId());
+        SAMRecord read7 = ArtificialSAMUtils.createArtificialRead(header,"read7",0,1,10);
+        read7.setAttribute("RG",readGroupOne.getId());
+
+        ReadPileup pileup = new ReadPileup(null, Arrays.asList(read1, read2, read3, read4, read5, read6, read7), 1);
+
+        ReadPileup rg1Pileup = pileup.getPileupForReadGroup("rg1");
+        List<SAMRecord> rg1Reads = rg1Pileup.getReads();
+        Assert.assertEquals(rg1Reads.size(), 4, "Wrong number of reads in read group rg1");
+        Assert.assertEquals(rg1Reads.get(0), read1, "Read " + read1.getReadName() + " should be in rg1 but isn't");
+        Assert.assertEquals(rg1Reads.get(1), read3, "Read " + read3.getReadName() + " should be in rg1 but isn't");
+        Assert.assertEquals(rg1Reads.get(2), read6, "Read " + read6.getReadName() + " should be in rg1 but isn't");
+        Assert.assertEquals(rg1Reads.get(3), read7, "Read " + read7.getReadName() + " should be in rg1 but isn't");
+
+        ReadPileup rg2Pileup = pileup.getPileupForReadGroup("rg2");
+        List<SAMRecord> rg2Reads = rg2Pileup.getReads();
+        Assert.assertEquals(rg2Reads.size(), 3, "Wrong number of reads in read group rg2");
+        Assert.assertEquals(rg2Reads.get(0), read2, "Read " + read2.getReadName() + " should be in rg2 but isn't");
+        Assert.assertEquals(rg2Reads.get(1), read4, "Read " + read4.getReadName() + " should be in rg2 but isn't");
+        Assert.assertEquals(rg2Reads.get(2), read5, "Read " + read5.getReadName() + " should be in rg2 but isn't");
+    }
+
+    @Test(expectedExceptions = GATKException.class)
+    public void testException1() {
+        SAMFileHeader header = ArtificialSAMUtils.createArtificialSamHeader(1,1,1000);
+
+        SAMRecord read1 = ArtificialSAMUtils.createArtificialRead(header,"read1",0,1,10);
+
+        ReadPileup pileup = new ReadPileup(null,
+                null,
+                Arrays.asList(1));
+    }
+
+    @Test(expectedExceptions = GATKException.class)
+    public void testException2() {
+        SAMFileHeader header = ArtificialSAMUtils.createArtificialSamHeader(1, 1, 1000);
+
+        SAMRecord read1 = ArtificialSAMUtils.createArtificialRead(header,"read1",0,1,10);
+
+        ReadPileup pileup = new ReadPileup(null,
+                Arrays.asList(read1),
+                null);
+    }
+
+    @Test(expectedExceptions = GATKException.class)
+    public void testException3() {
+        SAMFileHeader header = ArtificialSAMUtils.createArtificialSamHeader(1, 1, 1000);
+
+        SAMRecord read1 = ArtificialSAMUtils.createArtificialRead(header,"read1",0,1,10);
+
+        ReadPileup pileup = new ReadPileup(null,
+                Arrays.asList(read1),
+                Arrays.asList(1, 2, 3));
+    }
+
+
+    /**
+     * Ensure that splitting read groups still works when dealing with null read groups.
+     */
+    @Test
+    public void testSplitByNullReadGroups() {
+        SAMFileHeader header = ArtificialSAMUtils.createArtificialSamHeader(1,1,1000);
+
+        SAMRecord read1 = ArtificialSAMUtils.createArtificialRead(header,"read1",0,1,10);
+        SAMRecord read2 = ArtificialSAMUtils.createArtificialRead(header,"read2",0,1,10);
+        SAMRecord read3 = ArtificialSAMUtils.createArtificialRead(header,"read3",0,1,10);
+
+        ReadPileup pileup = new ReadPileup(null,
+                                                           Arrays.asList(read1, read2, read3),
+                                                           Arrays.asList(1, 1, 1));
+
+        ReadPileup nullRgPileup = pileup.getPileupForReadGroup(null);
+        List<SAMRecord> nullRgReads = nullRgPileup.getReads();
+        Assert.assertEquals(nullRgPileup.size(), 3, "Wrong number of reads in null read group");
+        Assert.assertEquals(nullRgReads.get(0), read1, "Read " + read1.getReadName() + " should be in null rg but isn't");
+        Assert.assertEquals(nullRgReads.get(1), read2, "Read " + read2.getReadName() + " should be in null rg but isn't");
+        Assert.assertEquals(nullRgReads.get(2), read3, "Read " + read3.getReadName() + " should be in null rg but isn't");
+
+        ReadPileup rg1Pileup = pileup.getPileupForReadGroup("rg1");
+        Assert.assertNull(rg1Pileup, "Pileup for non-existent read group should return null");
+    }
+
+    private static int sampleI = 0;
+    private class RBPCountTest {
+        final String sample;
+        final int nReads, nMapq0, nDeletions;
+
+        private RBPCountTest(int nReads, int nMapq0, int nDeletions) {
+            this.sample = "sample" + sampleI++;
+            this.nReads = nReads;
+            this.nMapq0 = nMapq0;
+            this.nDeletions = nDeletions;
+        }
+
+        private List<PileupElement> makeReads( final int n, final int mapq, final String op ) {
+            final int readLength = 3;
+
+            final List<PileupElement> elts = new LinkedList<>();
+            for ( int i = 0; i < n; i++ ) {
+                SAMRecord read = ArtificialSAMUtils.createArtificialRead(header, "read", 0, 1, readLength);
+                read.setReadBases(Utils.dupBytes((byte) 'A', readLength));
+                read.setBaseQualities(Utils.dupBytes((byte) 30, readLength));
+                read.setCigarString("1M1" + op + "1M");
+                read.setMappingQuality(mapq);
+                final int baseOffset = op.equals("M") ? 1 : 0;
+                final CigarElement cigarElement = read.getCigar().getCigarElement(1);
+                elts.add(new PileupElement(read, baseOffset, cigarElement, 1, 0));
+            }
+
+            return elts;
+        }
+
+        private ReadPileup makePileup() {
+            final List<PileupElement> elts = new LinkedList<>();
+
+            elts.addAll(makeReads(nMapq0, 0, "M"));
+            elts.addAll(makeReads(nDeletions, 30, "D"));
+            elts.addAll(makeReads(nReads - nMapq0 - nDeletions, 30, "M"));
+
+            return new ReadPileup(loc, elts);
+        }
+
+        @Override
+        public String toString() {
+            return "RBPCountTest{" +
+                    "sample='" + sample + '\'' +
+                    ", nReads=" + nReads +
+                    ", nMapq0=" + nMapq0 +
+                    ", nDeletions=" + nDeletions +
+                    '}';
+        }
+    }
+
+    @DataProvider(name = "RBPCountingTest")
+    public Object[][] makeRBPCountingTest() {
+        final List<Object[]> tests = new LinkedList<>();
+
+        for ( final int nMapq : Arrays.asList(0, 10, 20) ) {
+            for ( final int nDeletions : Arrays.asList(0, 10, 20) ) {
+                for ( final int nReg : Arrays.asList(0, 10, 20) ) {
+                    final int total = nMapq + nDeletions + nReg;
+                    if ( total > 0 )
+                        tests.add(new Object[]{new RBPCountTest(total, nMapq, nDeletions)});
+                }
+            }
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "RBPCountingTest")
+    public void testRBPCountingTestSinglePileup(RBPCountTest params) {
+        testRBPCounts(params.makePileup(), params);
+    }
+
+    private void testRBPCounts(final ReadPileup rbp, RBPCountTest expected) {
+        for ( int cycles = 0; cycles < 3; cycles++ ) {
+            // multiple cycles to make sure caching is working
+            Assert.assertEquals(rbp.size(), expected.nReads);
+            Assert.assertEquals(rbp.getNumberOfDeletions(), expected.nDeletions);
+            Assert.assertEquals(rbp.getNumberOfMappingQualityZeroReads(), expected.nMapq0);
+        }
+    }
+
+    @Test
+    public void testEmptyPileup(){
+        final ReadPileup empty = new ReadPileup(loc);
+        Assert.assertTrue(empty.isEmpty());
+        Assert.assertTrue(empty.size() == 0);
+        Assert.assertEquals(empty.getBaseCounts(), new int[4]);
+        Assert.assertEquals(empty.getBases(), new byte[0]);
+        Assert.assertEquals(empty.getQuals(), new byte[0]);
+        Assert.assertEquals(empty.getLocation(), loc);
+        Assert.assertEquals(empty.getMappingQuals(), new int[0]);
+        Assert.assertTrue(empty.getNegativeStrandPileup().isEmpty());
+        Assert.assertTrue(empty.getPositiveStrandPileup().isEmpty());
+        Assert.assertTrue(empty.getBaseAndMappingFilteredPileup(0, 0).isEmpty());
+        Assert.assertTrue(empty.getBaseFilteredPileup(0).isEmpty());
+        Assert.assertEquals(empty.getNumberOfDeletions(), 0);
+        Assert.assertEquals(empty.getNumberOfDeletionsAfterThisElement(), 0);
+        Assert.assertEquals(empty.getNumberOfInsertionsAfterThisElement(), 0);
+        Assert.assertEquals(empty.getNumberOfMappingQualityZeroReads(), 0);
+        Assert.assertTrue(empty.getOffsets().isEmpty());
+        Assert.assertTrue(empty.getReadGroupIDs().isEmpty());
+        Assert.assertTrue(empty.getReads().isEmpty());
+        Assert.assertTrue(empty.getSamples().isEmpty());
+        Assert.assertTrue(empty.getStartSortedPileup().isEmpty());
+        Assert.assertTrue(empty.getPileupForLane("fred") == null);
+        Assert.assertTrue(empty.getMappingFilteredPileup(10).isEmpty());
+        Assert.assertTrue(empty.toFragments().getOverlappingPairs().isEmpty());
+        Assert.assertTrue(empty.toFragments().getSingletonReads().isEmpty());
+        Assert.assertEquals("chr1 1 A  ", empty.getPileupString('A'));
+    }
+
+    @Test
+    public void testSimplePileup(){
+        final int readlength = 10;
+        final byte[] bases1 = Utils.arrayFromArrayWithLength(new byte[]{'A'}, readlength);
+        final byte[] quals1 = Utils.arrayFromArrayWithLength(new byte[]{10}, readlength);
+        final String cigar1 = "10M";
+
+        final byte[] bases2 = Utils.arrayFromArrayWithLength(new byte[]{'C'}, readlength);
+        final byte[] quals2 = Utils.arrayFromArrayWithLength(new byte[]{20}, readlength);
+        final String cigar2 = "5M3I2M";
+
+        final SAMRecord read1 = ArtificialSAMUtils.createArtificialRead(bases1, quals1, cigar1);
+        read1.setReadName("read1");
+        final SAMRecord read2 = ArtificialSAMUtils.createArtificialRead(bases2, quals2, cigar2);
+        read1.setReadName("read2");
+        List<SAMRecord> reads = Arrays.asList(read1, read2);
+        final ReadPileup pu = new ReadPileup(loc, reads, 1);
+        Assert.assertEquals(pu.getBases(), new byte[]{(byte) 'A', (byte) 'C'});
+        Assert.assertFalse(pu.isEmpty());
+        Assert.assertEquals(pu.size(), 2, "size");
+        Assert.assertEquals(pu.getBaseCounts(), new int[]{1,1,0,0});
+        Assert.assertEquals(pu.getQuals(), new byte[]{10, 20});
+        Assert.assertEquals(pu.getLocation(), loc);
+        Assert.assertEquals(pu.getMappingQuals(), new int[]{NO_MAPPING_QUALITY, NO_MAPPING_QUALITY});
+        Assert.assertTrue(pu.getNegativeStrandPileup().isEmpty(), "getNegativeStrandPileup");
+        Assert.assertEquals(pu.getPositiveStrandPileup().size(), 2, "getPositiveStrandPileup");
+        Assert.assertEquals(pu.getBaseAndMappingFilteredPileup(12, 0).size(), 1, "getBaseAndMappingFilteredPileup");
+        Assert.assertEquals(pu.getBaseFilteredPileup(12).size(), 1, "getBaseFilteredPileup");
+        Assert.assertEquals(pu.getNumberOfDeletions(), 0);
+        Assert.assertEquals(pu.getNumberOfDeletionsAfterThisElement(), 0);
+        Assert.assertEquals(pu.getNumberOfInsertionsAfterThisElement(), 0);
+        Assert.assertEquals(pu.getNumberOfMappingQualityZeroReads(), 2);
+        Assert.assertEquals(pu.getOffsets(), Arrays.asList(1, 1), "getOffsets");
+        Assert.assertEquals(pu.getReadGroupIDs(), Arrays.asList(new SAMReadGroupRecord[]{null}), "getReadGroups");
+        Assert.assertEquals(pu.getReads(), Arrays.asList(read1, read2), "getReads");
+        Assert.assertEquals(pu.getSamples(), Arrays.asList(new String[]{null}), "getSamples");
+        Assert.assertEquals(pu.getStartSortedPileup().size(), 2, "getStartSortedPileup");
+        Assert.assertTrue(pu.getPileupForLane("fred") == null);
+        Assert.assertTrue(pu.getMappingFilteredPileup(10).isEmpty());
+        Assert.assertTrue(pu.toFragments().getOverlappingPairs().isEmpty());
+        Assert.assertEquals(pu.toFragments().getSingletonReads().stream().map(pe -> pe.getRead()).collect(Collectors.toList()), Arrays.asList(read1, read2), "getSingletonReads");
+        Assert.assertEquals("chr1 1 A AC +5", pu.getPileupString('A'));
+    }
+
+    @Test
+    public void testSimplePileupWithOffset(){
+        final int readlength = 10;
+        final byte[] bases1 = Utils.arrayFromArrayWithLength(new byte[]{'A'}, readlength);
+        final byte[] quals1 = Utils.arrayFromArrayWithLength(new byte[]{10}, readlength);
+        final String cigar1 = "10M";
+
+        final byte[] bases2 = Utils.arrayFromArrayWithLength(new byte[]{'C'}, readlength);
+        final byte[] quals2 = Utils.arrayFromArrayWithLength(new byte[]{20}, readlength);
+        final String cigar2 = "10M";
+
+        final SAMRecord read1 = ArtificialSAMUtils.createArtificialRead(bases1, quals1, cigar1);
+        read1.setReadName("read1");
+        final SAMRecord read2 = ArtificialSAMUtils.createArtificialRead(bases2, quals2, cigar2);
+        read1.setReadName("read2");
+        List<SAMRecord> reads = Arrays.asList(read1, read2);
+        final int off = 6;
+        final ReadPileup pu = new ReadPileup(loc, reads, off);
+        Assert.assertEquals(pu.getBases(), new byte[]{(byte) 'A', (byte) 'C'});
+        Assert.assertFalse(pu.isEmpty());
+        Assert.assertEquals(pu.size(), 2, "size");
+        Assert.assertEquals(pu.getBaseCounts(), new int[]{1,1,0,0});
+        Assert.assertEquals(pu.getQuals(), new byte[]{10, 20});
+        Assert.assertEquals(pu.getLocation(), loc);
+        Assert.assertEquals(pu.getMappingQuals(), new int[]{NO_MAPPING_QUALITY, NO_MAPPING_QUALITY});
+        Assert.assertTrue(pu.getNegativeStrandPileup().isEmpty(), "getNegativeStrandPileup");
+        Assert.assertEquals(pu.getPositiveStrandPileup().size(), 2, "getPositiveStrandPileup");
+        Assert.assertEquals(pu.getBaseAndMappingFilteredPileup(12, 0).size(), 1, "getBaseAndMappingFilteredPileup");
+        Assert.assertEquals(pu.getBaseFilteredPileup(12).size(), 1, "getBaseFilteredPileup");
+        Assert.assertEquals(pu.getNumberOfDeletions(), 0);
+        Assert.assertEquals(pu.getNumberOfDeletionsAfterThisElement(), 0);
+        Assert.assertEquals(pu.getNumberOfInsertionsAfterThisElement(), 0);
+        Assert.assertEquals(pu.getNumberOfMappingQualityZeroReads(), 2);
+        Assert.assertEquals(pu.getOffsets(), Arrays.asList(off, off), "getOffsets");
+        Assert.assertEquals(pu.getReadGroupIDs(), Arrays.asList(new SAMReadGroupRecord[]{null}), "getReadGroups");
+        Assert.assertEquals(pu.getReads(), Arrays.asList(read1, read2), "getReads");
+        Assert.assertEquals(pu.getSamples(), Arrays.asList(new String[]{null}), "getSamples");
+        Assert.assertEquals(pu.getStartSortedPileup().size(), 2, "getStartSortedPileup");
+        Assert.assertTrue(pu.getPileupForLane("fred") == null);
+        Assert.assertTrue(pu.getMappingFilteredPileup(10).isEmpty());
+        Assert.assertTrue(pu.toFragments().getOverlappingPairs().isEmpty());
+        Assert.assertEquals(pu.toFragments().getSingletonReads().stream().map(pe -> pe.getRead()).collect(Collectors.toList()), Arrays.asList(read1, read2), "getSingletonReads");
+        Assert.assertEquals("chr1 1 A AC +5", pu.getPileupString('A'));
+    }
+}


### PR DESCRIPTION
Pileups. I kept only the most useful parts from GATK3 and removed most of the complex abstractions (generics upon generics etc etc). 

@droazen please review. This is step number 1 for IndelTargetDetector work (on the walker infractructure, not dataflow).