### PR TITLE
Making plotting with R require an explicit flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,11 @@ env:
 cache:
   directories:
   - ~/.gradle
-  - ~/site-library
 before_install:
-- sudo mkdir -p /usr/local/lib/R/
-- mkdir -p site-library
-- sudo ln -sFv ~/site-library /usr/local/lib/R/site-library
+- sudo apt-get install -y r-base-dev
 - wget -N https://downloads.gradle.org/distributions/gradle-2.2.1-bin.zip
 - unzip gradle-2.2.1-bin.zip
 - export PATH=`pwd`/gradle-2.2.1/bin:$PATH
-- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-- sudo add-apt-repository "deb http://cran.rstudio.com/bin/linux/ubuntu precise/"
-- sudo apt-get update
-- sudo apt-get install -y r-base-dev=3.1.3-1precise2
-- sudo apt-get install -y --force-yes r-base-core=3.1.3-1precise2
 - R --version
-- sudo Rscript scripts/install_R_packages.R
 after_success:
 - gradle jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -69,15 +69,17 @@ General guidelines for Hellbender developers
 
 R Dependency
 ----------------
-Certain Hellbender tools rely on R for generating plots. **R v3.1.3** must be installed for all unit tests to work (other versions of R may work, but there is no guarantee).  
+Certain Hellbender tools may optionally generate plots if R is installed.  We recommend **R v3.1.3** if you want to produce plots.  If you are uninterested in plotting, R is still required by several of the unit tests.  Plotting is currently untested and should be viewed as a convinience rather than a primary output.  
 
 R installation is not part of the gradle build.  See http://cran.r-project.org/ for general information on installing R for your system.
-* for [ubuntu specific instructions](http://cran.r-project.org/bin/linux/ubuntu/README))
+* for ubuntu see these [ubuntu specific instructions](http://cran.r-project.org/bin/linux/ubuntu/README)
 * for OSX we recommend installation through [homebrew](http://brew.sh/)
+```
+brew tap homebrew/science
+brew install R
+```
 
-* For more information on R see http://www.ihater.org/
-
-Gradle installApp will attempt to install R packages, this may potentially fail if your R library is not writable.  If this happens, the package installation script is the package installation script is `scripts/install_R_packages.R`.  Either run it as superuser to force installation into the sites library or run interactively and create a local library.
+The plotting R scripts require certain R packages to be installed. You can install these by running `scripts/install_R_packages.R`.  Either run it as superuser to force installation into the sites library or run interactively and create a local library.
 ```
 sudo Rscript scripts/install_R_packages.R
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         mavenCentral()
-
      }
 
     dependencies {
@@ -31,11 +30,6 @@ task downloadGsaLibFile(type: Download) {
     overwrite false
 }
 
-task installRPackages(type: Exec){
-  executable 'Rscript'
-  args 'scripts/install_R_packages.R'
-  ignoreExitValue true
-}
 
 repositories {
     mavenCentral()
@@ -65,7 +59,7 @@ compileTestJava {
   options.compilerArgs = ['-proc:none', '-Xlint:all']
 }
 
-installApp.dependsOn downloadGsaLibFile, installRPackages
+installApp.dependsOn downloadGsaLibFile
 build.dependsOn installApp
 check.dependsOn installApp
 
@@ -132,24 +126,18 @@ jar {
 }
 
 test {
-    dependsOn installRPackages
     // enable TestNG support (default is JUnit)
     useTestNG{
         excludeGroups 'cloud', 'bucket'
     }
 
-    beforeSuite {
-        boolean ROk = installRPackages.execResult.exitValue == 0
-        if (!ROk) {
-            logger.warn( "R package installation failed" )
-        }
-    }
     // set heap size for the test JVM(s)
     minHeapSize = "1G"
     maxHeapSize = "2G"
+    
+    maxParallelForks=2
   
     String CI = "$System.env.CI"
-    String runRTests = "$System.env.RUNR"
     if (CI == "true") {
         int count = 0
         // listen to events in the test execution lifecycle

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectBaseDistributionByCycle.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectBaseDistributionByCycle.java
@@ -34,6 +34,9 @@ public final class CollectBaseDistributionByCycle extends SinglePassSamProgram {
     @Argument(doc = "If set to true calculate the base distribution over PF reads only.")
     public boolean PF_READS_ONLY = false;
 
+    @Argument(doc = "Should an output plot be created")
+    public boolean PRODUCE_PLOT = false;
+
     private HistogramGenerator hist;
     private String plotSubtitle = "";
     private final Log log = Log.getInstance(CollectBaseDistributionByCycle.class);
@@ -67,9 +70,10 @@ public final class CollectBaseDistributionByCycle extends SinglePassSamProgram {
         final MetricsFile<BaseDistributionByCycleMetrics, ?> metrics = getMetricsFile();
         hist.addToMetricsFile(metrics);
         metrics.write(OUTPUT);
+
         if (hist.isEmpty()) {
             log.warn("No valid bases found in input file. No plot will be produced.");
-        } else {
+        } else if(PRODUCE_PLOT){
             final RScriptExecutor executor = new RScriptExecutor();
             executor.addScript(new Resource(R_SCRIPT, CollectBaseDistributionByCycle.class));
             executor.addArgs(OUTPUT.getAbsolutePath(), CHART_OUTPUT.getAbsolutePath(), INPUT.getName(), plotSubtitle);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectGcBiasMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectGcBiasMetrics.java
@@ -57,6 +57,9 @@ public final class CollectGcBiasMetrics extends SinglePassSamProgram {
     @Argument(shortName = "BS", doc = "Whether the SAM or BAM file consists of bisulfite sequenced reads.  ")
     public boolean IS_BISULFITE_SEQUENCED = false;
 
+    @Argument(doc = "Should an output plot be created")
+    public boolean PRODUCE_PLOT = false;
+
     // Used to keep track of the total clusters as this is kinda important for bias
     private int totalClusters = 0;
     private int totalAlignedReads = 0;
@@ -161,11 +164,12 @@ public final class CollectGcBiasMetrics extends SinglePassSamProgram {
                 ", Aligned reads: " + fmt.format(this.totalAlignedReads);
         String title = INPUT.getName().replace(".duplicates_marked", "").replace(".aligned.bam", "");
         title += "." + saveHeader;
-
-        final RScriptExecutor executor = new RScriptExecutor();
-        executor.addScript(new Resource(R_SCRIPT, CollectGcBiasMetrics.class));
-        executor.addArgs(OUTPUT.getAbsolutePath(), CHART_OUTPUT.getAbsolutePath(), title, subtitle, String.valueOf(WINDOW_SIZE));
-        executor.exec();
+        if (PRODUCE_PLOT){
+            final RScriptExecutor executor = new RScriptExecutor();
+            executor.addScript(new Resource(R_SCRIPT, CollectGcBiasMetrics.class));
+            executor.addArgs(OUTPUT.getAbsolutePath(), CHART_OUTPUT.getAbsolutePath(), title, subtitle, String.valueOf(WINDOW_SIZE));
+            executor.exec();
+        }
     }
 
     /** Sums the values in an int[]. */

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetrics.java
@@ -53,6 +53,9 @@ public final class CollectInsertSizeMetrics extends SinglePassSamProgram {
     @Argument(shortName="LEVEL", doc="The level(s) at which to accumulate metrics.  ")
     private Set<MetricAccumulationLevel> METRIC_ACCUMULATION_LEVEL = CollectionUtil.makeSet(MetricAccumulationLevel.ALL_READS);
 
+    @Argument(doc = "Should an output plot be created")
+    public boolean PRODUCE_PLOT = false;
+
     // Calculates InsertSizeMetrics for all METRIC_ACCUMULATION_LEVELs provided
     private InsertSizeMetricsCollector multiCollector;
 
@@ -107,11 +110,13 @@ public final class CollectInsertSizeMetrics extends SinglePassSamProgram {
         }
         else  {
             file.write(OUTPUT);
-            final RScriptExecutor executor = new RScriptExecutor();
-            executor.addScript(new Resource(R_SCRIPT, CollectInsertSizeMetrics.class));
-            executor.addArgs(OUTPUT.getAbsolutePath(), HISTOGRAM_FILE.getAbsolutePath(), INPUT.getName());
-            if (HISTOGRAM_WIDTH != null) executor.addArgs(String.valueOf(HISTOGRAM_WIDTH));
-            executor.exec();
+            if(PRODUCE_PLOT){
+                final RScriptExecutor executor = new RScriptExecutor();
+                executor.addScript(new Resource(R_SCRIPT, CollectInsertSizeMetrics.class));
+                executor.addArgs(OUTPUT.getAbsolutePath(), HISTOGRAM_FILE.getAbsolutePath(), INPUT.getName());
+                if (HISTOGRAM_WIDTH != null) executor.addArgs(String.valueOf(HISTOGRAM_WIDTH));
+                executor.exec();
+            }
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/MeanQualityByCycle.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/MeanQualityByCycle.java
@@ -44,6 +44,9 @@ public final class MeanQualityByCycle extends SinglePassSamProgram {
     @Argument(doc="If set to true calculate mean quality over PF reads only.")
     public boolean PF_READS_ONLY = false;
 
+    @Argument(doc = "Should an output plot be created")
+    public boolean PRODUCE_PLOT = false;
+
     private final HistogramGenerator q  = new HistogramGenerator(false);
     private final HistogramGenerator oq = new HistogramGenerator(true);
 
@@ -159,7 +162,7 @@ public final class MeanQualityByCycle extends SinglePassSamProgram {
         if (q.isEmpty() && oq.isEmpty()) {
             log.warn("No valid bases found in input file. No plot will be produced.");
         }
-        else {
+        else if (PRODUCE_PLOT){
             // Now run R to generate a chart
             final RScriptExecutor executor = new RScriptExecutor();
             executor.addScript(new Resource(R_SCRIPT, MeanQualityByCycle.class));

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/QualityScoreDistribution.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/QualityScoreDistribution.java
@@ -44,6 +44,9 @@ public final class QualityScoreDistribution extends SinglePassSamProgram {
     @Argument(doc="If set to true, include quality for no-call bases in the distribution.")
     public boolean INCLUDE_NO_CALLS = false;
 
+    @Argument(doc = "Should an output plot be created")
+    public boolean PRODUCE_PLOT = false;
+
     private final long[] qCounts  = new long[128];
     private final long[] oqCounts = new long[128];
 
@@ -107,7 +110,7 @@ public final class QualityScoreDistribution extends SinglePassSamProgram {
         if (qHisto.isEmpty() && oqHisto.isEmpty()) {
             log.warn("No valid bases found in input file. No plot will be produced.");
         }
-        else {
+        else if(PRODUCE_PLOT){
             // Now run R to generate a chart
             final RScriptExecutor executor = new RScriptExecutor();
             executor.addScript(new Resource(R_SCRIPT, QualityScoreDistribution.class));

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRrbsMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRrbsMetrics.java
@@ -68,6 +68,9 @@ public final class CollectRrbsMetrics extends PicardCommandLineProgram {
     @Argument(shortName = "LEVEL", doc = "The level(s) at which to accumulate metrics.  ")
     public Set<MetricAccumulationLevel> METRIC_ACCUMULATION_LEVEL = CollectionUtil.makeSet(MetricAccumulationLevel.ALL_READS);
 
+    @Argument(doc = "Should an output plot be created")
+    public boolean PRODUCE_PLOT = false;
+
     public static final String DETAIL_FILE_EXTENSION = "rrbs_detail_metrics";
     public static final String SUMMARY_FILE_EXTENSION = "rrbs_summary_metrics";
     public static final String PDF_FILE_EXTENSION = "rrbs_qc.pdf";
@@ -118,10 +121,12 @@ public final class CollectRrbsMetrics extends PicardCommandLineProgram {
         }
         summaryFile.write(SUMMARY_OUT);
         detailsFile.write(DETAILS_OUT);
-        final RScriptExecutor executor = new RScriptExecutor();
-        executor.addScript(new Resource(R_SCRIPT, CollectRrbsMetrics.class));
-        executor.addArgs(DETAILS_OUT.getAbsolutePath(), SUMMARY_OUT.getAbsolutePath(), PLOTS_OUT.getAbsolutePath());
-        executor.exec();
+        if(PRODUCE_PLOT) {
+            final RScriptExecutor executor = new RScriptExecutor();
+            executor.addScript(new Resource(R_SCRIPT, CollectRrbsMetrics.class));
+            executor.addArgs(DETAILS_OUT.getAbsolutePath(), SUMMARY_OUT.getAbsolutePath(), PLOTS_OUT.getAbsolutePath());
+            executor.exec();
+        }
 
         CloserUtil.close(samReader);
         return null;

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariatesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariatesIntegrationTest.java
@@ -65,30 +65,6 @@ public final class AnalyzeCovariatesIntegrationTest extends CommandLineProgramTe
     }
 
     /**
-     * Test the size of the generated pdf.
-     * <p/>
-     * Unfortunately we cannot test the content as it changes slightly
-     *    every time the tool is run.
-     *
-     * @throws java.io.IOException should never happen. It would be an
-     *    indicator of a problem with the testing environment.
-     */
-    @Test(groups = {"R"})
-    public void testPdfGeneration()
-            throws IOException {
-        final File pdfFile = createTempFile("ACTest", ".pdf");
-        pdfFile.delete();
-
-        final List<String> files = Collections.emptyList();
-        final IntegrationTestSpec spec = new IntegrationTestSpec(
-                buildCommandLine(null,pdfFile.toString(),true,true,true), files);
-        spec.executeTest("testPdfGeneration", this);
-        assertTrue(pdfFile.exists(),"the pdf file was not created");
-        assertTrue(pdfFile.length() > 260000,"the pdf file size does"
-                + " not reach the minimum of 260Kb");
-    }
-
-    /**
      * Test the effect of changing some recalibration parameters.
      * @param afterFileName name of the alternative after recalibration file.
      * @param description describes what has been changed.
@@ -155,16 +131,13 @@ public final class AnalyzeCovariatesIntegrationTest extends CommandLineProgramTe
     public Iterator<Object[]> alternativeInOutAbsenceCombinations(Method m) {
         List<Object[]> result = new LinkedList<>();
         if (m.getName().endsWith("Exception")) {
-           result.add(new Object[] { false, false, true, true, true });
-           result.add(new Object[] { true, true, false, false ,false});
+           result.add(new Object[] { true, false, false, false ,false});
         }
         else {
-           result.add(new Object[] { true, true, true, false, false });
-           result.add(new Object[] { true, true, false, true, false });
-           result.add(new Object[] { true, true, false, false, true });
-           result.add(new Object[] { true, false,false, true, false });
-           result.add(new Object[] { false, true, true, false, false });
-
+           result.add(new Object[] { true, false, true, false, false });
+           result.add(new Object[] { true, false, false, true, false });
+           result.add(new Object[] { true, false, false, false, true });
+           result.add(new Object[] { true, false, false, true, false });
         }
         return result.iterator();
     }


### PR DESCRIPTION
This allow us to simplify our R installation in Travis.  

R tests now only test Rscript executor
Using standard ubuntu R in travis instead of the more up to date one
Removing installation of R packages as part of gradle and travis builds
Updating readme