### PR TITLE
Removing my abuse of Objects.nonNull()

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
@@ -61,7 +61,7 @@ public final class SimpleInterval implements Locatable, Serializable {
      * @throws IllegalArgumentException if locatable violates any of the SimpleInterval constraints or is null
      */
     public SimpleInterval(final Locatable locatable){
-        this(Objects.requireNonNull(locatable, () -> {throw new IllegalArgumentException();}).getContig(),
+        this(Utils.nonNull(locatable).getContig(),
                 locatable.getStart(), locatable.getEnd());
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/Utils.java
@@ -509,4 +509,17 @@ public class Utils {
         return new String(big).endsWith(new String(suffix));
     }
 
+    /**
+     * Checks that an Object {@code object} is not null and returns the same object or throws an {@link IllegalArgumentException}
+     * @param object any Object
+     * @return the same object
+     * @throws IllegalArgumentException if a {@code o == null}
+     */
+    public static <T> T nonNull(T object) throws IllegalArgumentException {
+        if (object == null) {
+            throw new IllegalArgumentException("Null object is not allowed here.");
+        }
+        return object;
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -65,7 +65,7 @@ public class UtilsUnitTest extends BaseTest {
         Assert.assertEquals(Utils.join(",", new Object[] { true , -12, "Blah", this.getClass() }),
                 "true,-12,Blah," + this.getClass().toString());
         Assert.assertEquals(Utils.join(",", true, -13, "Blah", this.getClass()),"true,-13,Blah," + this.getClass().toString());
-        Assert.assertEquals(Utils.join(",",Boolean.TRUE),"true");
+        Assert.assertEquals(Utils.join(",", Boolean.TRUE),"true");
     }
 
     @Test
@@ -203,5 +203,17 @@ public class UtilsUnitTest extends BaseTest {
 
         final String sourceString = FileUtils.readFileToString(source);
         Assert.assertEquals(Utils.calcMD5(sourceString), sourceMD5);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNonNullThrows(){
+        Object o = null;
+        Utils.nonNull(o);
+    }
+
+    @Test
+    public void testNonNullDoesNotThrow(){
+        Object o = new Object();
+        Assert.assertSame(Utils.nonNull(o), o);
     }
 }


### PR DESCRIPTION
Adding a new `Utils.nonNull` which is a fluent style assert to throw `IllegalArgumentException` on nulls.