### PR TITLE
reduce number of iterations in SplitNCigarReadsTests

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/test/ReadClipperTestUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/ReadClipperTestUtils.java
@@ -77,13 +77,13 @@ public final class ReadClipperTestUtils {
      * - No repeated adjacent element (e.g. 1M2M -> this should be 3M)
      * - No consecutive I/D elements
      *
-     * @param maximumLength the maximum number of elements in the cigar
+     * @param maximumCigarElements the maximum number of elements in the cigar
      * @return a list with all valid Cigar objects
      */
-    public static List<Cigar> generateCigarList(int maximumLength, CigarElement[] cigarElements) {
+    public static List<Cigar> generateCigarList(int maximumCigarElements, CigarElement[] cigarElements) {
         int numCigarElements = cigarElements.length;
         LinkedList<Cigar> cigarList = new LinkedList<>();
-        byte[] cigarCombination = new byte[maximumLength];
+        byte[] cigarCombination = new byte[maximumCigarElements];
 
         Utils.fillArrayWithByte(cigarCombination, (byte) 0);               // we start off with all 0's in the combination array.
         int currentIndex = 0;
@@ -95,12 +95,12 @@ public final class ReadClipperTestUtils {
             }
 
             boolean currentIndexChanged = false;
-            while (currentIndex < maximumLength && cigarCombination[currentIndex] == numCigarElements - 1) {
+            while (currentIndex < maximumCigarElements && cigarCombination[currentIndex] == numCigarElements - 1) {
                 currentIndex++;                                            // find the next index to increment
                 currentIndexChanged = true;                                // keep track of the fact that we have changed indices!
             }
 
-            if (currentIndex == maximumLength)                             // if we hit the end of the array, we're done.
+            if (currentIndex == maximumCigarElements)                             // if we hit the end of the array, we're done.
                 break;
 
             cigarCombination[currentIndex]++;                              // otherwise advance the current index

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsIntegrationTest.java
@@ -60,8 +60,8 @@ public final class SplitNCigarReadsIntegrationTest extends CommandLineProgramTes
 
     @Test
     public void splitReadAtN() {
-        final int cigarStringLength = 10;
-        final List<Cigar> cigarList = ReadClipperTestUtils.generateCigarList(cigarStringLength, cigarElements);
+        final int maxCigarElements = 9;
+        final List<Cigar> cigarList = ReadClipperTestUtils.generateCigarList(maxCigarElements, cigarElements);
 
         // For Debugging use those lines (instead of above cigarList) to create specific read:
         //------------------------------------------------------------------------------------

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/rnaseq/SplitNCigarReadsUnitTest.java
@@ -38,8 +38,8 @@ public final class SplitNCigarReadsUnitTest extends BaseTest {
 
     @Test
     public void splitReadAtN() {
-        final int cigarStringLength = 10;
-        final List<Cigar> cigarList = ReadClipperTestUtils.generateCigarList(cigarStringLength, cigarElements);
+        final int maxCigarElements = 9;
+        final List<Cigar> cigarList = ReadClipperTestUtils.generateCigarList(maxCigarElements, cigarElements);
 
         // For Debugging use those lines (instead of above cigarList) to create specific read:
         //------------------------------------------------------------------------------------

--- a/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
@@ -22,11 +22,11 @@ import static org.broadinstitute.hellbender.utils.read.ReadUtils.*;
 
 public final class ReadClipperUnitTest extends BaseTest {
     List<Cigar> cigarList;
-    int maximumCigarSize = 10;                                                                                           // 6 is the minimum necessary number to try all combinations of cigar types with guarantee of clipping an element with length = 2
+    int maximumCigarElements = 9;                                                                                           // 6 is the minimum necessary number to try all combinations of cigar types with guarantee of clipping an element with length = 2
 
     @BeforeClass
     public void init() {
-        cigarList = ReadClipperTestUtils.generateCigarList(maximumCigarSize);
+        cigarList = ReadClipperTestUtils.generateCigarList(maximumCigarElements);
     }
 
     @Test


### PR DESCRIPTION
These take several minutes currently, reducing the number of iterations by an order of magnitude speeds them up and shouldn't greatly impact the effectiveness of the tests.