### PR TITLE
Dataflow BaseRecalibrator, local only

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/dev/pipelines/bqsr/BQSR_Dataflow.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/pipelines/bqsr/BQSR_Dataflow.java
@@ -1,0 +1,275 @@
+package org.broadinstitute.hellbender.dev.pipelines.bqsr;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.cloud.dataflow.sdk.coders.KvCoder;
+import com.google.cloud.dataflow.sdk.coders.SerializableCoder;
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.transforms.Combine;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.transforms.join.CoGbkResult;
+import com.google.cloud.dataflow.sdk.transforms.join.CoGroupByKey;
+import com.google.cloud.dataflow.sdk.transforms.join.KeyedPCollectionTuple;
+import com.google.cloud.dataflow.sdk.util.GcsUtil;
+import com.google.cloud.dataflow.sdk.util.gcsfs.GcsPath;
+import com.google.cloud.dataflow.sdk.values.*;
+import com.google.cloud.genomics.dataflow.coders.GenericJsonCoder;
+import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Iterables;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMTextHeaderCodec;
+import htsjdk.samtools.util.Locatable;
+import htsjdk.samtools.util.StringLineReader;
+import org.broadinstitute.hellbender.dev.tools.walkers.bqsr.BaseRecalibrationArgumentCollection;
+import org.broadinstitute.hellbender.tools.recalibration.RecalibrationTables;
+import org.broadinstitute.hellbender.tools.walkers.bqsr.RecalibrationEngine;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
+import org.broadinstitute.hellbender.utils.reference.ReferenceUtils;
+
+import java.io.*;
+import java.nio.channels.Channels;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Base Quality Score Recalibration, phase 1
+ * This contains the Dataflow-specific bits.
+ */
+public final class BQSR_Dataflow implements Serializable {
+
+  // how many bases until we move on to the next shard
+  static final int BLOCKSIZE = 1000000;
+  public static final TupleTag<Read> readTag = new TupleTag<>();
+  public static final TupleTag<SimpleInterval> intervalTag = new TupleTag<>();
+  public static final TupleTag<RecalibrationTables> tablesTag = new TupleTag<>();
+
+  /**
+   * Get a single RecalibrationTables object that represents the output of phase 1 of BQSR.
+   * <p>
+   * The reference file (*.fasta) must also have a .dict and a .fasta.fai next to it.
+   */
+  public static PCollection<RecalibrationTables> GetRecalibrationTables(SAMFileHeader readsHeader, PCollection<Read> reads, String referenceFileName, BaseRecalibrationArgumentCollection toolArgs, PCollection<SimpleInterval> placesToIgnore) {
+    PCollection<RecalibrationTables> stats = computeBlockStatistics(readsHeader, referenceFileName, toolArgs, groupByBlock(reads, placesToIgnore));
+    PCollection<RecalibrationTables> oneStat = aggregateStatistics(stats);
+    return oneStat;
+  }
+
+  /**
+   * Throws an exception if any of the files is missing.
+   * (offlineauth can be null if the files are local)
+   */
+  public static void ensureReferenceIsReadable(final PipelineOptions popts, String filename) throws IOException, GeneralSecurityException {
+    for (String fn : getRelatedFiles(filename)) {
+      if (BucketUtils.isCloudStorageUrl(fn)) {
+        // make sure we can access those files on Google Cloud Storage.
+        GcsPath path = GcsPath.fromUri(fn);
+        // this will throw if we can't get to the file.
+        new GcsUtil.GcsUtilFactory().create(popts).fileSize(path);
+      } else {
+        // make sure we can access those files on the local filesystem.
+        if (!new File(fn).canRead()) {
+          if (!new File(fn).exists()) {
+            throw new IOException("File not found: " + fn);
+          } else {
+            throw new IOException("File present, but not readable: " + fn);
+          }
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------------
+  // non-public methods
+
+  private static String[] getRelatedFiles(String fastaFilename) {
+    return new String[] { fastaFilename, ReferenceUtils.getFastaDictionaryFileName(fastaFilename), ReferenceUtils.getFastaIndexFileName(fastaFilename) };
+  }
+
+  // a key to group intervals by (aka sharding)
+  private static String posKey(final Locatable loc) {
+    return loc.getContig() + (loc.getStart() / BLOCKSIZE);
+  }
+
+  // a key to group intervals by (aka sharding)
+  private static String posKey(final Read r) {
+    // Reads are 0-based, SimpleIntervals are 1-based
+    int start = r.getAlignment().getPosition().getPosition().intValue() + 1;
+    return posKey(new SimpleInterval(r.getAlignment().getPosition().getReferenceName(),
+            start,
+            start));
+  }
+
+  // the shard that the last base of the interval lands in,
+  // if different from the first base's. Null otherwise.
+  private static String posKeyEnd(final Locatable loc) {
+    if (loc.getStart()/BLOCKSIZE == (loc.getEnd())/BLOCKSIZE) return null;
+    return loc.getContig() + (loc.getEnd() / BLOCKSIZE);
+  }
+
+  /**
+   * returns union(reads,placestoIgnore).groupBy(x->posKey(x))
+   */
+  private static PCollection<KV<String, CoGbkResult>> groupByBlock(final PCollection<Read> reads, final PCollection<SimpleInterval> placesToIgnore) {
+    // shard reads
+    PCollection<KV<String, Read>> shardedReads = reads.apply(ParDo
+        .named("shard reads")
+        .of(
+            new DoFn<Read, KV<String, Read>>() {
+              @Override
+              public void processElement(ProcessContext c) {
+                Read r = c.element();
+                c.output(KV.of(posKey(r), r));
+              }
+
+            }))
+        // Dataflow boilerplate
+        .setCoder(KvCoder.of(StringUtf8Coder.of(), GenericJsonCoder.of(Read.class)));
+    // send ignores to every shard that overlaps with them (so, possibly more than one).
+    // (for now we assume they can't span more than two)
+    PCollection<KV<String, SimpleInterval>> shardedIgnore = placesToIgnore.apply(ParDo
+        .named("shard known intervals")
+        .of(
+            new DoFn<SimpleInterval, KV<String, SimpleInterval>>() {
+              @Override
+              public void processElement(ProcessContext c) {
+                SimpleInterval i = c.element();
+                String firstPos = posKey(i);
+                c.output(KV.of(firstPos, i));
+                String secondPos = posKeyEnd(i);
+                if (null!=secondPos) {
+                  c.output(KV.of(secondPos, i));
+                }
+              }
+            }))
+        // Dataflow boilerplate
+        .setCoder(KvCoder.of(StringUtf8Coder.of(), SerializableCoder.of(SimpleInterval.class)));
+
+    return KeyedPCollectionTuple.of(readTag, shardedReads)
+        .and(intervalTag, shardedIgnore)
+        .apply(CoGroupByKey.<String>create());
+  }
+
+  /**
+   * For each input block, compute its statistics.
+   * <p>
+   * At a high level, just delegate to the CalibrationTablesBuilder.
+   * More specifically, this downloads the reference files, sorts the known intervals for each shard,
+   * and then delegates to CalibrationTablesBuilder. Then it outputs a log message about timings.
+   */
+  private static PCollection<RecalibrationTables> computeBlockStatistics(final SAMFileHeader readsHeader, String referenceFileName, final BaseRecalibrationArgumentCollection toolArgs, final PCollection<KV<String, CoGbkResult>> readsAndIgnores) {
+    PCollection<RecalibrationTables> ret = readsAndIgnores.apply(ParDo
+            .named("computeBlockStatistics")
+            .of(new DoFn<KV<String, CoGbkResult>, RecalibrationTables>() {
+              CalibrationTablesBuilder ct;
+              Stopwatch timer;
+              int nBlocks = 0;
+              int nReads = 0;
+
+              @Override
+              public void startBundle(DoFn.Context c) throws Exception {
+                timer = Stopwatch.createStarted();
+                SAMFileHeader header = readsHeader;
+
+                String localReference = referenceFileName;
+                if (BucketUtils.isCloudStorageUrl(referenceFileName)) {
+                  // the reference is on GCS, download all 3 files locally first.
+                  System.out.println("Downloading reference files");
+                  boolean first = true;
+                  for (String fname : getRelatedFiles(referenceFileName)) {
+                    String localName = "reference";
+                    int slash = fname.lastIndexOf('/');
+                    if (slash >= 0) {
+                      localName = fname.substring(slash + 1);
+                    }
+                    // download reference if necessary
+                    if (new File(localName).exists()) {
+                      if (first) localReference = localName;
+                    } else {
+                      try (
+                              InputStream in = Channels.newInputStream(new GcsUtil.GcsUtilFactory().create(c.getPipelineOptions()).open(GcsPath.fromUri(fname)));
+                              FileOutputStream fout = new FileOutputStream(localName)) {
+                        final byte[] buf = new byte[1024 * 1024];
+                        int count;
+                        while ((count = in.read(buf)) > 0) {
+                          fout.write(buf, 0, count);
+                        }
+                      }
+                      if (first) localReference = localName;
+                    }
+                    first = false;
+                  }
+                  System.out.printf("Done downloading reference files (%s ms)\n", timer.elapsed(TimeUnit.MILLISECONDS));
+                }
+
+                ct = new CalibrationTablesBuilder(header, localReference, toolArgs);
+              }
+
+              @Override
+              public void processElement(ProcessContext c) throws Exception {
+                nBlocks++;
+                // get the reads
+                KV<String, CoGbkResult> e = c.element();
+                List<Read> reads = new ArrayList<Read>();
+                Iterable<Read> readsIter = e.getValue().getAll(BQSR_Dataflow.readTag);
+                Iterables.addAll(reads, readsIter);
+                nReads += reads.size();
+                // get the skip intervals
+                List<SimpleInterval> skipIntervals = new ArrayList<SimpleInterval>();
+                Iterables.addAll(skipIntervals, e.getValue().getAll(BQSR_Dataflow.intervalTag));
+                Collections.sort(skipIntervals, new Comparator<SimpleInterval>() {
+                  @Override
+                  public int compare(SimpleInterval o1, SimpleInterval o2) {
+                    return ComparisonChain.start()
+                            .compare(o1.getContig(), o2.getContig())
+                            .compare(o1.getStart(), o2.getStart())
+                            .result();
+                  }
+                });
+                // update our statistics
+                ct.add(reads, skipIntervals);
+              }
+
+              @Override
+              public void finishBundle(DoFn.Context c) throws Exception {
+                ct.done();
+                c.output(ct.getRecalibrationTables());
+                System.out.println("Finishing a block statistics bundle. It took " + timer.elapsed(TimeUnit.MILLISECONDS) + " ms to process " + nBlocks + " blocks, " + nReads + " reads.");
+            timer = null;
+          }
+        }));
+
+    ret.setCoder(SerializableCoder.of(RecalibrationTables.class));
+    return ret;
+  }
+
+  /**
+   * Merge the statistics from each block. The resulting "collection" contains a single element, with the answer.
+   */
+  private static PCollection<RecalibrationTables> aggregateStatistics(final PCollection<RecalibrationTables> tables) {
+    return tables
+        // aggregate
+        .apply(Combine.globally(new RecalibrationTablesMerger()))
+        // call finalize on the result
+        .apply(ParDo
+            .named("finalizeRecalTables")
+            .of(new DoFn<RecalibrationTables, RecalibrationTables>() {
+              @Override
+              public void processElement(ProcessContext c) throws Exception {
+                RecalibrationTables tables = c.element();
+                RecalibrationEngine.finalizeRecalibrationTables(tables);
+                c.output(tables);
+              }
+            }));
+  }
+
+}
+
+

--- a/src/main/java/org/broadinstitute/hellbender/dev/pipelines/bqsr/RecalibrationTablesMerger.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/pipelines/bqsr/RecalibrationTablesMerger.java
@@ -66,5 +66,4 @@ public final class RecalibrationTablesMerger extends Combine.CombineFn<Recalibra
 
     }
 
-
 }

--- a/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/BaseRecalibrationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/BaseRecalibrationArgumentCollection.java
@@ -1,0 +1,79 @@
+package org.broadinstitute.hellbender.dev.tools.walkers.bqsr;
+
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.*;
+import org.broadinstitute.hellbender.tools.recalibration.RecalibrationArgumentCollection;
+import org.broadinstitute.hellbender.utils.QualityUtils;
+import org.broadinstitute.hellbender.utils.baq.BAQ;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+
+/**
+ * All the command line arguments for BQSR and its covariates.
+ */
+public final class BaseRecalibrationArgumentCollection implements Serializable, ArgumentCollection {
+
+    public BaseRecalibrationArgumentCollection() {}
+
+    /**
+     * (Almost) all the command line arguments for BQSR and its covariates.
+     */
+    @ArgumentCollection(doc="all the command line arguments for BQSR and its covariates")
+    protected final RecalibrationArgumentCollection RAC = new RecalibrationArgumentCollection();
+
+    @ArgumentCollection
+    public final ReadInputArgumentCollection readArguments = new OptionalReadInputArgumentCollection();
+
+    @ArgumentCollection
+    public final ReferenceInputArgumentCollection referenceArguments = new OptionalReferenceInputArgumentCollection();
+
+
+    @Argument(fullName = "bqsrBAQGapOpenPenalty", shortName = "bqsrBAQGOP", doc = "BQSR BAQ gap open penalty (Phred Scaled).  Default value is 40.  30 is perhaps better for whole genome call sets", optional = true)
+    public double BAQGOP = BAQ.DEFAULT_GOP;
+
+    /**
+     * This flag tells GATK not to modify quality scores less than this value. Instead they will be written out unmodified in the recalibrated BAM file.
+     * In general it's unsafe to change qualities scores below < 6, since base callers use these values to indicate random or bad bases.
+     * For example, Illumina writes Q2 bases when the machine has really gone wrong. This would be fine in and of itself,
+     * but when you select a subset of these reads based on their ability to align to the reference and their dinucleotide effect,
+     * your Q2 bin can be elevated to Q8 or Q10, leading to issues downstream.
+     */
+    @Argument(fullName = "preserve_qscores_less_than", shortName = "preserveQ", doc = "Don't recalibrate bases with quality scores less than this threshold (with -BQSR)", optional = true)
+    public int PRESERVE_QSCORES_LESS_THAN = QualityUtils.MIN_USABLE_Q_SCORE;
+
+
+    // --------------------------------------------------------------------------------------------------------------
+    //
+    // quality encoding checking arguments
+    //
+    // --------------------------------------------------------------------------------------------------------------
+
+    /**
+     * This flag tells GATK to use the original base qualities (that were in the data before BQSR/recalibration) which
+     * are stored in the OQ tag, if they are present, rather than use the post-recalibration quality scores. If no OQ
+     * tag is present for a read, the standard qual score will be used.
+     */
+    @Argument(fullName = "useOriginalQualities", shortName = "OQ", doc = "Use the base quality scores from the OQ tag", optional = true)
+    public Boolean useOriginalBaseQualities = false;
+
+    /**
+     * If reads are missing some or all base quality scores, this value will be used for all base quality scores.
+     * By default this is set to -1 to disable default base quality assignment.
+     */
+    //TODO: minValue = 0, maxValue = Byte.MAX_VALUE)
+    @Argument(fullName = "defaultBaseQualities", shortName = "DBQ", doc = "Assign a default base quality", optional = true)
+    public byte defaultBaseQualities = -1;
+
+
+    @Override
+    public String doc() {
+        return "First pass of the Base Quality Score Recalibration (BQSR) -- Generates recalibration table based on various user-specified covariates (such as read group, reported quality score, machine cycle, and nucleotide context).";
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return BaseRecalibrationArgumentCollection.class;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/DF_BaseRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/DF_BaseRecalibrator.java
@@ -1,0 +1,300 @@
+package org.broadinstitute.hellbender.dev.tools.walkers.bqsr;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.coders.CoderRegistry;
+import com.google.cloud.dataflow.sdk.coders.SerializableCoder;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.util.GcsUtil;
+import com.google.cloud.dataflow.sdk.util.gcsfs.GcsPath;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.genomics.dataflow.coders.GenericJsonCoder;
+import com.google.cloud.genomics.dataflow.readers.bam.ReadConverter;
+import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
+import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
+import htsjdk.samtools.SAMException;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamInputResource;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
+import htsjdk.tribble.Feature;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFCodec;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
+import org.broadinstitute.hellbender.dev.pipelines.bqsr.BQSR_Dataflow;
+import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.engine.FeatureInput;
+import org.broadinstitute.hellbender.engine.dataflow.ReadsSource;
+import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.tools.recalibration.RecalibrationTables;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
+
+import java.io.*;
+import java.nio.channels.Channels;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * First pass of the base quality score recalibration -- Generates recalibration table based on various covariates
+ * (such as read group, reported quality score, machine cycle, and nucleotide context).
+ * <p>
+ * Dataflow version of BaseRecalibrator.
+ */
+@CommandLineProgramProperties(
+        usage = "First pass of the Base Quality Score Recalibration (BQSR) -- Generates recalibration table based on various user-specified covariates (such as read group, reported quality score, machine cycle, and nucleotide context).",
+        usageShort = "Generates recalibration table",
+        programGroup = ReadProgramGroup.class
+)
+public class DF_BaseRecalibrator extends CommandLineProgram {
+
+    public static final String APP_NAME = "Hellbender";
+
+    // ------------------------------------------
+    // Command-line options
+
+    /**
+     * all the command line arguments for BQSR and its covariates
+     */
+    @ArgumentCollection(doc = "all the command line arguments for BQSR and its covariates")
+    private transient final BaseRecalibrationArgumentCollection BRAC = new BaseRecalibrationArgumentCollection();
+
+    /**
+     * Path to the input (BAM file). Eventually can be local or on GCS.
+     */
+    private String beforePath = null;
+
+
+    /**
+     * Path to the reference (SAM file). Eventually can be filesystem or gs://
+     */
+    private String referencePath = null;
+
+    /**
+     * Path to save the output to. Must be local for now.
+     */
+    @Argument(doc = "Path to save the output to. Must be filesystem.", optional = false)
+    protected String outputTablesPath = "df-recaltables.sj";
+
+    // ------------------------------------------
+    // Dataflow-specific options
+
+    @Argument(doc = "path to client-secrets.json", optional = false)
+    protected String secretsFile;
+
+    // not actually optional if you ask for remote exec
+    @Argument(doc = "Google Cloud project name", optional = true)
+    protected String project;
+
+    // not actually optional if you ask for remote exec
+    @Argument(doc = "Google Cloud Storage path for intermediate files", optional = true)
+    protected String stagingLocation;
+
+    @Argument(doc = "Number of Dataflow workers", optional = true)
+    protected int numWorkers = 0;
+
+    // ------------------------------------------
+
+    // the inputs to BQSR
+    private PCollection<Read> reads;
+    private PCollection<SimpleInterval> skipIntervals;
+    private SAMFileHeader header;
+
+    /**
+     * Do the work after command line has been parsed. RuntimeException may be
+     * thrown by this method, and are reported appropriately.
+     *
+     * @return the return value or null is there is none.
+     */
+    @Override
+    protected Object doWork() {
+
+        try {
+
+
+            // the parsing system helpfully provides a file, unaware that we might not mean a file on this machine.
+            referencePath = BRAC.referenceArguments.getReferenceFile().getPath();
+            // TODO: support more than one input.
+            beforePath = BRAC.readArguments.getReadFiles().get(0).getPath();
+
+            GenomicsOptions popts = makeDirectPipelineOptions(secretsFile);
+
+            Pipeline pipeline = Pipeline.create(popts);
+            CoderRegistry coderRegistry = pipeline.getCoderRegistry();
+            coderRegistry.registerCoder(Read.class, GenericJsonCoder.of(Read.class));
+            coderRegistry.registerCoder(SimpleInterval.class, SerializableCoder.of(SimpleInterval.class));
+
+            // 1. prepare inputs/outputs, check arguments
+            ingestLocalInputs(pipeline);
+            BQSR_Dataflow.ensureReferenceIsReadable(popts, referencePath);
+            BaseRecalibratorUprooted baseRecalibratorUprooted = BaseRecalibratorUprooted.fromArgs(header, BRAC);
+            baseRecalibratorUprooted.checkClientArguments();
+
+            // 2. set up computation
+            PCollection<RecalibrationTables> aggregated =
+                    BQSR_Dataflow.GetRecalibrationTables(header, reads, referencePath, BRAC, skipIntervals);
+
+            if (BucketUtils.isCloudStorageUrl(outputTablesPath)) {
+                saveSingleResultToGCS(aggregated, outputTablesPath);
+            } else {
+                // saving to a local path; this only makes sense if we're running locally.
+                saveRecalibrationTables(aggregated, outputTablesPath);
+            }
+
+            // 3. Compute
+            System.out.println("Computing!");
+            try {
+                pipeline.run();
+            } catch (RuntimeException rx) {
+                // Pipeline.run() helpfully wraps the underlying exception into a RuntimeException so that the stack trace shows pipeline.run at the top.
+                // However, the environment here expects to see the correct exception type. So we instead throw the underlying exception, storing
+                // the pipeline.run stack as "suppressed".
+                Throwable t = rx.getCause();
+                if (t instanceof Exception) {
+                    Exception x = (Exception) t;
+                    x.addSuppressed(rx);
+                    throw x;
+                }
+                throw rx;
+            }
+
+            // 5. Get the table back and output it in text form to RAC.RECAL_TABLE.
+            final InputStream tblIn;
+            if (BucketUtils.isCloudStorageUrl(outputTablesPath)) {
+                tblIn = Channels.newInputStream(new GcsUtil.GcsUtilFactory().create(popts).open(GcsPath.fromUri(outputTablesPath)));
+            } else {
+                tblIn = new FileInputStream(outputTablesPath);
+            }
+            ObjectInputStream oin = new ObjectInputStream(tblIn);
+            Object o = oin.readObject();
+            RecalibrationTables rt = (RecalibrationTables) o;
+            baseRecalibratorUprooted.onTraversalStart(null);
+            baseRecalibratorUprooted.saveReport(rt, baseRecalibratorUprooted.getRequestedCovariates());
+
+
+        } catch (RuntimeException rx) {
+            throw rx;
+        } catch (Exception x) {
+            // can't change the signature.
+            throw new RuntimeException(x);
+        }
+
+        return null;
+    }
+
+    // local files on the client's disk -> PCollections.
+    private void ingestLocalInputs(final Pipeline pipeline) throws IOException {
+        if (BucketUtils.isCloudStorageUrl(beforePath)) {
+            // set up ingestion on the cloud
+            // but read the header locally
+            GcsPath path = GcsPath.fromUri(beforePath);
+            InputStream inputstream = Channels.newInputStream(new GcsUtil.GcsUtilFactory().create(pipeline.getOptions())
+                    .open(path));
+            SamReader reader = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT).open(SamInputResource.of(inputstream));
+            header = reader.getFileHeader();
+            // this won't work!
+            // TODO(jpmartin): figure this out.
+            reads = new ReadsSource(beforePath, pipeline).getReadPCollection(null);
+        } else {
+            // ingestion from local file
+            SamReader reader = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT).open(new File(beforePath));
+            header = reader.getFileHeader();
+            List<Read> readLst = new ArrayList<>();
+            ReadFilter readFilter = BaseRecalibratorUprooted.readFilter();
+            for (SAMRecord sr : reader) {
+                if (!readFilter.test(sr)) continue;
+                try {
+                    Read e = ReadConverter.makeRead(sr);
+                    readLst.add(e);
+                } catch (SAMException x) {
+                    System.out.println("Skipping read " + sr.getReadName() + " because we can't convert it.");
+                } catch (NullPointerException y) {
+                    System.out.println("Skipping read " + sr.getReadName() + " because we can't convert it. (null?)");
+                }
+            }
+            reads = pipeline.apply(Create.of(readLst).withName("input ingest"));
+        }
+
+        List<SimpleInterval> knownSitesLst = new ArrayList<>();
+        for (FeatureInput<Feature> vcfSource : BRAC.RAC.knownSites) {
+            FeatureDataSource<VariantContext> source = new FeatureDataSource<>(vcfSource.getFeatureFile(), new VCFCodec(), "KnownIntervals");
+            for (VariantContext foo : source) {
+                int start = foo.getStart();
+                int end = foo.getEnd();
+                String contig = foo.getContig();
+                knownSitesLst.add(new SimpleInterval(contig, start, end));
+            }
+        }
+        skipIntervals = pipeline.apply(Create.of(knownSitesLst).withName("known intervals ingest"))
+                .setCoder(SerializableCoder.of(SimpleInterval.class)); // Dataflow boilerplate
+    }
+
+    private static void saveRecalibrationTables(final PCollection<RecalibrationTables> recalibrationTables, String fname) {
+        recalibrationTables.apply(ParDo
+                .named("saveRecalibrationTables")
+                .of(new DoFn<RecalibrationTables, Void>() {
+                    @Override
+                    public void processElement(ProcessContext c) throws Exception {
+                        RecalibrationTables r = c.element();
+                        System.out.println("Saving RecalibrationTables to " + fname);
+                        ObjectOutputStream os = new ObjectOutputStream(new FileOutputStream(fname));
+                        os.writeObject(r);
+                        os.close();
+                    }
+                }));
+    }
+
+    private static <T> void saveSingleResult(final PCollection<T> collection, String fname) {
+        collection.apply(ParDo
+                .named("save to " + fname)
+                .of(new DoFn<T, Void>() {
+                    @Override
+                    public void processElement(ProcessContext c) throws IOException {
+                        T obj = c.element();
+                        try (ObjectOutputStream os = new ObjectOutputStream(new FileOutputStream(fname))) {
+                            os.writeObject(obj);
+                        }
+                    }
+                }));
+    }
+
+
+    // a "gcsPath" starts with "gs://"
+    private static <T> void saveSingleResultToGCS(final PCollection<T> collection, String gcsDestPath) {
+        collection.apply(ParDo.named("save to " + gcsDestPath)
+                .of(new DoFn<T, Void>() {
+                    @Override
+                    public void processElement(ProcessContext c) throws IOException, GeneralSecurityException {
+                        GcsPath dest = GcsPath.fromUri(gcsDestPath);
+                        GcsUtil gcsUtil = new GcsUtil.GcsUtilFactory().create(c.getPipelineOptions());
+                        try (ObjectOutputStream out = new ObjectOutputStream(Channels.newOutputStream(gcsUtil.create(dest, "application/octet-stream")))) {
+                            out.writeObject(c.element());
+                        }
+                    }
+                }));
+    }
+
+    // Next you probably want to call: Pipeline pipeline = Pipeline.create(popts);
+    private static GenomicsOptions makeDirectPipelineOptions(String secretsFilePath) throws Exception {
+        PipelineOptionsFactory.register(GenomicsOptions.class);
+        GenomicsOptions popts = PipelineOptionsFactory.create().as(GenomicsDatasetOptions.class);
+        popts.setGenomicsSecretsFile(secretsFilePath);
+        popts.setAppName(APP_NAME);
+        popts.setRunner(DirectPipelineRunner.class);
+        return popts;
+    }
+
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalDatum.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalDatum.java
@@ -5,11 +5,13 @@ import org.apache.commons.math3.analysis.function.Gaussian;
 import org.broadinstitute.hellbender.utils.MathUtils;
 import org.broadinstitute.hellbender.utils.QualityUtils;
 
+import java.io.Serializable;
+
 /**
  * An individual piece of recalibration data. Each bin counts up the number of observations and the number
  * of reference mismatches seen for that combination of covariates.
  */
-public final class RecalDatum {
+public final class RecalDatum implements Serializable {
     public final static byte MAX_RECALIBRATED_Q_SCORE = SAMUtils.MAX_PHRED_SCORE;
     private static final double UNINITIALIZED = -1.0;
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalibrationArgumentCollection.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalibrationArgumentCollection.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.utils.report.GATKReportTable;
 
 import java.io.File;
 import java.io.PrintStream;
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -19,7 +20,7 @@ import java.util.*;
  * This set of arguments will also be passed to the constructor of every Covariate when it is instantiated.
  */
 
-public final class RecalibrationArgumentCollection implements ArgumentCollectionDefinition {
+public final class RecalibrationArgumentCollection implements Serializable, ArgumentCollectionDefinition {
 
     /**
      * This algorithm treats every reference mismatch as an indication of error. However, real genetic variation is expected to mismatch the reference,
@@ -29,7 +30,7 @@ public final class RecalibrationArgumentCollection implements ArgumentCollection
      * reflected those sites skipped by the -XL argument.
      */
     @Argument(fullName = "knownSites", shortName = "knownSites", doc = "One or more databases of known polymorphic sites used to exclude regions around known polymorphisms from analysis.", optional = true)
-    public List<FeatureInput<Feature>> knownSites;
+    public transient List<FeatureInput<Feature>> knownSites;
 
     /**
      * After the header, data records occur one per line until the end of the file. The first several items on a line are the
@@ -40,7 +41,7 @@ public final class RecalibrationArgumentCollection implements ArgumentCollection
     @Gather(BQSRGatherer.class)
     @Argument(fullName= "RECAL_TABLE_FILE", shortName="RECAL_TABLE_FILE", doc = "The output recalibration table file to create", optional = false)
     public File RECAL_TABLE_FILE = null;
-    public PrintStream RECAL_TABLE;
+    public transient PrintStream RECAL_TABLE;
 
     //We always use the same covariates. The field is retained for comparibility with GATK3 reports.
     public static final boolean DO_NOT_USE_STANDARD_COVARIATES = false;

--- a/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalibrationTables.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/recalibration/RecalibrationTables.java
@@ -5,12 +5,13 @@ import org.broadinstitute.hellbender.tools.recalibration.covariates.StandardCova
 import org.broadinstitute.hellbender.utils.collections.NestedIntegerArray;
 import org.broadinstitute.hellbender.utils.recalibration.EventType;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
  * Utility class to facilitate base quality score recalibration.
  */
-public final class RecalibrationTables implements Iterable<NestedIntegerArray<RecalDatum>>{
+public final class RecalibrationTables implements Serializable, Iterable<NestedIntegerArray<RecalDatum>> {
     private final int qualDimension;
     private final int eventDimension = EventType.values().length;
     private final int numReadGroups;

--- a/src/main/java/org/broadinstitute/hellbender/tools/recalibration/covariates/ContextCovariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/recalibration/covariates/ContextCovariate.java
@@ -16,7 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public final class ContextCovariate implements Covariate {
-    private final Logger logger = LogManager.getLogger(ContextCovariate.class);
+    private final static Logger logger = LogManager.getLogger(ContextCovariate.class);
 
     private final int mismatchesContextSize;
     private final int indelsContextSize;

--- a/src/main/java/org/broadinstitute/hellbender/tools/recalibration/covariates/Covariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/recalibration/covariates/Covariate.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMRecord;
 import org.broadinstitute.hellbender.tools.recalibration.ReadCovariates;
 import org.broadinstitute.hellbender.tools.recalibration.RecalibrationArgumentCollection;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,7 +15,7 @@ import java.util.List;
  *
  * Covariates are immutable objects after construction. All state setting and parameterization must happen during the construction call.
  */
-public interface Covariate {
+public interface Covariate extends Serializable {
 
     /**
      * Calculates covariate values for all positions in the read.

--- a/src/main/java/org/broadinstitute/hellbender/tools/recalibration/covariates/CycleCovariate.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/recalibration/covariates/CycleCovariate.java
@@ -7,6 +7,8 @@ import org.broadinstitute.hellbender.tools.recalibration.RecalibrationArgumentCo
 import org.broadinstitute.hellbender.utils.NGSPlatform;
 import org.broadinstitute.hellbender.utils.SequencerFlowClass;
 
+import java.io.Serializable;
+
 /**
  * The Cycle covariate.
  * For Solexa the cycle is simply the position in the read (counting backwards if it is a negative strand read)

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/NestedIntegerArray.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/NestedIntegerArray.java
@@ -3,11 +3,12 @@ package org.broadinstitute.hellbender.utils.collections;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public final class NestedIntegerArray<T> {
+public final class NestedIntegerArray<T extends Serializable> implements Serializable {
 
     private static Logger logger = LogManager.getLogger(NestedIntegerArray.class);
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/dataflow/DataflowUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/dataflow/DataflowUtils.java
@@ -2,12 +2,17 @@ package org.broadinstitute.hellbender.utils.dataflow;
 
 import com.google.api.services.genomics.model.Read;
 import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.runners.BlockingDataflowPipelineRunner;
+import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner;
 import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.genomics.dataflow.readers.bam.ReadConverter;
+import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
+import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import htsjdk.samtools.SAMRecord;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -93,4 +98,7 @@ public final class DataflowUtils {
             }
         }
     }
+
+
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/dev/CalibrationTablesBuilderIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/dev/CalibrationTablesBuilderIntegrationTest.java
@@ -118,14 +118,14 @@ public final class CalibrationTablesBuilderIntegrationTest extends CommandLinePr
         String outputDest = "test-table-pre.txt";
 
         // 1. Grab the needed inputs.
-        String toolArgs = String.format(params.getCommandLine(), outputDest);
+        String toolCmdLine = String.format(params.getCommandLine(), outputDest);
         SamReader reader = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT).open(new File(params.bam));
         SAMFileHeader header = reader.getFileHeader();
         List<Read> input = getReads(reader);
         List<SimpleInterval> knownSites = getKnownSites(params);
 
         // 2. Run the computation.
-        CalibrationTablesBuilder calibrationTablesBuilder = new CalibrationTablesBuilder(header, params.reference, toolArgs);
+        CalibrationTablesBuilder calibrationTablesBuilder = new CalibrationTablesBuilder(header, params.reference, toolCmdLine);
         calibrationTablesBuilder.add(input, knownSites);
         calibrationTablesBuilder.done();
         RecalibrationTables output = calibrationTablesBuilder.getRecalibrationTables();
@@ -135,7 +135,8 @@ public final class CalibrationTablesBuilderIntegrationTest extends CommandLinePr
         RecalibrationEngine.finalizeRecalibrationTables(output);
 
         // 4. Generate report.
-        BaseRecalibratorUprooted baseRecalibratorUprooted = BaseRecalibratorUprooted.fromArgs(header, toolArgs, System.out);
+        BaseRecalibratorUprooted baseRecalibratorUprooted = BaseRecalibratorUprooted.fromCommandLine(header, toolCmdLine, System.out);
+        baseRecalibratorUprooted.checkClientArguments();
         baseRecalibratorUprooted.onTraversalStart(null);
         baseRecalibratorUprooted.saveReport(output, requestedCovariates);
 
@@ -202,7 +203,7 @@ public final class CalibrationTablesBuilderIntegrationTest extends CommandLinePr
     private List<SimpleInterval> getKnownSites(BQSRTest params) {
         List<SimpleInterval> ret = new ArrayList<>();
         for (String knownSites : params.getKnownSites()) {
-            System.out.println("Reading the feature input");
+            System.out.println("Reading the known sites");
             FeatureDataSource<VariantContext> source = new FeatureDataSource<>(new File(knownSites), new VCFCodec(), "KnownIntervals");
             for (VariantContext foo : source) {
                 int start = foo.getStart();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/DF_BaseRecalibratorIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/DF_BaseRecalibratorIntegrationTest.java
@@ -1,0 +1,145 @@
+package org.broadinstitute.hellbender.tools.walkers.bqsr;
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.dev.tools.walkers.bqsr.DF_BaseRecalibrator;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.tools.ApplyBQSR;
+import org.broadinstitute.hellbender.tools.IntegrationTestSpec;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public final class DF_BaseRecalibratorIntegrationTest extends CommandLineProgramTest{
+
+    private static class BQSRTest {
+        final String reference;
+        final String bam;
+        final String knownSites;
+        final String args;
+        final String expectedFileName;
+
+        private BQSRTest(String reference, String bam, String knownSites, String args, String expectedFileName) {
+            this.reference = reference;
+            this.bam = bam;
+            this.knownSites = knownSites;
+            this.args = args;
+            this.expectedFileName = expectedFileName;
+        }
+
+        public String getCommandLine() {
+            return  " -R " + reference +
+                    " -I " + bam +
+                    " --secretsFile ../client-secrets.json" +
+                    " " + args +
+                    (knownSites.isEmpty() ? "": " -knownSites " + knownSites) +
+                    " --RECAL_TABLE_FILE %s" +
+                    " -sortAllCols";
+        }
+
+        @Override
+        public String toString() {
+            return String.format("BQSR(bam='%s', args='%s')", bam, args);
+        }
+    }
+
+    private String getResourceDir(){
+        return getTestDataDir() + "/" + "BQSR" + "/";
+    }
+
+    @DataProvider(name = "BQSRTest")
+    public Object[][] createBQSRTestData() {
+        final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+        final String b36Reference = getResourceDir() + "human_b36_both.chr1_1k.fasta";
+        final String HiSeqBam = getResourceDir() + "NA12878.chr17_69k_70k.dictFix.bam";
+        final String dbSNPb37 =  getResourceDir() + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
+        final String origQualsBam = getResourceDir() + "originalQuals.1kg.chr1.1-1K.1RG.dictFix.bam";
+        final String dbSNPb36 = getResourceDir() + "dbsnp_132.b36.excluding_sites_after_129.chr1_1k.vcf";
+
+        final String moreSites = getResourceDir() + "bqsr.fakeSitesForTesting.b37.chr17.vcf"; //for testing 2 input files
+
+        return new Object[][]{
+                {new BQSRTest(hg18Reference, HiSeqBam, dbSNPb37, "", getResourceDir() + "expected.NA12878.chr17_69k_70k.txt")},
+                {new BQSRTest(hg18Reference, HiSeqBam, dbSNPb37, "-knownSites " + moreSites, getResourceDir() + "expected.NA12878.chr17_69k_70k.2inputs.txt")},
+                {new BQSRTest(hg18Reference, HiSeqBam, dbSNPb37, "--indels_context_size 4", getResourceDir() + "expected.NA12878.chr17_69k_70k.indels_context_size4.txt")},
+                {new BQSRTest(hg18Reference, HiSeqBam, dbSNPb37, "--low_quality_tail 5", getResourceDir() + "expected.NA12878.chr17_69k_70k.low_quality_tail5.txt")},
+                {new BQSRTest(hg18Reference, HiSeqBam, dbSNPb37, "--quantizing_levels 6", getResourceDir() + "expected.NA12878.chr17_69k_70k.quantizing_levels6.txt")},
+                {new BQSRTest(hg18Reference, HiSeqBam, dbSNPb37, "--mismatches_context_size 4", getResourceDir() + "expected.NA12878.chr17_69k_70k.mismatches_context_size4.txt")},
+                {new BQSRTest(b36Reference, origQualsBam, dbSNPb36, "-OQ", getResourceDir() + "expected.originalQuals.1kg.chr1.1-1K.1RG.dictFix.OQ.txt")},
+        };
+    }
+    @Test(dataProvider = "BQSRTest")
+    public void testBQSR(BQSRTest params) throws IOException {
+        IntegrationTestSpec spec = new IntegrationTestSpec(
+                params.getCommandLine(),
+                Arrays.asList(params.expectedFileName));
+        spec.executeTest("testBQSR-" + params.args, this);
+    }
+
+    @Test(description = "This is to test https://github.com/broadinstitute/hellbender/issues/322")
+    public void testPlottingWorkflow() throws IOException {
+        final String cloudArgs = "--secretsFile ../client-secrets.json ";
+        final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
+        final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+        final String dbSNPb37 =  getResourceDir() + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
+        final String HiSeqBam = getResourceDir() + "NA12878.chr17_69k_70k.dictFix.bam";
+
+        final File actualHiSeqBam_recalibrated = createTempFile("actual.NA12878.chr17_69k_70k.dictFix.recalibrated", ".bam");
+
+        final String tablePre = createTempFile("gatk4.pre.cols", ".table").getAbsolutePath();
+        final String argPre = cloudArgs + "-R " + hg18Reference + " --knownSites " + dbSNPb37 + " -I " + HiSeqBam + " -RECAL_TABLE_FILE " + tablePre + " --sort_by_all_columns true";
+        new DF_BaseRecalibrator().instanceMain(Utils.escapeExpressions(argPre));
+
+        final String argApply = "-I " + HiSeqBam + " --bqsr_recal_file " + tablePre+ "  -O " + actualHiSeqBam_recalibrated.getAbsolutePath();
+        new ApplyBQSR().instanceMain(Utils.escapeExpressions(argApply));
+
+        final File actualTablePost = createTempFile("gatk4.post.cols", ".table");
+        final String argsPost = cloudArgs
+                + " -R " + hg18Reference + " --knownSites " + dbSNPb37 + " -I " + actualHiSeqBam_recalibrated.getAbsolutePath()
+                + " -RECAL_TABLE_FILE " + actualTablePost.getAbsolutePath() + " --sort_by_all_columns true";
+        new DF_BaseRecalibrator().instanceMain(Utils.escapeExpressions(argsPost));
+
+        final File expectedHiSeqBam_recalibrated = new File(resourceDir + "expected.NA12878.chr17_69k_70k.dictFix.recalibrated.bam");
+
+        //this fails, disable for now: https://github.com/broadinstitute/hellbender/issues/419
+        //IntegrationTestSpec.compareBamFiles(actualHiSeqBam_recalibrated, expectedHiSeqBam_recalibrated);
+
+        final File expectedTablePost = new File(getResourceDir() + "expected.NA12878.chr17_69k_70k.postRecalibrated.txt");
+        IntegrationTestSpec.compareTextFiles(actualTablePost, expectedTablePost);
+    }
+
+    @Test
+    public void testBQSRFailWithoutDBSNP() throws IOException {
+        final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
+
+        final String hg18Reference = publicTestDir + "human_g1k_v37.chr17_1Mb.fasta";
+        final String HiSeqBam = resourceDir + "NA12878.chr17_69k_70k.dictFix.bam";
+
+        final String  NO_DBSNP = "";
+        final String  NO_ARGS = "";
+        final BQSRTest params = new BQSRTest(hg18Reference, HiSeqBam, NO_DBSNP, NO_ARGS, resourceDir + "expected.NA12878.chr17_69k_70k.txt");
+        IntegrationTestSpec spec = new IntegrationTestSpec(
+                params.getCommandLine(),
+                1,
+                UserException.CommandLineException.class);
+        spec.executeTest("testBQSRFailWithoutDBSNP", this);
+    }
+
+    @Test
+    public void testBQSRFailWithIncompatibleReference() throws IOException {
+        final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
+
+        final String HiSeqBam_Hg18 = resourceDir + "HiSeq.1mb.1RG.2k_lines.bam";
+
+        final String  NO_ARGS = "";
+        final BQSRTest params = new BQSRTest(hg19MiniReference, HiSeqBam_Hg18, hg19_chr1_1M_dbSNP, NO_ARGS, resourceDir + "expected.txt");
+        IntegrationTestSpec spec = new IntegrationTestSpec(
+                params.getCommandLine(),
+                1,
+                UserException.MissingContigInSequenceDictionary.class);
+        spec.executeTest("testBQSRFailWithIncompatibleReference", this);
+    }
+}


### PR DESCRIPTION
* DF_BaseRecalibrator tool, can be called from the command line. Same syntax as BaseRecalibrator.
* BaseRecalibrator's integration tests ported to this Dataflow version.
* Small changes to make types serializable.
* Note that this pull request is an intermediate step as it only works for local computations.

(this depends on [PR#522](https://github.com/broadinstitute/hellbender/pull/522))