### PR TITLE
use API key for testing, fix mysterious cmdline-only bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     compile files("${System.properties['java.home']}/../lib/tools.jar")
 
     compile 'com.github.samtools:htsjdk:1.132'
-    compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.9'
+    compile 'com.google.cloud.genomics:google-genomics-dataflow:v1beta2-0.10'
     compile 'com.google.cloud.genomics:gatk-tools-java:1.0'
     compile 'org.apache.logging.log4j:log4j-api:2.2'
     compile 'org.apache.logging.log4j:log4j-core:2.2'

--- a/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/BaseRecalibratorDataflow.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/BaseRecalibratorDataflow.java
@@ -4,8 +4,6 @@ import com.google.api.services.genomics.model.Read;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.coders.SerializableCoder;
 import com.google.cloud.dataflow.sdk.transforms.Create;
-import com.google.cloud.dataflow.sdk.transforms.DoFn;
-import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.util.GcsUtil;
 import com.google.cloud.dataflow.sdk.util.gcsfs.GcsPath;
 import com.google.cloud.dataflow.sdk.values.PCollection;
@@ -43,7 +41,11 @@ import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
 import org.broadinstitute.hellbender.utils.dataflow.DataflowUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 
-import java.io.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/DataflowCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/DataflowCommandLineProgram.java
@@ -79,7 +79,7 @@ public abstract class DataflowCommandLineProgram extends CommandLineProgram impl
         options.setStagingLocation(stagingLocation);
         options.setRunner(this.runnerType.runner);
         if (clientSecret!=null) {
-            options.setGenomicsSecretsFile(clientSecret.getAbsolutePath()); // TODO: Migrate to secrets file (issue 516).
+            options.setSecretsFile(clientSecret.getAbsolutePath());
         }
         if (apiKey!=null) {
             options.setApiKey(apiKey);

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
@@ -17,6 +17,12 @@ import java.util.function.Predicate;
  */
 public interface ReadFilter extends Predicate<SAMRecord>, SerializableFunction<SAMRecord, Boolean>{
 
+    // It turns out, this is necessary. Please don't remove it.
+    // Without this line, we see the following error:
+    // java.io.InvalidClassException: org.broadinstitute.hellbender.engine.filters.ReadFilter; local class incompatible:
+    // stream classdesc serialVersionUID = -5040289903122017748, local class serialVersionUID = 6814309376393671214
+    static final long serialVersionUID = 1L;
+
     //HACK: These methods are a hack to get to get the type system to accept compositions of ReadFilters.
     /**
      * Specialization of {@link #and(Predicate)} so that ReadFilters anded with other ReadFilters produce a ReadFilter

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -31,6 +31,16 @@ public abstract class BaseTest {
     private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");
     public static final String gatkDirectory = System.getProperty("gatkdir", CURRENT_DIRECTORY) + "/";
 
+    // shortname of the project that stores the data and will run the code.
+    public final static String DATAFLOW_TEST_PROJECT = System.getenv("HELLBENDER_TEST_PROJECT");
+    // API key for DATAFLOW_TEST_PROJECT
+    public final static String DATAFLOW_TEST_APIKEY = System.getenv("HELLBENDER_TEST_APIKEY");
+    // A writeable folder on the project's GCS
+    public final static String DATAFLOW_TEST_STAGING = System.getenv("HELLBENDER_TEST_STAGING");
+    // A GCS path (on that project) where the test inputs are stored.
+    public final static String DATAFLOW_TEST_INPUTS = System.getenv("HELLBENDER_TEST_INPUTS");
+
+
     private static final String publicTestDirRelative = "src/test/resources/";
     public static final String publicTestDir = new File(gatkDirectory, publicTestDirRelative).getAbsolutePath() + "/";
     public static final String publicTestDirRoot = publicTestDir.replace(publicTestDirRelative, "");


### PR DESCRIPTION

This version introduces a change that (at least on my machine) fixes the mysterious "happens only on the command line" test failure.

Also uses a newer version of genomics-dataflow because I had to fix a bug there for API_KEY to work in our setting.

Finally, this version also moves the files around so they match the local tree, and changes the environment variables naming scheme to be a little more consistent.