### PR TITLE
Variants interface, two implementations, and a test

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/SkeletonVariant.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/SkeletonVariant.java
@@ -1,0 +1,38 @@
+package org.broadinstitute.hellbender.utils.variant;
+
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+
+import java.io.Serializable;
+
+/**
+ * SkeletonVariant is a minimal implementation of the Variant interface.
+ */
+public class SkeletonVariant implements Variant, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    final private SimpleInterval interval;
+    final private boolean snp;
+    final private boolean indel;
+
+    public SkeletonVariant(SimpleInterval interval, boolean isSNP, boolean isIndel) {
+        this.interval = interval;
+        this.snp = isSNP;
+        this.indel = isIndel;
+    }
+
+    @Override
+    public String getContig() { return interval.getContig(); }
+    @Override
+    public int getStart() { return interval.getStart(); }
+    @Override
+    public int getEnd() { return interval.getEnd(); }
+    @Override
+    public boolean isSnp() { return snp; }
+    @Override
+    public boolean isIndel() { return indel; }
+    @Override
+    public String toString() {
+        return String.format("SkeletonVariant -- interval(%s:%d-%d), snp(%b), indel(%b)",
+                interval.getContig(), interval.getStart(), interval.getEnd(), snp, indel);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/Variant.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/Variant.java
@@ -1,0 +1,14 @@
+package org.broadinstitute.hellbender.utils.variant;
+
+import htsjdk.samtools.util.Locatable;
+
+/**
+ * Variant is (currently) a minimal variant interface needed by the Hellbender pipeline.
+ * This will be expanded as more methods are needed.
+ * NOTE: getStart() and getEnd() are 1-base inclusive (which matches the current GATK tools).
+ * This does not match the GA4GH spec.
+ */
+public interface Variant extends Locatable {
+    boolean isSnp();
+    boolean isIndel();
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapter.java
@@ -1,0 +1,32 @@
+package org.broadinstitute.hellbender.utils.variant;
+
+import htsjdk.variant.variantcontext.VariantContext;
+
+import java.io.Serializable;
+
+/**
+ * VariantContextVariantAdapter wraps the existing htsjdk VariantContext class so it can be
+ * used with the Variant API.
+ */
+public class VariantContextVariantAdapter implements Variant, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    final private VariantContext variantContext;
+
+    public VariantContextVariantAdapter(VariantContext vc) { this.variantContext = vc; }
+    @Override
+    public String getContig() { return variantContext.getContig(); }
+    @Override
+    public int getStart() { return variantContext.getStart(); }
+    @Override
+    public int getEnd() { return variantContext.getEnd(); }
+    @Override
+    public boolean isSnp() { return variantContext.isSNP(); }
+    @Override
+    public boolean isIndel() { return variantContext.isIndel(); }
+    @Override
+    public String toString() {
+        return String.format("VariantContextVariantAdapter -- interval(%s:%d-%d), snp(%b), indel(%b)",
+                getContig(), getStart(), getEnd(), isSnp(), isIndel());
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/VariantUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/VariantUtils.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.hellbender.utils.variant;
+
+/**
+ * VariantUtils contains utility methods for the Variant interface.
+ **/
+public class VariantUtils {
+    static public boolean variantsAreEqual(Variant v1, Variant v2) {
+        if (v1.getStart() != v2.getStart()) {
+            return false;
+        }
+        if (v1.getEnd() != v2.getEnd()) {
+            return false;
+        }
+        if (v1.getContig() == null || v2.getContig() == null) {
+            return false;
+        }
+        if (!v1.getContig().equals(v2.getContig())) {
+            return false;
+        }
+        if (v1.isSnp() != v2.isSnp()) {
+            return false;
+        }
+        return v1.isIndel() == v2.isIndel();
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapterTest.java
@@ -1,0 +1,76 @@
+package org.broadinstitute.hellbender.utils.variant;
+
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFCodec;
+import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.*;
+
+public class VariantContextVariantAdapterTest extends BaseTest {
+    private static final String FEATURE_DATA_SOURCE_TEST_DIRECTORY = publicTestDir + "org/broadinstitute/hellbender/engine/";
+    private static final File QUERY_TEST_VCF = new File(FEATURE_DATA_SOURCE_TEST_DIRECTORY + "feature_data_source_test.vcf");
+
+    @Test(dataProvider = "VariantDataProvider")
+    public void testVariantAdapter(final List<Variant> expectedVariantList) {
+        // The test suite for reading in VCF files is FeatureDataSourceUnitTest.
+        try (FeatureDataSource<VariantContext> featureSource = new FeatureDataSource<>(QUERY_TEST_VCF, new VCFCodec())) {
+            List<Variant> variantList = new ArrayList<>();
+            for (VariantContext feature : featureSource) {
+                VariantContextVariantAdapter va = new VariantContextVariantAdapter(feature);
+                variantList.add(va);
+            }
+            // Now, test to see that every variant is in in the expected set.
+            Assert.assertEquals(variantList.size(), expectedVariantList.size());
+            for (Variant v : variantList) {
+                boolean matchFound = false;
+                for (Variant vv : expectedVariantList) {
+                    if (VariantUtils.variantsAreEqual(v, vv)) {
+                        matchFound = true;
+                    }
+                }
+                Assert.assertTrue(matchFound, v.toString());
+            }
+        }
+    }
+
+    @DataProvider(name = "VariantDataProvider")
+    public Object[][] getVariantData() {
+        List<Variant> variantSet = new ArrayList<>();
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 100, 100), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 199, 200), false, true));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 200, 200), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 203, 206), false, true));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 280, 280), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 284, 286), false, true));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 285, 285), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 286, 286), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 999, 999), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 1000, 1000), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 1000, 1003), false, true));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 1076, 1076), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 1150, 1150), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("1", 1176, 1176), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("2", 200, 200), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("2", 525, 525), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("2", 548, 550), false, true));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("2", 640, 640), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("2", 700, 700), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("3", 1, 1), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("3", 300, 300), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("3", 300, 303), false, true));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("3", 400, 400), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("4", 600, 600), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("4", 775, 775), true, false));
+        variantSet.add(new SkeletonVariant(new SimpleInterval("4", 776, 779), false, true));
+        return new Object[][]{
+                { variantSet }
+        };
+    }
+
+}


### PR DESCRIPTION
We need a interface for variants that can be backed by the Google variant as well as VariantContext (from htsjdk). At first, we only need interval and isSNP/isIndel, so that's the interface right now. This shouldn't impact clients much as the interface interface grows because it will initially only be filled by Hellbender code. 