### PR TITLE
#259 - replace calls to getChr() with getContig().

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/utils/codecs/table/TableCodecUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/codecs/table/TableCodecUnitTest.java
@@ -54,12 +54,12 @@ public final class TableCodecUnitTest extends BaseTest {
     @Test
     public void testChrs(){
         TableCodec tc = new TableCodec();
-        Assert.assertEquals(tc.decode("1:1  1   2   3").getChr(), "1");
-        Assert.assertEquals(tc.decode("chr1:1  1   2   3").getChr(), "chr1");
-        Assert.assertEquals(tc.decode("1:1+  1   2   3").getChr(), "1");
-        Assert.assertEquals(tc.decode("1  1   2   3").getChr(), "1");
-        Assert.assertEquals(tc.decode("fred  1   2   3").getChr(), "fred");
-        Assert.assertEquals(tc.decode("2:1,000  1   2   3").getChr(), "2");
+        Assert.assertEquals(tc.decode("1:1  1   2   3").getContig(), "1");
+        Assert.assertEquals(tc.decode("chr1:1  1   2   3").getContig(), "chr1");
+        Assert.assertEquals(tc.decode("1:1+  1   2   3").getContig(), "1");
+        Assert.assertEquals(tc.decode("1  1   2   3").getContig(), "1");
+        Assert.assertEquals(tc.decode("fred  1   2   3").getContig(), "fred");
+        Assert.assertEquals(tc.decode("2:1,000  1   2   3").getContig(), "2");
     }
 
     @DataProvider(name = "dataLines")
@@ -111,7 +111,6 @@ public final class TableCodecUnitTest extends BaseTest {
         Assert.assertEquals(decode.get("c"), "3");
         Assert.assertEquals(decode.getLocation().getContig(), "1");
         Assert.assertEquals(decode.getContig(), "1");
-        Assert.assertEquals(decode.getChr(), "1");
         Assert.assertEquals(decode.getLocation().getStart(), 1);
         Assert.assertEquals(decode.getLocation().getEnd(), 1);
     }


### PR DESCRIPTION
This request removes all calls to getChr() in the code by replacing calls to getChr() with calls to getContig() and removing a redundant assertion that contains a call to getChr().

To complete the removal of getChr() from the code, we could:

Remove the getChr() method overrides in the TableFeature and ArtificialTestFeature classes and convert these classes from implementing the Feature interface to implementing the Locatable interface.

Remove the definition of the Feature interface from htsjdk.tribble (since all Feature does is add getChr() to the Locatable interface), and replace all references to the Feature interface in the tools and libraries with references to the Locatable interface.

These steps will also remove the deprecation warnings for getChr() (part of #377).

