### PR TITLE
changing dataflow SAM classes to pass around a SAMHeader

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/DataFlowSAMFn.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/DataFlowSAMFn.java
@@ -7,11 +7,8 @@ import com.google.cloud.genomics.gatk.common.GenomicsConverter;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.broadinstitute.hellbender.utils.read.ReadUtils.samHeaderFromString;
 
 /**
  * A DoFn from Read -> Something which presents a SAMRecord to its apply method.
@@ -23,26 +20,22 @@ public abstract class DataFlowSAMFn<Output> extends DoFn<Read, Output> {
      * field to cache the reconstructed SAMFileHeader
      * SAMFileHeader is not Serializable, but this class must be, so this is marked transient and reconstructed as needed
      */
-    private transient SAMFileHeader header;
-    private final String headerString;
+    private final SAMFileHeader header;
 
     private final List<Output> toEmit = new ArrayList<>();
 
     /**
      * Construct a new DataFlowSAMFn and give it an appropriate {@link SAMFileHeader}
-     * @param headerString A header String from a SAM or BAM file.  This can be read from a SAM or BAM file using {@link SAMFileHeader#getTextHeader()}
+     * @param header A header String from a SAM or BAM file.  This can be read from a SAM or BAM file using {@link SAMFileHeader#getTextHeader()}
      */
-    public DataFlowSAMFn(final String headerString){
-        this.headerString = headerString;
+    public DataFlowSAMFn(final SAMFileHeader header){
+        this.header = header;
     }
 
     /**
      * @return a SAMFileHeader reconstituted from the header string this was constructed with
      */
     public final SAMFileHeader getHeader(){
-        if (header == null) {
-            this.header = samHeaderFromString(headerString);
-        }
         return header;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/PTransformSAM.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/PTransformSAM.java
@@ -3,41 +3,38 @@ package org.broadinstitute.hellbender.engine.dataflow;
 import com.google.api.services.genomics.model.Read;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.values.PCollection;
+import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.engine.GATKTool;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 
 /**
  * An abstract class representing a {@link PTransform<Read, Output>}.
- * This provides a mechanism for propagating a {@link htsjdk.samtools.SAMFileHeader} to {@link DataFlowSAMFn}.
- * This is a workaround the fact that SAMFileHeader is not Serializable.
+ * This provides a mechanism for propagating a {@link htsjdk.samtools.SAMFileHeader} to {@link DataFlowSAMFn}..
  *
- * Calls to {@link #getHeaderString()) must be proceded by a call to {@link #SetHeaderString())
+ * Calls to {@link #getHeader()} must be proceded by a call to {@link #setHeader(SAMFileHeader)}}
  * @param <Output> the output type of the resulting PCollection
  */
 public abstract class PTransformSAM<Output> extends PTransform<PCollection<Read>,PCollection<Output>> {
     private static final long serialVersionUID = 1l;
 
-    private String headerString;
+    private SAMFileHeader header;
 
     /**
-     * @return a String representation of a {@link htsjdk.samtools.SAMFileHeader}.
-     * @throws GATKException if {@link #setHeaderString(String)} wasn't called before this.
+     * @return a {@link SAMFileHeader}
+     * @throws GATKException if {@link #setHeader(SAMFileHeader)} wasn't called before this.
      */
-    public String getHeaderString(){
-        if (headerString == null){
-            throw new GATKException("You must call setHeaderString before calling getHeaderString");
-        }
-        return headerString;
+    public SAMFileHeader getHeader(){
+        return header;
     }
 
     /**
-     * @param headerString set the headerString to provide to the {@link DataFlowSAMFn} making up this transform.
+     * @param header set the {@link SAMFileHeader} to provide to the {@link DataFlowSAMFn} making up this transform.
      *                     Must be non-null and must be a valid header for the the PCollection<Read> that this transform is processing.
      */
-    public void setHeaderString(final String headerString) {
-        if (headerString == null){
-            throw new IllegalArgumentException("null header string");
+    public void setHeader(final SAMFileHeader header) {
+        if (header == null){
+            throw new IllegalArgumentException("null header");
         }
-        this.headerString = headerString;
+        this.header = header;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSource.java
@@ -11,6 +11,7 @@ import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.utils.Contig;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.common.collect.ImmutableList;
+import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -65,24 +66,19 @@ public final class ReadsSource {
     }
 
     /**
-     * Gets a header string representing a valid sam header for the data associated with this ReadsSource
-     *
-     * This method is a hack to get around the non-serializibility of {@link htsjdk.samtools.SAMFileHeader} and
-     * will be replaced with getSamHeader() when that is solved.
-     *
-     * @return a String representation of a {@link htsjdk.samtools.SAMFileHeader}
+     * Get a SAMFileHeader to use with Reads produced by this ReadsSource
      */
-    public String getHeaderString() {
+    public SAMFileHeader getHeader() {
         if(cloudStorageUrl) {
             try {
                 Storage.Objects storageClient = GCSOptions.Methods.createStorageClient(options, auth);
                 final SamReader reader = BAMIO.openBAM(storageClient, bam);
-                return reader.getFileHeader().getTextHeader();
+                return reader.getFileHeader();
             } catch (IOException e) {
                 throw new GATKException("Failed to read bams header from " + bam + ".", e);
             }
         } else {
-            return SamReaderFactory.makeDefault().getFileHeader(new File(bam)).getTextHeader();
+            return SamReaderFactory.makeDefault().getFileHeader(new File(bam));
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/SAMSerializableFunction.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/SAMSerializableFunction.java
@@ -17,26 +17,20 @@ import htsjdk.samtools.util.StringLineReader;
  */
 public final class SAMSerializableFunction<Output> implements SerializableFunction<Read, Output> {
 
-    private transient SAMFileHeader header;  //transient cache of the SAMFileHeader which is not Serializeable
-    private final String headerString;
+    private SAMFileHeader header;
     private final SerializableFunction<SAMRecord, Output> f;
 
     /**
      * Wrap a function from SAMRecord -> Output into a function from Read -> Output
-     * @param headerString A String to construct an appropriate SAMFileHeader from
+     * @param header A {@link SAMFileHeader } that is associated with the Reads this will be used on.
      * @param f the SerializableFunction to wrap
      */
-    public SAMSerializableFunction(String headerString, SerializableFunction<SAMRecord, Output> f){
-        this.headerString = headerString;
+    public SAMSerializableFunction(SAMFileHeader header, SerializableFunction<SAMRecord, Output> f){
+        this.header = header;
         this.f = f;
     }
 
     private SAMFileHeader getHeader(){
-        if (header == null) {
-            final SAMTextHeaderCodec headerCodec = new SAMTextHeaderCodec();
-            headerCodec.setValidationStringency(ValidationStringency.LENIENT);
-            this.header = headerCodec.decode(new StringLineReader(headerString), "magic string");
-        }
         return header;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/CountBasesDataflowTransform.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/CountBasesDataflowTransform.java
@@ -17,7 +17,7 @@ public final class CountBasesDataflowTransform extends PTransformSAM<Long> {
     @Override
     public PCollection<Long> apply(final PCollection<Read> reads) {
 
-        return reads.apply(ParDo.of(new DataFlowSAMFn<Long>(getHeaderString()) {
+        return reads.apply(ParDo.of(new DataFlowSAMFn<Long>(getHeader()) {
             private static final long serialVersionUID = 1l;
 
             @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/PrintReadsDataflowTransform.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/PrintReadsDataflowTransform.java
@@ -16,7 +16,7 @@ public final class PrintReadsDataflowTransform extends PTransformSAM<String> {
 
         @Override
         public PCollection<String> apply(final PCollection<Read> reads) {
-                return reads.apply(ParDo.of(new DataFlowSAMFn<String>(getHeaderString()) {
+                return reads.apply(ParDo.of(new DataFlowSAMFn<String>(getHeader()) {
                         private static final long serialVersionUID = 1l;
 
                         @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -67,15 +67,6 @@ public final class ReadUtils {
     }
 
     /**
-     * create a SAMFileHeader from a String
-     */
-    public static SAMFileHeader samHeaderFromString(String headerString){
-      final SAMTextHeaderCodec headerCodec = new SAMTextHeaderCodec();
-      headerCodec.setValidationStringency(ValidationStringency.LENIENT);
-      return headerCodec.decode(new StringLineReader(headerString), null);
-    }
-
-    /**
      * A marker to tell which end of the read has been clipped
      */
     public enum ClippingTail {

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSourceTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSourceTest.java
@@ -6,9 +6,10 @@ import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Count;
 import com.google.cloud.dataflow.sdk.values.PCollection;
-import com.google.cloud.genomics.dataflow.coders.GenericJsonCoder;
 import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
 import com.google.common.collect.ImmutableList;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SamReaderFactory;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
@@ -17,24 +18,15 @@ import org.testng.annotations.Test;
 import java.io.File;
 
 public final class ReadsSourceTest extends BaseTest {
-    public static final String EXPECTED_HEADER = "@HD\tVN:1.0\tSO:coordinate\n" +
-            "@SQ\tSN:chr1\tLN:101\n" +
-            "@SQ\tSN:chr2\tLN:101\n" +
-            "@SQ\tSN:chr3\tLN:101\n" +
-            "@SQ\tSN:chr4\tLN:101\n" +
-            "@SQ\tSN:chr5\tLN:101\n" +
-            "@SQ\tSN:chr6\tLN:101\n" +
-            "@SQ\tSN:chr7\tLN:404\n" +
-            "@SQ\tSN:chr8\tLN:202\n" +
-            "@RG\tID:0\tSM:Hi,Mom!\n" +
-            "@PG\tID:1\tPN:Hey!\tVN:2.0\n";
+
     private final File bam = new File(this.getToolTestDataDir(), "count_reads_sorted.bam");
 
     @Test
     public void testGetHeaderFromLocalBAM(){
+        final SAMFileHeader expectedHeader = SamReaderFactory.makeDefault().open(bam).getFileHeader();
         ReadsSource source = new ReadsSource(bam.getAbsolutePath(), null);
-        String header = source.getHeaderString();
-        Assert.assertEquals(header, EXPECTED_HEADER);
+        SAMFileHeader header = source.getHeader();
+        Assert.assertEquals(header, expectedHeader);
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/SAMSerializableFunctionTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/SAMSerializableFunctionTest.java
@@ -25,7 +25,7 @@ public final class SAMSerializableFunctionTest extends CommandLineProgramTest{
                 .collect(Collectors.toList());
 
 
-        SAMSerializableFunction<Integer> f = new SAMSerializableFunction<>(header.toString() ,SAMRecord::getReadLength);
+        SAMSerializableFunction<Integer> f = new SAMSerializableFunction<>(header ,SAMRecord::getReadLength);
 
         final List<Integer> recoveredLengths = reads.stream()
                 .map(f::apply)

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/DataflowReadsPipelineTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/DataflowReadsPipelineTest.java
@@ -88,7 +88,7 @@ public final class DataflowReadsPipelineTest {
         String bam = "src/test/resources/org/broadinstitute/hellbender/tools/count_reads_sorted.bam";
         PCollection<Read> preads = DataflowUtils.getReadsFromLocalBams(p, Lists.newArrayList(new SimpleInterval("chr7", 1, 404)), Lists.newArrayList(new File(bam)));
 
-        PCollection<?> presult = rcp.applyTransformsToPipeline(SamReaderFactory.makeDefault().getFileHeader(new File(bam)).getTextHeader(), preads);
+        PCollection<?> presult = rcp.applyTransformsToPipeline(SamReaderFactory.makeDefault().getFileHeader(new File(bam)), preads);
 
         DataflowAssert.thatSingleton((PCollection<Long>) presult).isEqualTo(expectedCounts);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/CountBasesTransformUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/CountBasesTransformUnitTest.java
@@ -36,7 +36,7 @@ public final class CountBasesTransformUnitTest {
         DataflowWorkarounds.registerGenomicsCoders(p);
         PCollection<Read> preads = p.apply(Create.of(reads));
         PTransformSAM<Long> transform = new CountBasesDataflowTransform();
-        transform.setHeaderString(ArtificialSAMUtils.createArtificialSamHeader().toString());
+        transform.setHeader(ArtificialSAMUtils.createArtificialSamHeader());
         PCollection<Long> presult = preads.apply(transform);
 
         DataflowAssert.thatSingleton(presult).isEqualTo(expected);

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/PrintReadsTransformUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/PrintReadsTransformUnitTest.java
@@ -44,7 +44,7 @@ public final class PrintReadsTransformUnitTest {
         DataflowWorkarounds.registerGenomicsCoders(p);
         PCollection<Read> preads = p.apply(Create.of(reads));
         PTransformSAM<String> transform = new PrintReadsDataflowTransform();
-        transform.setHeaderString(ArtificialSAMUtils.createArtificialSamHeader().toString());
+        transform.setHeader(ArtificialSAMUtils.createArtificialSamHeader());
         PCollection<String> presult = preads.apply(transform);
 
         DataflowAssert.that(presult);


### PR DESCRIPTION
Passing a `SAMFileHeader` since it's serializable now.  A minor reduction in hacky workarounds.