### PR TITLE
Da credentials

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/DataflowReadsPipeline.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/DataflowReadsPipeline.java
@@ -42,10 +42,6 @@ public abstract class DataflowReadsPipeline extends DataflowCommandLineProgram {
     @Argument(doc="a prefix for the dataflow output files", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
     protected String outputFile;
 
-    @Argument(doc = "path to the client secret file for google cloud authentication, necessary if accessing data from buckets",
-            shortName = "secret", fullName = "client_secret", optional=true)
-    protected File clientSecret = new File("client_secret.json");
-
     @Argument(doc = "uri for the input bam, either a local file path or a gs:// bucket path",
             shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.INPUT_LONG_NAME,
             optional = false)
@@ -81,13 +77,13 @@ public abstract class DataflowReadsPipeline extends DataflowCommandLineProgram {
 
     @Override
     final protected void setupPipeline(Pipeline pipeline) {
-        ReadsSource readsSource = new ReadsSource(bam, clientSecret);
+        ReadsSource readsSource = new ReadsSource(bam, pipeline);
         String headerString = readsSource.getHeaderString();
         SAMSequenceDictionary sequenceDictionary = ReadUtils.samHeaderFromString(headerString).getSequenceDictionary();
         List<SimpleInterval> intervals = intervalArgumentCollection.intervalsSpecified() ? intervalArgumentCollection.getIntervals(sequenceDictionary):
                 getAllIntervalsForReference(sequenceDictionary);
 
-        PCollection<Read> preads = readsSource.getReadPCollection(pipeline, intervals);
+        PCollection<Read> preads = readsSource.getReadPCollection(intervals);
 
         PCollection<?> presult = applyTransformsToPipeline(headerString, preads);
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSourceTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSourceTest.java
@@ -39,10 +39,10 @@ public class ReadsSourceTest extends BaseTest {
 
     @Test
     public void testGetReadPCollectionLocal(){
-        ReadsSource source = new ReadsSource(bam.getAbsolutePath(), null);
         Pipeline p = TestPipeline.create();
+        ReadsSource source = new ReadsSource(bam.getAbsolutePath(), p);
         DataflowWorkarounds.registerGenomicsCoders(p);
-        PCollection<Read> reads = source.getReadPCollection(p, ImmutableList.of(new SimpleInterval("chr7", 1, 404)));
+        PCollection<Read> reads = source.getReadPCollection(ImmutableList.of(new SimpleInterval("chr7", 1, 404)));
         PCollection<Long> count = reads.apply(Count.globally());
         DataflowAssert.thatSingleton(count).isEqualTo(7L);
         p.run();


### PR DESCRIPTION
I created a minimal branch to clean up the way we were passing around credentials. We create a GCSOptions class instead of a DataflowPipelineOptions when we create the pipeline and pass in secrets in at the point instead at the ReadSources level. ReadSources now takes a pipeline instead of the secrets file location.

This isn't a long term solution. We should switch the code to get rid of the GenomicsSecret and instead use the more general secret. I think much of the secets factory junk can go away now (they dated from a time when the Dataflow API wasn't built out much.

All tests passed locally. Oddly, I now am sometimes getting a dialog about DSDE needing access to basic information about my Google account, not sure source of the issue (maybe the secret I grabbed?), if it's repeatable, or blocking. I recommend the reviewer patch my branch and test locally. 