### PR TITLE
Adding maven upload to build.gradle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 ------------
 To build and run all tests, run `gradle check`. Test report is in `build/reports/tests/index.html`.
 
-To only build, run `gradle install`.
+To only build, run `gradle installApp`.
 
 To run all tests, run `gradle test`. 
 
@@ -140,3 +140,31 @@ If there are dependency changes in `build.gradle` it is necessary to refresh the
 
 * Open the gradle tool window  ( "View" -> "Tool Windows" -> "Gradle" )
 * Click the refresh button in the Gradle tool window.  It is in the top left of the gradle view and is represented by two blue arrows.
+
+Uploading Archives to Sonatype
+-------------------
+To upload snapshots to sonatype you'll need the following:
+
+*You must have a registered account on the sonatype JIRA (and be approved as a hellbender uploader)
+*You need to configure several additional properties in your `/~.gradle/gradle.properties` file
+
+*If you want to upload a release instead of a snapshot you will additionally need to have access to the hellbender signing key and password
+
+```
+#needed for snapshot upload
+sonatypeUsername=<your sonatype username>
+sonatypePassword=<your sonatype password>
+
+#needed for signing a release
+signing.keyId=<hellbender key id>
+signing.password=<hellbender key password>
+signing.secretKeyRingFile=/Users/<username>/.gnupg/secring.gpg
+```
+
+To perform an upload, use
+```
+gradle uploadArchives
+```
+
+Currently all builds are considered snapshots.  The archive name is based off of `git describe`.
+

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ apply plugin: 'idea'
 apply plugin: 'application'
 apply plugin: "jacoco"
 apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'maven'
+apply plugin: 'signing'
 
 mainClassName = "org.broadinstitute.hellbender.Main"
 
@@ -103,7 +105,7 @@ def String deriveVersion(){
     try {
         logger.info("path is $System.env.PATH")
         exec {
-            commandLine "git", "describe", "--always", "--long"
+            commandLine "git", "describe", "--always"
             standardOutput = stdout;
 
             ignoreExitValue = true
@@ -113,8 +115,11 @@ def String deriveVersion(){
     }
     return stdout.size() > 0 ? stdout.toString().trim() : "version-unknown"
 }
-
-version = deriveVersion()
+final SNAPSHOT = "-SNAPSHOT"
+version = deriveVersion() + SNAPSHOT  //all builds are snapshot builds until we decide that there is something we want to keep
+boolean isRelease = ! version.endsWith(SNAPSHOT)
+logger.info("build for version:" + version)
+group = 'org.broadinstitute'
 
 
 jar {
@@ -187,4 +192,90 @@ task fatJar(type: Jar) {
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
- 
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from 'build/docs/javadoc'
+}
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allSource
+    classifier = 'sources'
+}
+
+// This is a hack to disable the java 8 default javadoc lint until we fix the html formatting
+if (JavaVersion.current().isJava8Compatible()) {
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
+}
+
+/**
+ *This specifies what artifacts will be built and uploaded when performing a maven upload.
+ */
+artifacts {
+    archives jar
+    archives javadocJar
+    archives sourcesJar
+}
+
+/**
+ * Sign non-snapshot releases with our secret key.  This should never need to be invoked directly.
+ */
+signing {
+    required { isRelease && gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
+}
+
+/**
+ * Upload a release to sonatype.  You must be an authorized uploader and have your sonatype
+ * username and password information in your gradle properties file.  See the readme for more info.
+ *
+ * For releasing to your local maven repo, use gradle install
+ */
+uploadArchives {
+    if(project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')){
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                    authentication(userName: sonatypeUsername, password: sonatypePassword)
+                }
+
+                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
+                    authentication(userName: sonatypeUsername, password: sonatypePassword)
+                }
+
+                pom.project {
+                    name 'Hellbender'
+                    packaging 'jar'
+                    description 'Development on GATK4'
+                    url 'http://github.com/broadinstitute/hellbender'
+
+                    scm {
+                        url 'scm:git@github.com:broadinstitute/hellbender.git'
+                        connection 'scm:git@github.com:broadinstitute/hellbender.git'
+                        developerConnection 'scm:git@github.com:broadinstitute/hellbender.git'
+                    }
+
+                    licenses {
+                        license {
+                            name 'BSD 3-Clause'
+                            url 'https://github.com/broadinstitute/hellbender/blob/master/LICENSE.TXT'
+                            distribution 'repo'
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        doFirst({
+            logger.error( 'Users are not generally supposed to upload archives.  ' +
+                'To upload archives you must specify certain information in your gradle.properties. See the README' +
+                ' for more information.' )
+            throw new Exception("Missing sonatype username or password, please see the README for properties that must be specified for uploading an archive.")}
+        )
+
+    }
+}


### PR DESCRIPTION
gradle uploadArchives will perform a maven release (currently a snapshot release)

Unfortunately the maven plugin has an "install" task which installs to the local repo, so it's now necessary to specify `installApp` or `installDist` instead of just `gradle install`   