### PR TITLE
ported pairhmms

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/QualityUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/QualityUtils.java
@@ -76,6 +76,21 @@ public final class QualityUtils {
     }
 
     /**
+     * Convert a phred-scaled quality score to its probability of being true (Q30 => 0.999)
+     *
+     * This is the Phred-style conversion, *not* the Illumina-style conversion.
+     *
+     * Because the input is a double value, this function must call Math.pow so can be quite expensive
+     *
+     * @param qual a phred-scaled quality score encoded as a double.  Can be non-integer values (30.5)
+     * @return a probability (0.0-1.0)
+     */
+    public static double qualToProb(final double qual) {
+        if ( qual < 0.0 ) throw new IllegalArgumentException("qual must be >= 0.0 but got " + qual);
+        return 1.0 - qualToErrorProb(qual);
+    }
+
+    /**
      * Convert a phred-scaled quality score to its log10 probability of being true (Q30 => log10(0.999))
      *
      * This is the Phred-style conversion, *not* the Illumina-style conversion.

--- a/src/main/java/org/broadinstitute/hellbender/utils/RandomDNA.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/RandomDNA.java
@@ -1,0 +1,90 @@
+package org.broadinstitute.hellbender.utils;
+
+import java.util.Random;
+
+/**
+ * Random DNA sequence generator.
+ *
+ * <p>
+ *     Returned bases are always in upper case and one of the valid four nocleotides 'A', 'C', 'G' and 'T'.
+ * </p>
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public final class RandomDNA {
+
+    private final Random random;
+
+    /**
+     * Constructs a new random DNA generator.
+     *
+     * <p>
+     *     The seed would be the default which would depend on system properties and the current time as
+     *     described in {@link Random} documentation.
+     * </p>
+     */
+    public RandomDNA() {
+        this(new Random());
+    }
+
+
+    /**
+     * Creates a new random DNA generator given a random number generator.
+     * @param rnd the underlying random number generator.
+     *
+     * @throws IllegalArgumentException if {@code rnd} is {@code null}.
+     */
+    public RandomDNA(final Random rnd) {
+        random = Utils.nonNull(rnd,"the random number generator cannot be null");
+    }
+
+    /**
+     * Constructs a new random DNA generator providing a seed.
+     *
+     * @param seed the random number generator seed.
+     */
+    public RandomDNA(final long seed) {
+        this(new Random(seed));
+    }
+
+    /**
+     * Updates the content of a byte array with a random base sequence.
+     *
+     * <p>
+     *     The whole array will be filled with new base values.
+     * </p>
+     *
+     * @param destination the array to update.
+     *
+     * @throws NullPointerException if {@code destination} is {@code null}.
+     */
+    public void nextBases(final byte[] destination) {
+        random.nextBytes(destination);
+        for (int i = 0; i < destination.length; i++) {
+            final int ord = destination[i] & 0x03;
+            switch (ord) {
+                case 0: destination[i] = 'A'; break;
+                case 1: destination[i] = 'C'; break;
+                case 2: destination[i] = 'G'; break;
+                case 3: destination[i] = 'T'; break;
+                default: throw new IllegalStateException("this cannot be happening!!!");
+            }
+        }
+    }
+
+    /**
+     * Returns a random RNA sequence of bases.
+     * @param size the length of the sequence.
+     *
+     * @throws IllegalArgumentException if {@code size} is negative.
+     * @return never {@code null}.
+     */
+    public byte[] nextBases(final int size) {
+        if (size < 0) throw new IllegalArgumentException("the size cannot be negative");
+        final byte[] result = new byte[size];
+        nextBases(result);
+        return result;
+    }
+
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/IndexedSet.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/IndexedSet.java
@@ -1,0 +1,303 @@
+package org.broadinstitute.hellbender.utils.collections;
+
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.*;
+
+/**
+* Set set where each element can be reference by a unique integer index that runs from
+*     0 to the size of the set - 1.
+*
+* @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+*/
+public final class IndexedSet<E> extends AbstractSet<E> implements Set<E> {
+
+    /**
+     * Elements stored in an array-list by their index.
+     */
+    private final ArrayList<E> elements;
+
+    /**
+     * A unmodifiable view to the element list. Initially {@code null} it is thread-unsafe lazy instantiated
+     * when requested first time through {@link #asList}. Therefore typically it is shared by invoking code but
+     * there could be some extra copies (rare though) in multi-thread runs.
+     */
+    private List<E> unmodifiableElementsListView;
+
+    /**
+     * Quick element to index lookup map.
+     * <p>
+     *  Uses a primitive int value map for efficiency sake.
+     * </p>
+     */
+    private final Map<E, Integer> indexByElement;
+
+    /**
+     * Creates an empty indexed set indicating the expected number of elements.
+     *
+     * @param initialCapacity the initial number of elements.
+     */
+    public IndexedSet(final int initialCapacity) {
+        elements = new ArrayList<>(initialCapacity);
+        indexByElement = new HashMap<>(initialCapacity);
+    }
+
+    /**
+     * Creates a new sample list from a existing collection of elements.
+     *
+     * <p>
+     *     Elements will be indexed as they appear in the input array. Repeats will be ignored.
+     * </p>
+     *
+     * @param values the original sample list.
+     *
+     * @throws IllegalArgumentException
+     * if {@code values} array is {@code null} itself, or it contains {@code null}.
+     */
+    public IndexedSet(final Collection<E> values) {
+        Utils.nonNull(values, "input values cannot be null");
+
+        final int initialCapacity = values.size();
+        elements = new ArrayList<>(initialCapacity);
+        indexByElement = new HashMap<>(initialCapacity);
+        int nextIndex = 0;
+        for (final E value : values) {
+            if (value == null) {
+                throw new IllegalArgumentException("null element not allowed: index == " + nextIndex);
+            }
+            if (indexByElement.containsKey(value)) {
+                continue;
+            }
+            indexByElement.put(value, nextIndex++);
+            elements.add(value);
+        }
+    }
+
+    /**
+     * Creates a new sample list from a existing array of elements.
+     *
+     * <p>
+     *     Elements will be indexed as they appear in the collection. Repeats will be ignored.
+     * </p>
+     *
+     * @param values the original sample list.
+     *
+     * @throws IllegalArgumentException
+     * if {@code values} collection is {@code null} itself, or it contains {@code null}.
+     */
+    public IndexedSet(final E... values) {
+        Utils.nonNull(values, "input values cannot be null");
+
+        final int initialCapacity = values.length;
+        elements = new ArrayList<>(initialCapacity);
+        indexByElement = new HashMap<>(initialCapacity);
+        int nextIndex = 0;
+        for (final E value : values) {
+            Utils.nonNull(value, "null element not allowed: index == " + nextIndex);
+
+            if (indexByElement.containsKey(value)) {
+                continue;
+            }
+            indexByElement.put(value, nextIndex++);
+            elements.add(value);
+        }
+    }
+
+    /**
+     * Returns a list view of the elements in the set.
+     *
+     * <p>
+     *     Elements are sorted by their index within the set.
+     * </p>
+     *
+     * <p>
+     *     This view changes as the indexed set changes but it cannot be used to update its contents.
+     *     In such case a {@link UnsupportedOperationException} exception will be thrown if the calling
+     *     code tries to tho just that.
+     * </p>
+     *
+     * @return never {@code null}.
+     */
+    public List<E> asList() {
+        if (unmodifiableElementsListView == null) {
+            unmodifiableElementsListView = Collections.unmodifiableList(elements);
+        }
+        return unmodifiableElementsListView;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return asList().iterator();
+    }
+
+    /**
+     * Returns number of elements in the set.
+     * @return never {@code null}.
+     */
+    @Override
+    public int size() {
+        return elements.size();
+    }
+
+    /**
+     *
+     * @param o
+     * @return {@code true} iff {@code o} is in
+     */
+    @Override
+    @SuppressWarnings("all")
+    public boolean contains(final Object o) {
+        return o != null && indexByElement.containsKey(o);
+    }
+
+    /**
+     * Adds a new element to the set.
+     *
+     * <p>
+     *     If the element was already in th set nothing will happen and the method will return {@code false}. However,
+     *     if the element is new to this set, it will assigned the next index available (equal to the size before addition).
+     *     The method will return {@code true} in this case.
+     * </p>
+     *
+     * @param o the object to add.
+     *
+     * @throw IllegalArgumentException if {@code o} is {@code null}.
+     *
+     * @return {@code true} iff the set was modified by this operation.
+     */
+    @Override
+    public boolean add(final E o) {
+        Utils.nonNull(o, "the input argument cannot be null");
+        if (contains(o)) {
+            return false;
+        }
+        final int nextIndex = size();
+        elements.add(o);
+        indexByElement.put(o, nextIndex);
+        return true;
+    }
+
+    /**
+     * Removes an element from the set.
+     *
+     * <p>
+     *     If the element was not present in the set, nothing happens and the method return false. However,
+     *     if the element is new to this set, it will be assigned the next index available (equal to the size
+     *     before addition).
+     *     The method will return {@code true} in this case.
+     * </p>
+     *
+     * @param o the object to remove.
+     *
+     * @throw IllegalArgumentException if {@code o} is {@code null}.
+     *
+     * @return {@code true} iff the set was modified by this operation.
+     */
+    @Override
+    public boolean remove(final Object o) {
+        final int index = indexOf(o);
+        if (index == -1) {
+            return false;
+        }
+        elements.remove(index);
+        indexByElement.remove(o);
+        final ListIterator<E> it = elements.listIterator(index);
+        int nextIndex = index;
+        while (it.hasNext()) {
+            indexByElement.put(it.next(), nextIndex++);
+        }
+        return true;
+    }
+
+    /**
+     * Removes all elements in the set.
+     */
+    @Override
+    public void clear() {
+        elements.clear();
+        indexByElement.clear();
+    }
+
+    /**
+     * Compares this with another indexed set.
+     * @param o the other object to compare to.
+     * @return {@code false} unless {@code o} is a indexed-set that contains the same elements in the same order.
+     */
+    @Override
+    public boolean equals(final Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof IndexedSet<?>)) {
+            return false;
+        }
+
+        final IndexedSet<?> other = (IndexedSet<?>)o;
+
+        return equals(other);
+    }
+
+    /**
+     * Compare to another indexed set.
+     *
+     * @param other the target indexed set.
+     *
+     * @throws java.lang.IllegalArgumentException if {@code other} is {@code null}.
+     *
+     * @return {@code true} iff {@other} is not {@code null}, and contains exactly the same elements
+     * (as compared using {@link Object#equals} a this set with matching indices.
+     */
+    public boolean equals(final IndexedSet<?> other) {
+        Utils.nonNull(other, "other cannot be null");
+        final ArrayList<?> otherElements = other.elements;
+
+        final int elementCount = elements.size();
+        if (otherElements.size() != elementCount) {
+            return false;
+        }
+        for (int i = 0; i < elementCount; i++) {
+            if (!elements.get(i).equals(otherElements.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        for (final E element : elements) {
+            result = 31 * result + (element == null ? 0 : element.hashCode());
+        }
+        return result;
+    }
+
+    /**
+     * Returns the element given its index within the set.
+     * @param index the target element's index.
+     *
+     * @throws IllegalArgumentException if {@code index} is not valid; in [0,{@link #size()}).
+     *
+     * @return never {@code null}; as null is not a valid element.
+     */
+    public E get(final int index) {
+        Utils.validIndex(index, size());
+        return elements.get(index);
+    }
+
+    /**
+     * Returns the index of an object.
+     * @param o the object of interest.
+     *
+     * @throws IllegalArgumentException if {@code o} is {@code null}.
+     *
+     * @return {@code -1} if such an object is not an element of this set, otherwise is index in the set thus a
+     * values within [0,{@link #size()}).
+     */
+    public int indexOf(final Object o) {
+        Utils.nonNull(o, "the query object cannot be null");
+        return indexByElement.containsKey(o) ? indexByElement.get(o) : -1;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/collections/Permutation.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/collections/Permutation.java
@@ -1,0 +1,78 @@
+package org.broadinstitute.hellbender.utils.collections;
+
+import java.util.List;
+
+/**
+ * Represent a permutation of a ordered set or list of elements.
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public interface Permutation<E> {
+
+    /**
+     * Checks whether this permutation is a partial one of the original list.
+     *
+     * <p>
+     *     A partial permutation is one in that no all original elements take part of.
+     * </p>
+     *
+     * @return {@code true} iff this is a partial permutation.
+     */
+    public boolean isPartial();
+
+    /**
+     * Checks whether this is a trivial permutation where the resulting element list is the same as original.
+     *
+     * @return {@code true} iff the resulting element list is the same as the original.
+     */
+    public boolean isNonPermuted();
+
+    /**
+     * Given an index on the original list, returns the position of tha element in the resulting list.
+     *
+     * @param fromIndex the query original element index.
+     *
+     * @throws IllegalArgumentException if {@code fromIndex} is not a valid index within the original list.
+     *
+     * @return -1 if that element is not part of the result (partial) permutation, otherwise some number between
+     *   0 and {@link #toSize()} - 1.
+     */
+    public int toIndex(final int fromIndex);
+
+    /**
+     * Given an index on the resulting list, it gives you the index of that element on the original list.
+     * @param toIndex the query resulting list index.
+     *
+     * @throws IllegalArgumentException if {@code toIndex} is not a valid index, i.e. in [0,{@link #toSize()}-1).
+     *
+     * @return a value between 0 and {@link #fromSize()} - 1.
+     */
+    public int fromIndex(final int toIndex);
+
+    /**
+     * Length of the original element list.
+     *
+     * @return 0 or greater.
+     */
+    public int fromSize();
+
+    /**
+     * Length of the resulting element list.
+     *
+     * @return 0 or greater.
+     */
+    public int toSize();
+
+    /**
+     * Returns an unmodifiable view to the original element list.
+     * @return never {@code null}.
+     */
+    public List<E> fromList();
+
+    /**
+     * Returns an unmodifiable view to the original element list.
+     *
+     * @return never {@code null}.
+     */
+    public List<E> toList();
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleList.java
@@ -1,0 +1,15 @@
+package org.broadinstitute.hellbender.utils.genotyper;
+
+import htsjdk.variant.variantcontext.Allele;
+
+/**
+ * Minimal interface for random access to a collection of Alleles.
+ */
+public interface AlleleList<A extends Allele> {
+
+    public int alleleCount();
+
+    public int alleleIndex(final A allele);
+
+    public A alleleAt(final int index);
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleListPermutation.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleListPermutation.java
@@ -1,0 +1,10 @@
+package org.broadinstitute.hellbender.utils.genotyper;
+
+import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.hellbender.utils.collections.Permutation;
+
+/**
+ * Marks allele list permutation implementation classes.
+ */
+public interface AlleleListPermutation<A extends Allele> extends Permutation<A>, AlleleList<A> {
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleListUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/AlleleListUtils.java
@@ -1,0 +1,316 @@
+package org.broadinstitute.hellbender.utils.genotyper;
+
+import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.AbstractList;
+import java.util.List;
+
+/**
+ * Utils operations on {@link AlleleList} instances.
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public final class AlleleListUtils {
+    private AlleleListUtils(){}
+
+    @SuppressWarnings("unchecked")
+    private static final AlleleList EMPTY_LIST = new AlleleList() {
+        @Override
+        public int alleleCount() {
+            return 0;
+        }
+
+        @Override
+        public int alleleIndex(final Allele allele) {
+            return -1;
+        }
+
+        @Override
+        public Allele alleleAt(final int index) {
+            throw new IllegalArgumentException("allele index is out of range");
+        }
+    };
+
+    /**
+     * Checks whether two allele lists are in fact the same.
+     * @param first one list to compare.
+     * @param second another list to compare.
+     *
+     * @throws IllegalArgumentException if if either list is {@code null}.
+     *
+     * @return {@code true} iff both list are equal.
+     */
+    public static <A extends Allele> boolean equals(final AlleleList<A> first, final AlleleList<A> second) {
+        if (first == null || second == null) {
+            throw new IllegalArgumentException("no null list allowed");
+        }
+        final int alleleCount = first.alleleCount();
+        if (alleleCount != second.alleleCount()) {
+            return false;
+        }
+
+        for (int i = 0; i < alleleCount; i++) {
+            final A firstSample = first.alleleAt(i);
+            Utils.nonNull(firstSample, "no null samples allowed in sample-lists: first list at " + i);
+            final A secondSample = second.alleleAt(i);
+            Utils.nonNull(secondSample,"no null samples allowed in sample-list: second list at " + i);
+            if (!firstSample.equals(secondSample)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolves the index of the reference allele in an allele-list.
+     *
+     * <p>
+     *     If there is no reference allele, it returns -1. If there is more than one reference allele,
+     *     it returns the first occurrence (lowest index).
+     * </p>
+     *
+     * @param list the search allele-list.
+     * @param <A> allele component type.
+     *
+     * @throws IllegalArgumentException if {@code list} is {@code null}.
+     *
+     * @return -1 if there is no reference allele, or a values in [0,{@code list.alleleCount()}).
+     */
+    public static <A extends Allele> int indexOfReference(final AlleleList<A> list) {
+        Utils.nonNull(list, "the input list cannot be null");
+        final int alleleCount = list.alleleCount();
+        for (int i = 0; i < alleleCount; i++) {
+            if (list.alleleAt(i).isReference()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+
+    /**
+     * Returns a {@link java.util.List} unmodifiable view of a allele-list
+     * @param list the sample-list to wrap.
+     *
+     * @throws IllegalArgumentException if {@code list} is {@code null}.
+     *
+     * @return never {@code null}.
+     */
+    public static <A extends Allele> List<A> asList(final AlleleList<A> list) {
+        Utils.nonNull(list, "the list cannot be null");
+        return new AsList(list);
+    }
+
+    /**
+     * Returns an unmodifiable empty allele-list.
+     * @param <A> the allele class.
+     * @return never {@code null}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <A extends Allele> AlleleList<A> emptyList() {
+        return EMPTY_LIST;
+    }
+
+    /**
+     * Simple list view of a sample-list.
+     */
+    private static final class AsList<A extends Allele> extends AbstractList<A> {
+
+        private final AlleleList<A> list;
+
+        private AsList(final AlleleList<A> list) {
+            this.list = list;
+        }
+
+        @Override
+        public A get(final int index) {
+            return list.alleleAt(index);
+        }
+
+        @Override
+        public int size() {
+            return list.alleleCount();
+        }
+    }
+
+
+    /**
+     * Returns a permutation between two allele lists.
+     * @param original the original allele list.
+     * @param target the target allele list.
+     * @param <A> the allele type.
+     *
+     * @throws IllegalArgumentException if {@code original} or {@code target} is {@code null}, or
+     * elements in {@code target} is not contained in {@code original}
+     *
+     * @return never {@code null}
+     */
+    public static <A extends Allele> AlleleListPermutation<A> permutation(final AlleleList<A> original, final AlleleList<A> target) {
+        if (equals(original,target)) {
+            return new NonPermutation<>(original);
+        } else {
+            return new ActualPermutation<>(original, target);
+        }
+    }
+
+    /**
+     * This is the identity permutation.
+     */
+    private static final class NonPermutation<A extends Allele> implements AlleleListPermutation<A> {
+
+        private final AlleleList<A> list;
+
+        public NonPermutation(final AlleleList<A> original) {
+            list = original;
+        }
+
+        @Override
+        public boolean isPartial() {
+            return false;
+        }
+
+        @Override
+        public boolean isNonPermuted() {
+            return true;
+        }
+
+        @Override
+        public int toIndex(final int fromIndex) {
+            return fromIndex;
+        }
+
+        @Override
+        public int fromIndex(final int toIndex) {
+            return toIndex;
+        }
+
+        @Override
+        public int fromSize() {
+            return list.alleleCount();
+        }
+
+        @Override
+        public int toSize() {
+            return list.alleleCount();
+        }
+
+        @Override
+        public List<A> fromList() {
+            return asList(list);
+        }
+
+        @Override
+        public java.util.List<A> toList() {
+            return asList(list);
+        }
+
+        @Override
+        public int alleleCount() {
+            return list.alleleCount();
+        }
+
+        @Override
+        public int alleleIndex(final A allele) {
+            return list.alleleIndex(allele);
+        }
+
+        @Override
+        public A alleleAt(final int index) {
+            return list.alleleAt(index);
+        }
+    }
+
+    private static final class ActualPermutation<A extends Allele> implements AlleleListPermutation<A> {
+
+        private final AlleleList<A> from;
+
+        private final AlleleList<A> to;
+
+        private final int[] fromIndex;
+
+        private final boolean nonPermuted;
+
+        private final boolean isPartial;
+
+        private ActualPermutation(final AlleleList<A> original, final AlleleList<A> target) {
+            this.from = original;
+            this.to = target;
+            final int toSize = target.alleleCount();
+            final int fromSize = original.alleleCount();
+            if (fromSize < toSize) {
+                throw new IllegalArgumentException("target allele list is not a permutation of the original allele list");
+            }
+
+            fromIndex = new int[toSize];
+            boolean nonPermuted = fromSize == toSize;
+            this.isPartial = !nonPermuted;
+            for (int i = 0; i < toSize; i++) {
+                final int originalIndex = original.alleleIndex(target.alleleAt(i));
+                if (originalIndex < 0) {
+                    throw new IllegalArgumentException("target allele list is not a permutation of the original allele list");
+                }
+                fromIndex[i] = originalIndex;
+                nonPermuted &= originalIndex == i;
+            }
+
+            this.nonPermuted = nonPermuted;
+        }
+
+        @Override
+        public boolean isPartial() {
+            return isPartial;
+        }
+
+        @Override
+        public boolean isNonPermuted() {
+            return nonPermuted;
+        }
+
+        @Override
+        public int toIndex(final int fromIndex) {
+            return to.alleleIndex(from.alleleAt(fromIndex));
+        }
+
+        @Override
+        public int fromIndex(final int toIndex) {
+            return fromIndex[toIndex];
+        }
+
+        @Override
+        public int fromSize() {
+            return from.alleleCount();
+        }
+
+        @Override
+        public int toSize() {
+            return to.alleleCount();
+        }
+
+        @Override
+        public List<A> fromList() {
+            return asList(from);
+        }
+
+        @Override
+        public List<A> toList() {
+            return asList(to);
+        }
+
+        @Override
+        public int alleleCount() {
+            return to.alleleCount();
+        }
+
+        @Override
+        public int alleleIndex(final A allele) {
+            return to.alleleIndex(allele);
+        }
+
+        @Override
+        public A alleleAt(final int index) {
+            return to.alleleAt(index);
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/IndexedAlleleList.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/IndexedAlleleList.java
@@ -1,0 +1,70 @@
+package org.broadinstitute.hellbender.utils.genotyper;
+
+import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.hellbender.utils.collections.IndexedSet;
+
+import java.util.Collection;
+
+/**
+ * Allele list implementation using and indexed-set.
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public final class IndexedAlleleList<A extends Allele> implements AlleleList<A> {
+
+    private final IndexedSet<A> alleles;
+
+    /**
+     * Constructs a new empty allele-list
+     */
+    public IndexedAlleleList() {
+        alleles = new IndexedSet<>();
+    }
+
+    /**
+     * Constructs a new allele-list from an array of alleles.
+     *
+     * <p>
+     *     Repeats in the input array will be ignored (keeping the first one). The order of alleles in the
+     *     resulting list is the same as in the natural traversal of the input collection.
+     *
+     * </p>
+     * @param alleles the original allele array
+     *
+     * @throws java.lang.IllegalArgumentException if {@code alleles} is {@code null} or contains {@code null}s.
+     */
+    public IndexedAlleleList(final A... alleles) {
+        this.alleles = new IndexedSet<>(alleles);
+    }
+
+    /**
+     * Constructs a new allele-list from a collection of alleles.
+     *
+     * <p>
+     *     Repeats in the input collection will be ignored (keeping the first one). The order of alleles in the
+     *     resulting list is the same as in the natural traversal of the input collection.
+     *
+     * </p>
+     * @param alleles the original allele collection
+     *
+     * @throws java.lang.IllegalArgumentException if {@code alleles} is {@code null} or contains {@code null}s.
+     */
+    public IndexedAlleleList(final Collection<A> alleles) {
+        this.alleles = new IndexedSet<>(alleles);
+    }
+
+    @Override
+    public int alleleCount() {
+        return alleles.size();
+    }
+
+    @Override
+    public int alleleIndex(final A allele) {
+        return alleles.indexOf(allele);
+    }
+
+    @Override
+    public A alleleAt(final int index) {
+        return alleles.get(index);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/genotyper/LikelihoodMatrix.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/genotyper/LikelihoodMatrix.java
@@ -1,0 +1,115 @@
+package org.broadinstitute.hellbender.utils.genotyper;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.hellbender.utils.genotyper.AlleleList;
+
+import java.util.List;
+
+/**
+ * Likelihood matrix between a set of alleles and reads.
+ * @param <A> the allele-type.
+ */
+public interface LikelihoodMatrix<A extends Allele> extends AlleleList<A> {
+
+    /**
+     * List of reads in the matrix sorted by their index therein.
+     * @return never {@code null}.
+     */
+    public List<SAMRecord> reads();
+
+    /**
+     * List of alleles in the matrix sorted by their index in the collection.
+     * @return never {@code null}.
+     */
+    public List<A> alleles();
+
+    /**
+     * Set the likelihood of a read given an allele through their indices.
+     *
+     * @param alleleIndex the target allele index.
+     * @param readIndex the target read index.
+     * @param value new likelihood value for the target read give the target allele.
+     *
+     * @throws IllegalArgumentException if {@code alleleIndex} or {@code readIndex}
+     *  are not valid allele and read indices respectively.
+     */
+    public void set(final int alleleIndex, final int readIndex, final double value);
+
+    /**
+     * Returns the likelihood of a read given a haplotype.
+     *
+     * @param alleleIndex the index of the given haplotype.
+     * @param readIndex the index of the target read.
+     *
+     * @throws IllegalArgumentException if {@code alleleIndex} or {@code readIndex} is not a
+     * valid allele or read index respectively.
+     *
+     * @return the requested likelihood, whatever value was provided using {@link #set(int,int,double) set}
+     *    or 0.0 if none was set.
+     */
+    public double get(final int alleleIndex, final int readIndex);
+
+    /**
+     * Queries the index of an allele in the matrix.
+     *
+     * @param allele the target allele.
+     *
+     * @throws IllegalArgumentException if {@code allele} is {@code null}.
+     * @return -1 if such allele does not exist, otherwise its index which 0 or greater.
+     */
+    public int alleleIndex(final A allele);
+
+    /**
+     * Queries the index of a read in the matrix.
+     *
+     * @param read the target read.
+     *
+     * @throws IllegalArgumentException if {@code read} is {@code null}.
+     *
+     * @return -1 if there is not such a read in the matrix, otherwise its index
+     *    which is 0 or greater.
+     */
+    public int readIndex(final SAMRecord read);
+
+    /**
+     * Number of allele in the matrix.
+     * @return never negative.
+     */
+    public int alleleCount();
+
+    /**
+     * Number of reads in the matrix.
+     * @return never negative.
+     */
+    public int readCount();
+
+    /**
+     * Returns the allele given its index.
+     *
+     * @param alleleIndex the target allele index.
+     *
+     * @throws IllegalArgumentException if {@code alleleIndex} is not a valid allele index.
+     * @return never {@code null}.
+     */
+    public A alleleAt(final int alleleIndex);
+
+    /**
+     * Returns the allele given its index.
+     *
+     * @param readIndex the target allele index.
+     *
+     * @throws IllegalArgumentException if {@code readIndex} is not a valid read index.
+     * @return never {@code null}.
+     */
+    public SAMRecord readAt(final int readIndex);
+
+
+    /**
+     * Copies the likelihood of all the reads for a given allele into an array from a particular offset.
+     * @param alleleIndex the targeted allele
+     * @param dest the destination array.
+     * @param offset the copy offset within the destination allele
+     */
+    public void copyAlleleLikelihoods(final int alleleIndex, final double[] dest, final int offset);
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/haplotype/Haplotype.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/haplotype/Haplotype.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 
 public final class Haplotype extends Allele implements HasGenomeLocation {
 
+    private static final long serialVersionUID = 1l;
+
     private GenomeLoc genomeLocation = null;
     private EventMap eventMap = null;
     private Cigar cigar;

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/Log10PairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/Log10PairHMM.java
@@ -1,0 +1,185 @@
+package org.broadinstitute.hellbender.utils.pairhmm;
+
+import org.broadinstitute.hellbender.utils.MathUtils;
+import org.broadinstitute.hellbender.utils.QualityUtils;
+
+import java.util.Arrays;
+
+import static java.lang.Math.log10;
+import static org.broadinstitute.hellbender.utils.pairhmm.PairHMMModel.*;
+
+/**
+ * Util class for performing the pair HMM for local alignment. Figure 4.3 in Durbin 1998 book.
+ */
+public final class Log10PairHMM extends N2MemoryPairHMM {
+    /**
+     * Should we use exact log10 calculation (true), or an approximation (false)?
+     */
+    private final boolean doExactLog10;
+
+
+    // we divide e by 3 because the observed base could have come from any of the non-observed alleles
+    private final static double log10_3 = log10(3.0);
+
+    /**
+     * Create an uninitialized PairHMM
+     *
+     * @param doExactLog10 should the log10 calculations be exact (slow) or approximate (faster)
+     */
+    public Log10PairHMM(final boolean doExactLog10) {
+        this.doExactLog10 = doExactLog10;
+    }
+
+    /**
+     * Is this HMM using exact log10 calculations?
+     * @return true if exact, false if approximate
+     */
+    public boolean isDoingExactLog10Calculations() {
+        return doExactLog10;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void initialize(final int readMaxLength, final int haplotypeMaxLength ) {
+        super.initialize(readMaxLength, haplotypeMaxLength);
+
+        for( int i=0; i < paddedMaxReadLength; i++ ) {
+            Arrays.fill(matchMatrix[i], Double.NEGATIVE_INFINITY);
+            Arrays.fill(insertionMatrix[i], Double.NEGATIVE_INFINITY);
+            Arrays.fill(deletionMatrix[i], Double.NEGATIVE_INFINITY);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double subComputeReadLikelihoodGivenHaplotypeLog10( final byte[] haplotypeBases,
+                                                               final byte[] readBases,
+                                                               final byte[] readQuals,
+                                                               final byte[] insertionGOP,
+                                                               final byte[] deletionGOP,
+                                                               final byte[] overallGCP,
+                                                               final int hapStartIndex,
+                                                               final boolean recacheReadValues,
+                                                               final int nextHapStartIndex) {
+
+
+        if ( ! constantsAreInitialized || recacheReadValues ) {
+            initializeProbabilities(insertionGOP, deletionGOP, overallGCP);
+        }
+        initializePriors(haplotypeBases, readBases, readQuals, hapStartIndex);
+        if (previousHaplotypeBases == null || previousHaplotypeBases.length != haplotypeBases.length) {
+            // set the initial value (free deletions in the beginning) for the first row in the deletion matrix
+            initializeMatrixValues(haplotypeBases);
+        }
+
+        for (int i = 1; i < paddedReadLength; i++) {
+            // +1 here is because hapStartIndex is 0-based, but our matrices are 1 based
+            for (int j = hapStartIndex+1; j < paddedHaplotypeLength; j++) {
+                updateCell(i, j, prior[i][j], transition[i]);
+            }
+        }
+
+        // final probability is the log10 sum of the last element in the Match and Insertion state arrays
+        // this way we ignore all paths that ended in deletions! (huge)
+        // but we have to sum all the paths ending in the M and I matrices, because they're no longer extended.
+        return finalLikelihoodCalculation();
+    }
+
+    private void initializeMatrixValues(final byte[] haplotypeBases) {
+        final double initialValue = log10(1.0 / haplotypeBases.length);
+        for( int j = 0; j < paddedHaplotypeLength; j++ ) {
+            deletionMatrix[0][j] = initialValue;
+        }
+    }
+
+    private double finalLikelihoodCalculation() {
+        final int endI = paddedReadLength - 1;
+        double finalSumProbabilities = myLog10SumLog10(new double[]{matchMatrix[endI][1], insertionMatrix[endI][1]});
+        for (int j = 2; j < paddedHaplotypeLength; j++) {
+            finalSumProbabilities = myLog10SumLog10(new double[]{finalSumProbabilities, matchMatrix[endI][j], insertionMatrix[endI][j]});
+        }
+        return finalSumProbabilities;
+    }
+
+
+    /**
+     * Initializes the matrix that holds all the constants related to the editing
+     * distance between the read and the haplotype.
+     *
+     * @param haplotypeBases the bases of the haplotype
+     * @param readBases      the bases of the read
+     * @param readQuals      the base quality scores of the read
+     * @param startIndex     where to start updating the distanceMatrix (in case this read is similar to the previous read)
+     */
+    public void initializePriors(final byte[] haplotypeBases, final byte[] readBases, final byte[] readQuals, final int startIndex) {
+
+        // initialize the pBaseReadLog10 matrix for all combinations of read x haplotype bases
+        // Java initializes arrays with 0.0, so no need to fill in rows and columns below 2.
+
+        for (int i = 0; i < readBases.length; i++) {
+            final byte x = readBases[i];
+            final byte qual = readQuals[i];
+            for (int j = startIndex; j < haplotypeBases.length; j++) {
+                final byte y = haplotypeBases[j];
+                prior[i+1][j+1] = ( x == y || x == (byte) 'N' || y == (byte) 'N' ?
+                        QualityUtils.qualToProbLog10(qual) : (QualityUtils.qualToErrorProbLog10(qual) - (doNotUseTristateCorrection ? 0.0 : log10_3)) );
+            }
+        }
+    }
+
+    /**
+     * Initializes the matrix that holds all the constants related to quality scores.
+     *
+     * @param insertionGOP   insertion quality scores of the read
+     * @param deletionGOP    deletion quality scores of the read
+     * @param overallGCP     overall gap continuation penalty
+     */
+    protected void initializeProbabilities(final byte[] insertionGOP, final byte[] deletionGOP, final byte[] overallGCP) {
+        PairHMMModel.qualToTransProbsLog10(transition,insertionGOP,deletionGOP,overallGCP);
+        // note that we initialized the constants
+        constantsAreInitialized = true;
+    }
+
+
+    /**
+     * Compute the log10SumLog10 of the values
+     *
+     * NOTE NOTE NOTE
+     *
+     * Log10PairHMM depends critically on this function tolerating values that are all -Infinity
+     * and the sum returning -Infinity.  Note good.  Needs to be fixed.
+     *
+     * NOTE NOTE NOTE
+     *
+     * @param values an array of log10 probabilities that need to be summed
+     * @return the log10 of the sum of the probabilities
+     */
+    private double myLog10SumLog10(final double[] values) {
+        return doExactLog10 ? MathUtils.log10sumLog10(values) : MathUtils.approximateLog10SumLog10(values);
+    }
+
+    /**
+     * Updates a cell in the HMM matrix
+     *
+     * The read and haplotype indices are offset by one because the state arrays have an extra column to hold the
+     * initial conditions
+
+     * @param indI             row index in the matrices to update
+     * @param indJ             column index in the matrices to update
+     * @param prior            the likelihood editing distance matrix for the read x haplotype
+     * @param transition        an array with the six transition relevant to this location
+     */
+    private void updateCell( final int indI, final int indJ, final double prior, final double[] transition) {
+
+        matchMatrix[indI][indJ] = prior +
+                myLog10SumLog10(new double[]{matchMatrix[indI - 1][indJ - 1] + transition[matchToMatch],
+                                         insertionMatrix[indI - 1][indJ - 1] + transition[indelToMatch],
+                                          deletionMatrix[indI - 1][indJ - 1] + transition[indelToMatch]});
+        insertionMatrix[indI][indJ] = myLog10SumLog10(new double[] {matchMatrix[indI - 1][indJ] + transition[matchToInsertion], insertionMatrix[indI - 1][indJ] + transition[insertionToInsertion]});
+        deletionMatrix[indI][indJ]  = myLog10SumLog10(new double[] {matchMatrix[indI][indJ - 1] + transition[matchToDeletion],  deletionMatrix[indI][indJ - 1] + transition[deletionToDeletion]});
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/LoglessPairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/LoglessPairHMM.java
@@ -1,0 +1,105 @@
+package org.broadinstitute.hellbender.utils.pairhmm;
+
+import org.broadinstitute.hellbender.utils.QualityUtils;
+
+import static org.broadinstitute.hellbender.utils.pairhmm.PairHMMModel.*;
+
+public final class LoglessPairHMM extends N2MemoryPairHMM {
+    static final double INITIAL_CONDITION = Math.pow(2, 1020);
+    static final double INITIAL_CONDITION_LOG10 = Math.log10(INITIAL_CONDITION);
+
+    // we divide e by 3 because the observed base could have come from any of the non-observed alleles
+    static final double TRISTATE_CORRECTION = 3.0;
+
+
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double subComputeReadLikelihoodGivenHaplotypeLog10( final byte[] haplotypeBases,
+                                                               final byte[] readBases,
+                                                               final byte[] readQuals,
+                                                               final byte[] insertionGOP,
+                                                               final byte[] deletionGOP,
+                                                               final byte[] overallGCP,
+                                                               final int hapStartIndex,
+                                                               final boolean recacheReadValues,
+                                                               final int nextHapStartIndex) {
+
+        if (previousHaplotypeBases == null || previousHaplotypeBases.length != haplotypeBases.length) {
+            final double initialValue = INITIAL_CONDITION / haplotypeBases.length;
+            // set the initial value (free deletions in the beginning) for the first row in the deletion matrix
+            for( int j = 0; j < paddedHaplotypeLength; j++ ) {
+                deletionMatrix[0][j] = initialValue;
+            }
+        }
+
+        if ( ! constantsAreInitialized || recacheReadValues ) {
+            initializeProbabilities(transition, insertionGOP, deletionGOP, overallGCP);
+
+            // note that we initialized the constants
+            constantsAreInitialized = true;
+        }
+
+        initializePriors(haplotypeBases, readBases, readQuals, hapStartIndex);
+
+        for (int i = 1; i < paddedReadLength; i++) {
+            // +1 here is because hapStartIndex is 0-based, but our matrices are 1 based
+            for (int j = hapStartIndex+1; j < paddedHaplotypeLength; j++) {
+                //Inlined the code from updateCell - helps JIT to detect hotspots and produce good native code
+                matchMatrix[i][j] = prior[i][j] * ( matchMatrix[i - 1][j - 1] * transition[i][matchToMatch] +
+                        insertionMatrix[i - 1][j - 1] * transition[i][indelToMatch] +
+                        deletionMatrix[i - 1][j - 1] * transition[i][indelToMatch] );
+                insertionMatrix[i][j] = matchMatrix[i - 1][j] * transition[i][matchToInsertion] + insertionMatrix[i - 1][j] * transition[i][insertionToInsertion];
+                deletionMatrix[i][j] = matchMatrix[i][j - 1] * transition[i][matchToDeletion] + deletionMatrix[i][j - 1] * transition[i][deletionToDeletion];
+            }
+        }
+
+        // final probability is the log10 sum of the last element in the Match and Insertion state arrays
+        // this way we ignore all paths that ended in deletions! (huge)
+        // but we have to sum all the paths ending in the M and I matrices, because they're no longer extended.
+        final int endI = paddedReadLength - 1;
+        double finalSumProbabilities = 0.0;
+        for (int j = 1; j < paddedHaplotypeLength; j++) {
+            finalSumProbabilities += matchMatrix[endI][j] + insertionMatrix[endI][j];
+        }
+        return Math.log10(finalSumProbabilities) - INITIAL_CONDITION_LOG10;
+    }
+
+    /**
+     * Initializes the matrix that holds all the constants related to the editing
+     * distance between the read and the haplotype.
+     *
+     * @param haplotypeBases the bases of the haplotype
+     * @param readBases      the bases of the read
+     * @param readQuals      the base quality scores of the read
+     * @param startIndex     where to start updating the distanceMatrix (in case this read is similar to the previous read)
+     */
+    void initializePriors(final byte[] haplotypeBases, final byte[] readBases, final byte[] readQuals, final int startIndex) {
+
+        // initialize the pBaseReadLog10 matrix for all combinations of read x haplotype bases
+        // Abusing the fact that java initializes arrays with 0.0, so no need to fill in rows and columns below 2.
+
+        for (int i = 0; i < readBases.length; i++) {
+            final byte x = readBases[i];
+            final byte qual = readQuals[i];
+            for (int j = startIndex; j < haplotypeBases.length; j++) {
+                final byte y = haplotypeBases[j];
+                prior[i+1][j+1] = ( x == y || x == (byte) 'N' || y == (byte) 'N' ?
+                        QualityUtils.qualToProb(qual) : (QualityUtils.qualToErrorProb(qual) / (doNotUseTristateCorrection ? 1.0 : TRISTATE_CORRECTION)) );
+            }
+        }
+    }
+
+    /**
+     * Initializes the matrix that holds all the constants related to quality scores.
+     *
+     * @param insertionGOP   insertion quality scores of the read
+     * @param deletionGOP    deletion quality scores of the read
+     * @param overallGCP     overall gap continuation penalty
+     */
+    static void initializeProbabilities(final double[][] transition, final byte[] insertionGOP, final byte[] deletionGOP, final byte[] overallGCP) {
+        PairHMMModel.qualToTransProbs(transition,insertionGOP,deletionGOP,overallGCP);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/N2MemoryPairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/N2MemoryPairHMM.java
@@ -1,0 +1,65 @@
+package org.broadinstitute.hellbender.utils.pairhmm;
+
+/**
+ * Superclass for PairHMM that want to use a full read x haplotype matrix for their match, insertion, and deletion matrix
+ */
+abstract class N2MemoryPairHMM extends PairHMM {
+    protected double[][] transition = null; // The transition probabilities cache
+    protected double[][] prior = null;      // The prior probabilities cache
+    protected double[][] matchMatrix = null;
+    protected double[][] insertionMatrix = null;
+    protected double[][] deletionMatrix = null;
+
+    @Override
+    public void doNotUseTristateCorrection() {
+        doNotUseTristateCorrection = true;
+    }
+
+    /**
+     * Initialize this PairHMM, making it suitable to run against a read and haplotype with given lengths
+     *
+     * Note: Do not worry about padding, just provide the true max length of the read and haplotype. The HMM will take care of the padding.
+     *
+     * @param haplotypeMaxLength the max length of haplotypes we want to use with this PairHMM
+     * @param readMaxLength the max length of reads we want to use with this PairHMM
+     */
+    @Override
+    public void initialize( final int readMaxLength, final int haplotypeMaxLength ) {
+        super.initialize(readMaxLength, haplotypeMaxLength);
+
+        matchMatrix = new double[paddedMaxReadLength][paddedMaxHaplotypeLength];
+        insertionMatrix = new double[paddedMaxReadLength][paddedMaxHaplotypeLength];
+        deletionMatrix = new double[paddedMaxReadLength][paddedMaxHaplotypeLength];
+
+        transition = PairHMMModel.createTransitionMatrix(maxReadLength);
+        prior = new double[paddedMaxReadLength][paddedMaxHaplotypeLength];
+    }
+
+    /**
+     * Print out the core hmm matrices for debugging
+     */
+    protected void dumpMatrices() {
+        dumpMatrix("matchMetricArray", matchMatrix);
+        dumpMatrix("insertionMatrix", insertionMatrix);
+        dumpMatrix("deletionMatrix", deletionMatrix);
+    }
+
+    /**
+     * Print out in a human readable form the matrix for debugging
+     * @param name the name of this matrix
+     * @param matrix the matrix of values
+     */
+    private void dumpMatrix(final String name, final double[][] matrix) {
+        System.out.printf("%s%n", name);
+        for ( int i = 0; i < matrix.length; i++) {
+            System.out.printf("\t%s[%d]", name, i);
+            for ( int j = 0; j < matrix[i].length; j++ ) {
+                if ( Double.isInfinite(matrix[i][j]) )
+                    System.out.printf(" %15s", String.format("%f", matrix[i][j]));
+                else
+                    System.out.printf(" % 15.5e", matrix[i][j]);
+            }
+            System.out.println();
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMM.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMM.java
@@ -1,0 +1,300 @@
+package org.broadinstitute.hellbender.utils.pairhmm;
+
+import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.variant.variantcontext.Allele;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.utils.MathUtils;
+import org.broadinstitute.hellbender.utils.genotyper.LikelihoodMatrix;
+import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+
+import java.io.Closeable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class for performing the pair HMM for local alignment. Figure 4.3 in Durbin 1998 book.
+ */
+public abstract class PairHMM implements Closeable{
+    protected final static Logger logger = LogManager.getLogger(PairHMM.class);
+
+    protected boolean constantsAreInitialized = false;
+
+    protected byte[] previousHaplotypeBases;
+    protected int hapStartIndex;
+
+    public enum HMM_IMPLEMENTATION {
+        /* Very slow implementation which uses very accurate log10 sum functions. Only meant to be used as a reference test implementation */
+        EXACT,
+        /* PairHMM as implemented for the UnifiedGenotyper. Uses log10 sum functions accurate to only 1E-4 */
+        ORIGINAL,
+        /* Optimized version of the PairHMM which caches per-read computations and operations in real space to avoid costly sums of log10'ed likelihoods */
+        LOGLESS_CACHING,
+    }
+
+    protected int maxHaplotypeLength, maxReadLength;
+    protected int paddedMaxReadLength, paddedMaxHaplotypeLength;
+    protected int paddedReadLength, paddedHaplotypeLength;
+    protected boolean initialized = false;
+
+    // only used for debugging purposes
+    protected boolean doNotUseTristateCorrection = false;
+    protected void doNotUseTristateCorrection() { doNotUseTristateCorrection = true; }
+
+    //debug array
+    protected double[] mLikelihoodArray;
+
+    //profiling information
+    protected static Boolean doProfiling = true;
+    protected static long pairHMMComputeTime = 0;
+    protected long threadLocalPairHMMComputeTimeDiff = 0;
+    protected long startTime = 0;
+
+    /**
+     * Initialize this PairHMM, making it suitable to run against a read and haplotype with given lengths
+     *
+     * Note: Do not worry about padding, just provide the true max length of the read and haplotype. The HMM will take care of the padding.
+     *
+     * @param haplotypeMaxLength the max length of haplotypes we want to use with this PairHMM
+     * @param readMaxLength the max length of reads we want to use with this PairHMM
+     * @throws IllegalArgumentException if readMaxLength or haplotypeMaxLength is less than or equal to zero
+     */
+    public void initialize( final int readMaxLength, final int haplotypeMaxLength ) throws IllegalArgumentException {
+        if ( readMaxLength <= 0 ) throw new IllegalArgumentException("READ_MAX_LENGTH must be > 0 but got " + readMaxLength);
+        if ( haplotypeMaxLength <= 0 ) throw new IllegalArgumentException("HAPLOTYPE_MAX_LENGTH must be > 0 but got " + haplotypeMaxLength);
+
+        maxHaplotypeLength = haplotypeMaxLength;
+        maxReadLength = readMaxLength;
+
+        // M, X, and Y arrays are of size read and haplotype + 1 because of an extra column for initial conditions and + 1 to consider the final base in a non-global alignment
+        paddedMaxReadLength = readMaxLength + 1;
+        paddedMaxHaplotypeLength = haplotypeMaxLength + 1;
+
+        previousHaplotypeBases = null;
+
+        constantsAreInitialized = false;
+        initialized = true;
+    }
+
+    /**
+     * Initialize this PairHMM, making it suitable to run against a read and haplotype with given lengths
+     * This function is used by the JNI implementations to transfer all data once to the native code
+     * @param haplotypes the list of haplotypes
+     * @param perSampleReadList map from sample name to list of reads
+     * @param haplotypeMaxLength the max length of haplotypes we want to use with this PairHMM
+     * @param readMaxLength the max length of reads we want to use with this PairHMM
+     */
+    public void initialize( final List<Haplotype> haplotypes, final Map<String, List<SAMRecord>> perSampleReadList, final int readMaxLength, final int haplotypeMaxLength ) {
+        initialize(readMaxLength, haplotypeMaxLength);
+    }
+
+    private static int findMaxAlleleLength(final List<? extends Allele> alleles) {
+        int max = 0;
+        for (final Allele allele : alleles) {
+            final int alleleLength = allele.length();
+            if (max < alleleLength) {
+                max = alleleLength;
+            }
+        }
+        return max;
+    }
+
+    static int findMaxReadLength(final List<SAMRecord> reads) {
+        int listMaxReadLength = 0;
+        for(final SAMRecord read : reads){
+            final int readLength = read.getReadLength();
+            if( readLength > listMaxReadLength ) {
+                listMaxReadLength = readLength;
+            }
+        }
+        return listMaxReadLength;
+    }
+
+    /**
+     *  Given a list of reads and haplotypes, for every read compute the total probability of said read arising from
+     *  each haplotype given base substitution, insertion, and deletion probabilities.
+     *
+     * @param processedReads reads to analyze instead of the ones present in the destination read-likelihoods.
+     * @param likelihoods where to store the likelihoods where position [a][r] is reserved for the likelihood of {@code reads[r]}
+     *             conditional to {@code alleles[a]}.
+     * @param gcp penalty for gap continuations base array map for processed reads.
+     *
+     * @return never {@code null}.
+     */
+    public void computeLikelihoods(final LikelihoodMatrix<Haplotype> likelihoods,
+                                   final List<SAMRecord> processedReads,
+                                   final Map<SAMRecord, byte[]> gcp) {
+        if (processedReads.isEmpty()) {
+            return;
+        }
+        if(doProfiling) {
+            startTime = System.nanoTime();
+        }
+        // (re)initialize the pairHMM only if necessary
+        final int readMaxLength = findMaxReadLength(processedReads);
+        final int haplotypeMaxLength = findMaxAlleleLength(likelihoods.alleles());
+        if (!initialized || readMaxLength > maxReadLength || haplotypeMaxLength > maxHaplotypeLength) {
+            initialize(readMaxLength, haplotypeMaxLength);
+        }
+
+        final int readCount = processedReads.size();
+        final List<Haplotype> alleles = likelihoods.alleles();
+        final int alleleCount = alleles.size();
+        mLikelihoodArray = new double[readCount * alleleCount];
+        int idx = 0;
+        int readIndex = 0;
+        for(final SAMRecord read : processedReads){
+            final byte[] readBases = read.getReadBases();
+            final byte[] readQuals = read.getBaseQualities();
+            final byte[] readInsQuals = ReadUtils.getBaseInsertionQualities(read);
+            final byte[] readDelQuals = ReadUtils.getBaseDeletionQualities(read);
+            final byte[] overallGCP = gcp.get(read);
+
+            // peak at the next haplotype in the list (necessary to get nextHaplotypeBases, which is required for caching in the array implementation)
+            final boolean isFirstHaplotype = true;
+            for (int a = 0; a < alleleCount; a++) {
+                final Allele allele = alleles.get(a);
+                final byte[] alleleBases = allele.getBases();
+                final byte[] nextAlleleBases = a == alleles.size() - 1 ? null : alleles.get(a + 1).getBases();
+                final double lk = computeReadLikelihoodGivenHaplotypeLog10(alleleBases,
+                        readBases, readQuals, readInsQuals, readDelQuals, overallGCP, isFirstHaplotype, nextAlleleBases);
+                likelihoods.set(a, readIndex, lk);
+                mLikelihoodArray[idx++] = lk;
+            }
+            readIndex++;
+        }
+        if(doProfiling) {
+            threadLocalPairHMMComputeTimeDiff = (System.nanoTime() - startTime);
+            {
+                pairHMMComputeTime += threadLocalPairHMMComputeTimeDiff;
+            }
+        }
+    }
+
+    /**
+     * Compute the total probability of read arising from haplotypeBases given base substitution, insertion, and deletion
+     * probabilities.
+     *
+     * Note on using hapStartIndex.  This allows you to compute the exact true likelihood of a full haplotypes
+     * given a read, assuming that the previous calculation read over a full haplotype, recaching the read values,
+     * starting only at the place where the new haplotype bases and the previous haplotype bases different.  This
+     * index is 0-based, and can be computed with findFirstPositionWhereHaplotypesDiffer given the two haplotypes.
+     * Note that this assumes that the read and all associated quals values are the same.
+     *
+     * @param haplotypeBases the full sequence (in standard SAM encoding) of the haplotype, must be >= than read bases in length
+     * @param readBases the bases (in standard encoding) of the read, must be <= haplotype bases in length
+     * @param readQuals the phred-scaled per base substitution quality scores of read.  Must be the same length as readBases
+     * @param insertionGOP the phred-scaled per base insertion quality scores of read.  Must be the same length as readBases
+     * @param deletionGOP the phred-scaled per base deletion quality scores of read.  Must be the same length as readBases
+     * @param overallGCP the phred-scaled gap continuation penalties scores of read.  Must be the same length as readBases
+     * @param recacheReadValues if false, we don't recalculate any cached results, assuming that readBases and its associated
+     *                          parameters are the same, and only the haplotype bases are changing underneath us
+     * @throws IllegalStateException  if did not call initialize() beforehand
+     * @throws IllegalArgumentException haplotypeBases is null or greater than maxHaplotypeLength
+     * @throws IllegalArgumentException readBases is null or greater than maxReadLength
+     * @throws IllegalArgumentException readBases, readQuals, insertionGOP, deletionGOP and overallGCP are not the same size
+     * @return the log10 probability of read coming from the haplotype under the provided error model
+     */
+    @VisibleForTesting
+    double computeReadLikelihoodGivenHaplotypeLog10( final byte[] haplotypeBases,
+                                                                  final byte[] readBases,
+                                                                  final byte[] readQuals,
+                                                                  final byte[] insertionGOP,
+                                                                  final byte[] deletionGOP,
+                                                                  final byte[] overallGCP,
+                                                                  final boolean recacheReadValues,
+                                                                  final byte[] nextHaploytpeBases) throws IllegalStateException, IllegalArgumentException {
+
+        if ( ! initialized ) throw new IllegalStateException("Must call initialize before calling computeReadLikelihoodGivenHaplotypeLog10");
+        if ( haplotypeBases == null ) throw new IllegalArgumentException("haplotypeBases cannot be null");
+        if ( haplotypeBases.length > maxHaplotypeLength ) throw new IllegalArgumentException("Haplotype bases is too long, got " + haplotypeBases.length + " but max is " + maxHaplotypeLength);
+        if ( readBases == null ) throw new IllegalArgumentException("readBases cannot be null");
+        if ( readBases.length > maxReadLength ) throw new IllegalArgumentException("readBases is too long, got " + readBases.length + " but max is " + maxReadLength);
+        if ( readQuals.length != readBases.length ) throw new IllegalArgumentException("Read bases and read quals aren't the same size: " + readBases.length + " vs " + readQuals.length);
+        if ( insertionGOP.length != readBases.length ) throw new IllegalArgumentException("Read bases and read insertion quals aren't the same size: " + readBases.length + " vs " + insertionGOP.length);
+        if ( deletionGOP.length != readBases.length ) throw new IllegalArgumentException("Read bases and read deletion quals aren't the same size: " + readBases.length + " vs " + deletionGOP.length);
+        if ( overallGCP.length != readBases.length ) throw new IllegalArgumentException("Read bases and overall GCP aren't the same size: " + readBases.length + " vs " + overallGCP.length);
+
+        paddedReadLength = readBases.length + 1;
+        paddedHaplotypeLength = haplotypeBases.length + 1;
+
+        hapStartIndex =  (recacheReadValues) ? 0 : hapStartIndex;
+
+        // Pre-compute the difference between the current haplotype and the next one to be run
+        // Looking ahead is necessary for the ArrayLoglessPairHMM implementation
+        final int nextHapStartIndex =  (nextHaploytpeBases == null || haplotypeBases.length != nextHaploytpeBases.length) ? 0 : findFirstPositionWhereHaplotypesDiffer(haplotypeBases, nextHaploytpeBases);
+
+        final double result = subComputeReadLikelihoodGivenHaplotypeLog10(haplotypeBases, readBases, readQuals, insertionGOP, deletionGOP, overallGCP, hapStartIndex, recacheReadValues, nextHapStartIndex);
+
+        if ( result > 0.0) {
+            throw new IllegalStateException("PairHMM Log Probability cannot be greater than 0: " + String.format("haplotype: %s, read: %s, result: %f, PairHMM: %s", new String(haplotypeBases), new String(readBases), result, this.getClass().getSimpleName()));
+        } else if (!MathUtils.goodLog10Probability(result)) {
+            throw new IllegalStateException("Invalid Log Probability: " + result);
+        }
+
+        // Warning: This assumes no downstream modification of the haplotype bases (saves us from copying the array). It is okay for the haplotype caller.
+        previousHaplotypeBases = haplotypeBases;
+
+        // For the next iteration, the hapStartIndex for the next haploytpe becomes the index for the current haplotype
+        // The array implementation has to look ahead to the next haplotype to store caching info. It cannot do this if nextHapStart is before hapStart
+        hapStartIndex = (nextHapStartIndex < hapStartIndex) ? 0: nextHapStartIndex;
+
+        return result;
+    }
+
+    /**
+     * To be implemented by subclasses to do calculation for #computeReadLikelihoodGivenHaplotypeLog10
+     */
+    protected abstract double subComputeReadLikelihoodGivenHaplotypeLog10( final byte[] haplotypeBases,
+                                                                           final byte[] readBases,
+                                                                           final byte[] readQuals,
+                                                                           final byte[] insertionGOP,
+                                                                           final byte[] deletionGOP,
+                                                                           final byte[] overallGCP,
+                                                                           final int hapStartIndex,
+                                                                           final boolean recacheReadValues,
+                                                                           final int nextHapStartIndex);
+
+    /**
+     * Compute the first position at which two haplotypes differ
+     *
+     * If the haplotypes are exact copies of each other, returns the min length of the two haplotypes.
+     *
+     * @param haplotype1 the first haplotype1
+     * @param haplotype2 the second haplotype1
+     * @throws IllegalArgumentException if haplotype1 or haplotype2 are null or zero length
+     * @return the index of the first position in haplotype1 and haplotype2 where the byte isn't the same
+     */
+    public static int findFirstPositionWhereHaplotypesDiffer(final byte[] haplotype1, final byte[] haplotype2) throws IllegalArgumentException {
+        if ( haplotype1 == null || haplotype1.length == 0 ) throw new IllegalArgumentException("Haplotype1 is bad " + Arrays.toString(haplotype1));
+        if ( haplotype2 == null || haplotype2.length == 0 ) throw new IllegalArgumentException("Haplotype2 is bad " + Arrays.toString(haplotype2));
+
+        for( int i = 0; i < haplotype1.length && i < haplotype2.length; i++ ) {
+            if( haplotype1[i] != haplotype2[i] ) {
+                return i;
+            }
+        }
+
+        return Math.min(haplotype1.length, haplotype2.length);
+    }
+
+    /**
+     * Return the results of the computeLikelihoods function
+     */
+    public double[] getLikelihoodArray() {
+        return mLikelihoodArray;
+    }
+
+    /**
+     * Called at the end of the program to close files, print profiling information etc 
+     */
+    @Override
+    public void close() {
+        if(doProfiling)
+            logger.info("Total compute time in PairHMM computeLikelihoods() : "+(pairHMMComputeTime*1e-9));
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMMModel.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMMModel.java
@@ -1,0 +1,423 @@
+package org.broadinstitute.hellbender.utils.pairhmm;
+
+import org.broadinstitute.hellbender.utils.MathUtils;
+import org.broadinstitute.hellbender.utils.QualityUtils;
+import org.broadinstitute.hellbender.utils.Utils;
+
+/**
+ * Helper class that implement calculations required to implement the PairHMM Finite State Automation (FSA) model.
+ */
+public final class PairHMMModel {
+
+    /**
+     * Prevents instantiation of this class
+     */
+    private PairHMMModel() {
+    }
+
+    /**
+     * Length of the standard transition probability array.
+     */
+    public static final int TRANS_PROB_ARRAY_LENGTH = 6;
+
+    /**
+     * Position in the transition probability array for the Match-to-Match transition.
+     */
+    public static final int matchToMatch = 0;
+
+    /**
+     * Position in the transition probability array for the Indel-to-Match transition.
+     */
+    public static final int indelToMatch = 1;
+
+    /**
+     * Position in the transition probability array for the Match-to-Insertion transition.
+     */
+    public static final int matchToInsertion = 2;
+
+    /**
+     * Position in the transition probability array for the Insertion-to-Insertion transition.
+     */
+    public static final int insertionToInsertion = 3;
+
+    /**
+     * Position in the transition probability array for the Match-to-Deletion transition.
+     */
+    public static final int matchToDeletion = 4;
+
+    /**
+     * Position in the transition probability array for the Deletion-to-Deletion transition.
+     */
+    public static final int deletionToDeletion = 5;
+
+    /**
+     * Convenient ln10 constant.
+     */
+    private static final double LN10 = Math.log(10);
+
+    /**
+     * Convenient (ln10)^-1 constant.
+     */
+    private static final double INV_LN10 = 1.0 / LN10;
+
+    /**
+     * Holds pre-calculated the matchToMath probability values in linear scale.
+     *
+     * <p/>
+     * This is a triangular matrix stored in a unidimentional array like so:
+     * <p/>
+     * (0,0), (0,1), (1,1), (0,2), (1,2), (2,2), (0,3) ... ({@link QualityUtils#MAX_QUAL},{@link QualityUtils#MAX_QUAL})
+     */
+    private static final double[] matchToMatchProb = new double[((QualityUtils.MAX_QUAL + 1) * (QualityUtils.MAX_QUAL + 2)) >> 1];
+
+    /**
+     * Holds pre-calculated the matchToMath probability values in log10 scale.
+     *
+     * <p/>
+     * This is a triangular matrix stored in a unidimentional array like so:
+     * <p/>
+     * (0,0), (0,1), (1,1), (0,2), (1,2), (2,2), (0,3) ... ({@link QualityUtils#MAX_QUAL},{@link QualityUtils#MAX_QUAL})
+     */
+    private static final double[] matchToMatchLog10 = new double[((QualityUtils.MAX_QUAL + 1) * (QualityUtils.MAX_QUAL + 2)) >> 1];
+
+    /**
+     * Initialize matchToMatch cache tables {@link #matchToMatch} and {@link #matchToMatchLog10}
+     */
+    static {
+        for (int i = 0, offset = 0; i <= QualityUtils.MAX_QUAL; offset += ++i)
+            for (int j = 0; j <= i; j++) {
+                final double log10Sum = MathUtils.approximateLog10SumLog10(-0.1 * i, -0.1 * j);
+                matchToMatchLog10[offset + j] =
+                        Math.log1p(-Math.min(1, Math.pow(10, log10Sum))) * INV_LN10;
+                matchToMatchProb[offset + j] = Math.pow(10, matchToMatchLog10[offset + j]);
+            }
+    }
+
+    /**
+     * Fills a transition probability array given the different quality scores affecting a read site
+     *
+     * @param insQual the insertion quality score as a byte.
+     * @param delQual the deletion quality score as a byte.
+     * @param gcp the gap-continuation-penalty score as a byte.
+     *
+     * @throws NullPointerException if {@code dest} is {@code null}.
+     * @throws ArrayIndexOutOfBoundsException if {@code dest} is not large enough.
+     * @throws IllegalArgumentException if {@code insQual}, {@code delQual} or {@code gcp} is less than negative.
+     */
+    public static void qualToTransProbs(final double[] dest, final byte insQual, final byte delQual, final byte gcp) {
+        Utils.nonNull(dest, "dest array null");
+        if (insQual < 0) throw new IllegalArgumentException("insert quality cannot less than 0: " + insQual);
+        if (delQual < 0) throw new IllegalArgumentException("deletion quality cannot be less than 0: " + delQual);
+        if (gcp < 0) throw new IllegalArgumentException("gcp cannot be less than 0: " + gcp);
+        dest[matchToMatch] = matchToMatchProb(insQual, delQual);
+        dest[matchToInsertion] = QualityUtils.qualToErrorProb(insQual);
+        dest[matchToDeletion] = QualityUtils.qualToErrorProb(delQual);
+        dest[indelToMatch] = QualityUtils.qualToProb(gcp);
+        dest[insertionToInsertion] = dest[deletionToDeletion] = QualityUtils.qualToErrorProb(gcp);
+    }
+
+    /**
+     * Returns a transition probability array given the different quality scores affecting a read site.
+     *
+     * @param insQual the insertion quality score as a byte.
+     * @param delQual the deletion quality score as a byte.
+     * @param gcp the gap-continuation-penalty score as a byte.
+     *
+     * @throws NullPointerException if {@code dest} is {@code null}.
+     * @throws ArrayIndexOutOfBoundsException if {@code dest} is not large enough.
+     * @throws IllegalArgumentException if {@code insQual}, {@code delQual} or {@code gcp} is less than negative.
+     *
+     * @return never {@code null}. An array of length {@link #TRANS_PROB_ARRAY_LENGTH}.
+     */
+    public static double[] qualToTransProbs(final byte insQual, final byte delQual, final byte gcp) {
+        final double[] dest = new double[TRANS_PROB_ARRAY_LENGTH];
+        qualToTransProbs(dest,insQual,delQual,gcp);
+        return dest;
+    }
+
+    /**
+     * Fills ax matrix with the transition probabilities for a number of bases.
+     *
+     * <p/>
+     * The first dimension of the matrix correspond to the different bases where the first one is stored in position 1.
+     * Thus the position 0 is left empty and the length of the resulting matrix is actually {@code insQual.length + 1}.
+     * <p/>
+     * Each entry is the transition probability array for that base with a length of {@link #TRANS_PROB_ARRAY_LENGTH}.
+     *
+     * @param dest the matrix to update
+     * @param insQuals insertion qualities.
+     * @param delQuals deletion qualities.
+     * @param gcps gap-continuation penalty qualities.
+     *
+     * @throws NullPointerException if any of the input arrays, matrices is {@code null} or any entry in {@code dest} is {@code null}.
+     * @throws IllegalArgumentException if {@code IllegalArgumentException}
+     *  if the input array don't have the same length.
+     * @throws ArrayIndexOutOfBoundsException if {@code dest} or any of its elements is not large enough to contain the
+     *  transition  matrix.
+     */
+    public static void qualToTransProbs(final double[][] dest, final byte[] insQuals, final byte[] delQuals, final byte[] gcps) {
+        Utils.nonNull(dest,     "dest array null");
+        Utils.nonNull(insQuals, "insQuals array null");
+        Utils.nonNull(delQuals, "delQuals array null");
+        Utils.nonNull(gcps,     "gcps array null");
+
+        final int readLength = insQuals.length;
+        if (delQuals.length != readLength) throw new IllegalArgumentException("deletion quality array length does not match insert quality array length: " + readLength + " != " + delQuals.length);
+        if (gcps.length != readLength) throw new IllegalArgumentException("deletion quality array length does not match insert quality array length: " + readLength + " != " + gcps.length);
+        if (dest.length < readLength + 1) throw new IllegalArgumentException("destination length is not enough for the read length: " + dest.length + " < " + readLength + " + 1");
+
+        for (int i = 0; i < readLength; i++) {
+            qualToTransProbs(dest[i + 1], insQuals[i], delQuals[i], gcps[i]);
+        }
+    }
+
+    /**
+     * Returns a matrix with the transition probabilities for a number of bases.
+     *
+     * <p/>
+     * The first dimension of the matrix correspond to the different bases where the first one is stored in position 1.
+     * Thus the position 0 is left empty and the length of the resulting matrix is actually {@code insQual.length + 1}.
+     * <p/>
+     * Each entry is the transition probability array for that base with a length of {@link #TRANS_PROB_ARRAY_LENGTH}.
+     *
+     * @param insQuals insertion qualities.
+     * @param delQuals deletion qualities.
+     * @param gcps gap-continuation penalty qualities.
+     *
+     * @throws NullPointerException if any of the input arrays is {@code null}.
+     * @throws IllegalArgumentException if {@code IllegalArgumentException}
+     *  if the input array don't have the same length.
+     *
+     * @return never {@code null}, an matrix of the dimensions explained above.
+     */
+    public static double[][] qualToTransProbs(final byte[] insQuals, final byte[] delQuals, final byte[] gcps) {
+        Utils.nonNull(insQuals, "insQuals array null");
+        Utils.nonNull(delQuals, "delQuals array null");
+        Utils.nonNull(gcps,     "gcps array null");
+
+        final double[][] dest = createTransitionMatrix(insQuals.length);
+        qualToTransProbs(dest,insQuals,delQuals,gcps);
+        return dest;
+    }
+
+    /**
+     * Fills a transition log10 probability array given the different quality scores affecting a read site.
+     *
+     * @param insQual the insertion quality score as a byte.
+     * @param delQual the deletion quality score as a byte.
+     * @param gcp the gap-continuation-penalty score as a byte.
+     *
+     * @throws NullPointerException if {@code dest} is {@code null}.
+     * @throws ArrayIndexOutOfBoundsException if {@code dest} is not large enough.
+     * @throws IllegalArgumentException if {@code insQual}, {@code delQual} or {@code gcp} is less than negative.
+     */
+    public static void qualToTransProbsLog10(final double[] dest, final byte insQual, final byte delQual, final byte gcp) {
+        Utils.nonNull(dest, "dest array null");
+        if (insQual < 0) throw new IllegalArgumentException("insert quality cannot less than 0: " + insQual);
+        if (delQual < 0) throw new IllegalArgumentException("deletion quality cannot be less than 0: " + delQual);
+        if (gcp < 0) throw new IllegalArgumentException("gcp cannot be less than 0: " + gcp);
+        dest[matchToMatch] = matchToMatchProbLog10(insQual, delQual);
+        dest[matchToInsertion] = QualityUtils.qualToErrorProbLog10(insQual);
+        dest[matchToDeletion] = QualityUtils.qualToErrorProbLog10(delQual);
+        dest[indelToMatch] = QualityUtils.qualToProbLog10(gcp);
+        dest[insertionToInsertion] = QualityUtils.qualToErrorProbLog10(gcp);
+        dest[deletionToDeletion] = QualityUtils.qualToErrorProbLog10(gcp);
+    }
+
+    /**
+     * Returns a transition log10 probability array given the different quality scores affecting a read site.
+     *
+     * @param insQual the insertion quality score as a byte.
+     * @param delQual the deletion quality score as a byte.
+     * @param gcp the gap-continuation-penalty score as a byte.
+     *
+     * @throws NullPointerException if {@code dest} is {@code null}.
+     * @throws ArrayIndexOutOfBoundsException if {@code dest} is not large enough.
+     * @throws IllegalArgumentException if {@code insQual}, {@code delQual} or {@code gcp} is less than negative.
+     *
+     * @return never {@code null}. An array of length {@link #TRANS_PROB_ARRAY_LENGTH}.
+     */
+    public static double[] qualToTransProbsLog10(final byte insQual, final byte delQual, final byte gcp) {
+        final double[] dest = new double[TRANS_PROB_ARRAY_LENGTH];
+        qualToTransProbsLog10(dest,insQual,delQual,gcp);
+        return dest;
+    }
+
+    /**
+     * Fills a matrix with the log10 transition probabilities for a number of bases.
+     *
+     * <p/>
+     * The first dimension of the matrix correspond to the different bases where the first one is stored in position 1.
+     * Thus the position 0 is left empty and the length of the resulting matrix is actually {@code insQual.length + 1}.
+     * <p/>
+     * Each entry is the transition probability array for that base with a length of {@link #TRANS_PROB_ARRAY_LENGTH}.
+     *
+     * @param insQuals insertion qualities.
+     * @param delQuals deletion qualities.
+     * @param gcps gap-continuation penalty qualities.
+     *
+     * @throws NullPointerException if any of the input arrays, matrices is {@code null} or any entry in {@code dest} is {@code null}.
+     * @throws IllegalArgumentException if {@code IllegalArgumentException}
+     *  if the input array don't have the same length.
+     * @throws ArrayIndexOutOfBoundsException if {@code dest} or any of its elements is not large enough to contain the
+     *  transition  matrix.
+     */
+    public static void qualToTransProbsLog10(final double[][] dest, final byte[] insQuals, final byte[] delQuals, final byte[] gcps) {
+        Utils.nonNull(dest,     "dest array null");
+        Utils.nonNull(insQuals, "insQuals array null");
+        Utils.nonNull(delQuals, "delQuals array null");
+        Utils.nonNull(gcps,     "gcps array null");
+
+        final int readLength = insQuals.length;
+        if (delQuals.length != readLength) throw new IllegalArgumentException("deletion quality array length does not match insert quality array length: " + readLength + " != " + delQuals.length);
+        if (gcps.length != readLength) throw new IllegalArgumentException("deletion quality array length does not match insert quality array length: " + readLength + " != " + gcps.length);
+        if (dest.length < readLength + 1) throw new IllegalArgumentException("destination length is not enough for the read length: " + dest.length + " < " + readLength + " + 1");
+
+        for (int i = 0; i < readLength; i++) {
+            qualToTransProbsLog10(dest[i + 1], insQuals[i], delQuals[i], gcps[i]);
+        }
+    }
+
+    /**
+     * Returns a matrix with the log10 transition probabilities for a number of bases.
+     *
+     * <p/>
+     * The first dimension of the matrix correspond to the different bases where the first one is stored in position 1.
+     * Thus the position 0 is left empty and the length of the resulting matrix is actually {@code insQual.length + 1}.
+     * <p/>
+     * Each entry is the transition probability array for that base with a length of {@link #TRANS_PROB_ARRAY_LENGTH}.
+     *
+     * @param insQuals insertion qualities.
+     * @param delQuals deletion qualities.
+     * @param gcps gap-continuation penalty qualities.
+     *
+     * @throws NullPointerException if any of the input arrays is {@code null}.
+     * @throws IllegalArgumentException if {@code IllegalArgumentException}
+     *  if the input array don't have the same length.
+     *
+     * @return never {@code null}, an matrix of the dimensions explained above.
+     */
+    public static double[][] qualToTransProbsLog10(final byte[] insQuals, final byte[] delQuals, final byte[] gcps) {
+        Utils.nonNull(insQuals, "insQuals array null");
+        Utils.nonNull(delQuals, "delQuals array null");
+        Utils.nonNull(gcps,     "gcps array null");
+
+        final double[][] dest = createTransitionMatrix(insQuals.length);
+        qualToTransProbsLog10(dest,insQuals,delQuals,gcps);
+        return dest;
+    }
+
+    /**
+     * Creates a transition probability matrix large enough to work with sequences of a particular length.
+     *
+     * @param maxReadLength the maximum read length for the transition matrix.
+     *
+     * @return never {@code null}. A matrix of {@code maxReadLength + 1} by {@link #TRANS_PROB_ARRAY_LENGTH} positions.
+     */
+    public static double[][] createTransitionMatrix(final int maxReadLength) {
+        return new double[maxReadLength + 1][TRANS_PROB_ARRAY_LENGTH];
+    }
+
+    /**
+     * Returns the probability that neither of two event takes place.
+     * <p/>
+     *
+     * We assume that both event never occur together and that delQual is the conditional probability
+     * (qual. encoded) of the second event, given the first event didn't took place. So that the
+     * probability of no event is: <br/>
+     *
+     * We assume that both event never occur together so that the probability of no event is: <br/>
+     *
+     * <code>1 - ProbErr(insQual) - ProbErr(delQual)</code> <br/>
+     *
+     * @param insQual PhRED scaled quality/probability of the first event.
+     * @param delQual PhRED scaled quality/probability of the second event.
+     *
+     * @return a value between 0 and 1.
+     */
+    public static double matchToMatchProb(final byte insQual, final byte delQual) {
+        return matchToMatchProb((insQual & 0xFF), (delQual & 0xFF));
+    }
+
+    /**
+     * Returns the probability (log 10 scaled) that neither of two event, insertion and deletion, takes place.
+     * <p/>
+     *
+     * We assume that both event never occur together so that the probability of no event is: <br/>
+     *
+     * <code>1 - ProbErr(insQual) - ProbErr(delQual)</code> <br/>
+     *
+     * @param insQual PhRED scaled quality/probability of an insertion.
+     * @param delQual PhRED scaled quality/probability of a deletion.
+     *
+     * @return a value between 0 and -Inf.
+     */
+    public static double matchToMatchProbLog10(final byte insQual, final byte delQual) {
+        return matchToMatchProbLog10((insQual & 0xFF), (delQual & 0xFF));
+    }
+
+    /**
+     * Returns the probability that neither of two events, insertion and deletion, takes place.
+     * <p/>
+     *
+     * We assume that both event never occur together and that delQual is the conditional probability
+     * (qual. encoded) of the second event, given the first event didn't took place. So that the
+     * probability of no event is: <br/>
+     *
+     * We assume that both event never occur together so that the probability of no event is: <br/>
+     *
+     * <code>1 - ProbErr(insQual) - ProbErr(delQual)</code> <br/>
+     *
+     * @param insQual PhRED scaled quality/probability of an insertion.
+     * @param delQual PhRED scaled quality/probability of a deletion.
+     * @return a value between 0 and 1.
+     */
+    public static double matchToMatchProb(final int insQual, final int delQual) {
+        final int minQual;
+        final int maxQual;
+        if (insQual <= delQual) {
+            minQual = insQual;
+            maxQual = delQual;
+        } else {
+            minQual = delQual;
+            maxQual = insQual;
+        }
+
+        if (minQual < 0) throw new IllegalArgumentException("quality cannot be negative: " + minQual + " and " + maxQual);
+
+        return (QualityUtils.MAX_QUAL < maxQual) ?  1.0 - Math.pow(10, MathUtils.approximateLog10SumLog10(-0.1 * minQual, -0.1 * maxQual)) :
+                matchToMatchProb[((maxQual * (maxQual + 1)) >> 1) + minQual];
+    }
+
+    /**
+     * Returns the probability (log 10 scaled) that neither of two event takes place.
+     * <p/>
+     *
+     * We assume that both event never occur together and that delQual is the conditional probability (qual. encoded)
+     * of the second event, given the first event didn't took place. So that the probability of no event is: <br/>
+     *
+     * We assume that both event never occur together so that the probability of no event is: <br/>
+     *
+     * <code>1 - ProbErr(insQual) - ProbErr(delQual)</code> <br/>
+     *
+     * @param insQual PhRED scaled quality/probability of an insertion.
+     * @param delQual PhRED scaled quality/probability of a deletion.
+     *
+     * @return a value between 0 and -Inf.
+     */
+    public static double matchToMatchProbLog10(final int insQual, final int delQual) {
+        final int minQual;
+        final int maxQual;
+        if (insQual <= delQual) {
+            minQual = insQual;
+            maxQual = delQual;
+        } else {
+            minQual = delQual;
+            maxQual = insQual;
+        }
+        return (QualityUtils.MAX_QUAL < maxQual) ? Math.log1p (
+                -Math.min(1, Math.pow(10,
+                        MathUtils.approximateLog10SumLog10(-.1 * minQual, -.1 * maxQual)))) * INV_LN10 :
+                matchToMatchLog10[((maxQual * (maxQual + 1)) >> 1) + minQual];
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/AlignmentUtils.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMRecord;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
 import org.broadinstitute.hellbender.utils.pileup.PileupElement;
 
 import java.util.*;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialSAMUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ArtificialSAMUtils.java
@@ -178,11 +178,11 @@ public final class ArtificialSAMUtils {
     }
 
     public static SAMRecord createArtificialRead(Cigar cigar) {
-        int length = cigar.getReadLength();
-        byte [] base = {'A'};
-        byte [] qual = {30};
-        byte [] bases = Utils.arrayFromArrayWithLength(base, length);
-        byte [] quals = Utils.arrayFromArrayWithLength(qual, length);
+        final int length = cigar.getReadLength();
+        final byte base = 'A';
+        final byte qual = 30;
+        final byte [] bases = Utils.dupBytes(base, length);
+        final byte [] quals = Utils.dupBytes(qual, length);
         SAMFileHeader header = ArtificialSAMUtils.createArtificialSamHeader();
         return ArtificialSAMUtils.createArtificialRead(header, "default_read", 0, 10000, bases, quals, cigar.toString());
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -236,9 +236,27 @@ public abstract class BaseTest {
 
     private static final double DEFAULT_FLOAT_TOLERANCE = 1e-1;
 
+
+    /**
+     * Checks whether two double array contain the same values or not.
+     * @param actual actual produced array.
+     * @param expected expected array.
+     * @param tolerance maximum difference between double value to be consider equivalent.
+     */
+    protected static void assertEqualsDoubleArray(final double[] actual, final double[] expected, final double tolerance) {
+        if (expected == null)
+            Assert.assertNull(actual);
+        else {
+            Assert.assertNotNull(actual);
+            Assert.assertEquals(actual.length,expected.length,"array length");
+        }
+        for (int i = 0; i < actual.length; i++)
+            Assert.assertEquals(actual[i],expected[i],tolerance,"array position " + i);
+    }
+
     public static void assertEqualsDoubleSmart(final Object actual, final Double expected, final double tolerance) {
         Assert.assertTrue(actual instanceof Double, "Not a double");
-        assertEqualsDoubleSmart((double)(Double)actual, (double)expected, tolerance);
+        assertEqualsDoubleSmart((double) (Double) actual, (double) expected, tolerance);
     }
 
     public static void assertEqualsDoubleSmart(final double actual, final double expected) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/ReadClipperTestUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/ReadClipperTestUtils.java
@@ -5,6 +5,7 @@ import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.ArtificialSAMUtils;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -46,7 +47,15 @@ public final class ReadClipperTestUtils {
         if (readLength >= -lengthChange) {
             readLength += lengthChange;
         }
-        return ArtificialSAMUtils.createArtificialRead(Utils.arrayFromArrayWithLength(BASES, readLength), Utils.arrayFromArrayWithLength(QUALS, readLength), cigar.toString());
+        return ArtificialSAMUtils.createArtificialRead(arrayFromArrayWithLength(BASES, readLength), arrayFromArrayWithLength(QUALS, readLength), cigar.toString());
+    }
+
+    private static byte [] arrayFromArrayWithLength(final byte[] array, final int length) {
+        final byte [] output = new byte[length];
+        for (int j = 0; j < length; j++) {
+            output[j] = array[(j % array.length)];
+        }
+        return output;
     }
 
     /**
@@ -85,7 +94,7 @@ public final class ReadClipperTestUtils {
         LinkedList<Cigar> cigarList = new LinkedList<>();
         byte[] cigarCombination = new byte[maximumCigarElements];
 
-        Utils.fillArrayWithByte(cigarCombination, (byte) 0);               // we start off with all 0's in the combination array.
+        Arrays.fill(cigarCombination, (byte) 0);
         int currentIndex = 0;
         while (true) {
             Cigar cigar = createCigarFromCombination(cigarCombination, cigarElements);    // create the cigar

--- a/src/test/java/org/broadinstitute/hellbender/utils/MathUtilsUnitTests.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/MathUtilsUnitTests.java
@@ -8,6 +8,10 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+
+import static java.lang.Math.log10;
+
 /**
  * Basic unit test for MathUtils
  */
@@ -19,6 +23,30 @@ public final class MathUtilsUnitTests {
     public void init() {
     }
 
+    @Test
+    public void testGoodProbability(){
+        Assert.assertTrue(MathUtils.goodLog10Probability(log10(0.1)));
+        Assert.assertTrue(MathUtils.goodLog10Probability(log10(0.1), true));
+        Assert.assertTrue(MathUtils.goodLog10Probability(log10(0.1), false));
+        Assert.assertTrue(MathUtils.goodLog10Probability(Double.NEGATIVE_INFINITY));
+        Assert.assertTrue(MathUtils.goodLog10Probability(Double.NEGATIVE_INFINITY, true));
+        Assert.assertFalse(MathUtils.goodLog10Probability(Double.NEGATIVE_INFINITY, false));
+        Assert.assertTrue(MathUtils.goodProbability(0.1));
+        Assert.assertTrue(MathUtils.goodProbability(0.0));
+        Assert.assertTrue(MathUtils.goodProbability(1.0));
+        Assert.assertFalse(MathUtils.goodProbability(-1.0));
+        Assert.assertFalse(MathUtils.goodProbability(2.0));
+        Assert.assertFalse(MathUtils.goodProbability(Double.NaN));
+        Assert.assertFalse(MathUtils.goodProbability(Double.NEGATIVE_INFINITY));
+        Assert.assertFalse(MathUtils.goodProbability(Double.POSITIVE_INFINITY));
+    }
+
+    @Test
+    public void testLog10OneMinusX(){
+        Assert.assertEquals(-0.04575749056, MathUtils.log10OneMinusX(0.1), 1e-6); //result from worlphram alpha
+        Assert.assertEquals(0.0, MathUtils.log10OneMinusX(0.0), 1e-6);
+        Assert.assertEquals(Double.NEGATIVE_INFINITY, MathUtils.log10OneMinusX(1.0), 1e-6);
+    }
 
     @Test
     public void testLog10Gamma() {
@@ -30,21 +58,36 @@ public final class MathUtilsUnitTests {
     }
 
     @Test
+    public void testBinomialProbability() {
+        Assert.assertEquals(MathUtils.binomialProbability(3, 2, 0.5), 0.375, 0.0001);
+        Assert.assertEquals(MathUtils.binomialProbability(100, 10, 0.5), 1.365543e-17, 1e-18);
+        Assert.assertEquals(MathUtils.binomialProbability(217, 73, 0.02), 4.521904e-67, 1e-68);
+        Assert.assertEquals(MathUtils.binomialProbability(300, 100, 0.02), 9.27097e-91, 1e-92);
+        Assert.assertEquals(MathUtils.binomialProbability(300, 150, 0.98), 6.462892e-168, 1e-169);
+        Assert.assertEquals(MathUtils.binomialProbability(300, 120, 0.98), 3.090054e-221, 1e-222);
+        Assert.assertEquals(MathUtils.binomialProbability(300, 112, 0.98), 2.34763e-236, 1e-237);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBinomialProbabilityError() {
+        Assert.assertEquals(MathUtils.binomialProbability(3, 2, 1.5), 0.375, 0.0001);
+    }
+
+    @Test
     public void testLog10BinomialCoefficient() {
-        logger.warn("Executing testLog10BinomialCoefficient");
         // note that we can test the binomial coefficient calculation indirectly via Newton's identity
         // (1+z)^m = sum (m choose k)z^k
-        double[] z_vals = new double[]{0.999,0.9,0.8,0.5,0.2,0.01,0.0001};
-        int[] exponent = new int[]{5,15,25,50,100};
-        for ( double z : z_vals ) {
-            double logz = Math.log10(z);
-            for ( int exp : exponent ) {
-                double expected_log = exp*Math.log10(1+z);
-                double[] newtonArray_log = new double[1+exp];
-                for ( int k = 0 ; k <= exp; k++ ) {
-                    newtonArray_log[k] = MathUtils.log10BinomialCoefficient(exp,k)+k*logz;
+        double[] z_vals = new double[]{0.999, 0.9, 0.8, 0.5, 0.2, 0.01, 0.0001};
+        int[] exponent = new int[]{5, 15, 25, 50, 100};
+        for (double z : z_vals) {
+            double logz = log10(z);
+            for (int exp : exponent) {
+                double expected_log = exp * log10(1 + z);
+                double[] newtonArray_log = new double[1 + exp];
+                for (int k = 0; k <= exp; k++) {
+                    newtonArray_log[k] = MathUtils.log10BinomialCoefficient(exp, k) + k * logz;
                 }
-                Assert.assertEquals(MathUtils.log10sumLog10(newtonArray_log),expected_log,1e-6);
+                Assert.assertEquals(MathUtils.log10sumLog10(newtonArray_log), expected_log, 1e-6);
             }
         }
 
@@ -53,71 +96,214 @@ public final class MathUtilsUnitTests {
         Assert.assertEquals(MathUtils.log10BinomialCoefficient(103928, 119), 400.2156, 1e-4);
     }
 
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLog10BinomialCoefficientErrorN() {
+        Assert.assertEquals(MathUtils.log10BinomialCoefficient(-4, 2), 0.7781513, 1e-6);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLog10BinomialCoefficientErrorK() {
+        Assert.assertEquals(MathUtils.log10BinomialCoefficient(4, -2), 0.7781513, 1e-6);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLog10BinomialCoefficientErrorKmoreThanN() {
+        Assert.assertEquals(MathUtils.log10BinomialCoefficient(2, 4), 0.7781513, 1e-6);
+    }
+
+    @Test
+    public void testApproximateLog10SumLog10() {
+
+        final double requiredPrecision = 1E-4;
+
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{0.0}), 0.0, requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-5.15}), -5.15, requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{130.0}), 130.0, requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-0.145}), -0.145, requiredPrecision);
+
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(0.0, 0.0), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-1.0, 0.0), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(0.0, -1.0), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, -1.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-2.2, -3.5), log10(Math.pow(10.0, -2.2) + Math.pow(10.0, -3.5)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-1.0, -7.1), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, -7.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(5.0, 6.2), log10(Math.pow(10.0, 5.0) + Math.pow(10.0, 6.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(38.1, 16.2), log10(Math.pow(10.0, 38.1) + Math.pow(10.0, 16.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-38.1, 6.2), log10(Math.pow(10.0, -38.1) + Math.pow(10.0, 6.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-19.1, -37.1), log10(Math.pow(10.0, -19.1) + Math.pow(10.0, -37.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-29.1, -27.6), log10(Math.pow(10.0, -29.1) + Math.pow(10.0, -27.6)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-0.12345, -0.23456), log10(Math.pow(10.0, -0.12345) + Math.pow(10.0, -0.23456)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-15.7654, -17.0101), log10(Math.pow(10.0, -15.7654) + Math.pow(10.0, -17.0101)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-0.12345, Double.NEGATIVE_INFINITY), -0.12345, requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-15.7654, Double.NEGATIVE_INFINITY), -15.7654, requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(Double.NEGATIVE_INFINITY, -15.7654), -15.7654, requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(Double.NEGATIVE_INFINITY,Double.NEGATIVE_INFINITY), Double.NEGATIVE_INFINITY, requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(Double.POSITIVE_INFINITY,Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY, requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(Double.POSITIVE_INFINITY,Double.NEGATIVE_INFINITY), Double.POSITIVE_INFINITY, requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(Double.NEGATIVE_INFINITY,Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY, requiredPrecision);
+
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{0.0, 0.0}), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-1.0, 0.0}), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{0.0, -1.0}), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, -1.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-2.2, -3.5}), log10(Math.pow(10.0, -2.2) + Math.pow(10.0, -3.5)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-1.0, -7.1}), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, -7.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{5.0, 6.2}), log10(Math.pow(10.0, 5.0) + Math.pow(10.0, 6.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{38.1, 16.2}), log10(Math.pow(10.0, 38.1) + Math.pow(10.0, 16.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-38.1, 6.2}), log10(Math.pow(10.0, -38.1) + Math.pow(10.0, 6.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-19.1, -37.1}), log10(Math.pow(10.0, -19.1) + Math.pow(10.0, -37.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-29.1, -27.6}), log10(Math.pow(10.0, -29.1) + Math.pow(10.0, -27.6)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-0.12345, -0.23456}), log10(Math.pow(10.0, -0.12345) + Math.pow(10.0, -0.23456)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-15.7654, -17.0101}), log10(Math.pow(10.0, -15.7654) + Math.pow(10.0, -17.0101)), requiredPrecision);
+
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{0.0, 0.0, 0.0}), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-1.0, 0.0, 0.0}), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{0.0, -1.0, -2.5}), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, -1.0) + Math.pow(10.0, -2.5)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-2.2, -3.5, -1.1}), log10(Math.pow(10.0, -2.2) + Math.pow(10.0, -3.5) + Math.pow(10.0, -1.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-1.0, -7.1, 0.5}), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, -7.1) + Math.pow(10.0, 0.5)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{5.0, 6.2, 1.3}), log10(Math.pow(10.0, 5.0) + Math.pow(10.0, 6.2) + Math.pow(10.0, 1.3)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{38.1, 16.2, 18.1}), log10(Math.pow(10.0, 38.1) + Math.pow(10.0, 16.2) + Math.pow(10.0, 18.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-38.1, 6.2, 26.6}), log10(Math.pow(10.0, -38.1) + Math.pow(10.0, 6.2) + Math.pow(10.0, 26.6)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-19.1, -37.1, -45.1}), log10(Math.pow(10.0, -19.1) + Math.pow(10.0, -37.1) + Math.pow(10.0, -45.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-29.1, -27.6, -26.2}), log10(Math.pow(10.0, -29.1) + Math.pow(10.0, -27.6) + Math.pow(10.0, -26.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-0.12345, -0.23456, -0.34567}), log10(Math.pow(10.0, -0.12345) + Math.pow(10.0, -0.23456) + Math.pow(10.0, -0.34567)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(new double[]{-15.7654, -17.0101, -17.9341}), log10(Math.pow(10.0, -15.7654) + Math.pow(10.0, -17.0101) + Math.pow(10.0, -17.9341)), requiredPrecision);
+
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(0.0, 0.0, 0.0), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-1.0, 0.0, 0.0), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(0.0, -1.0, -2.5), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, -1.0) + Math.pow(10.0, -2.5)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-2.2, -3.5, -1.1), log10(Math.pow(10.0, -2.2) + Math.pow(10.0, -3.5) + Math.pow(10.0, -1.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-1.0, -7.1, 0.5), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, -7.1) + Math.pow(10.0, 0.5)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(5.0, 6.2, 1.3), log10(Math.pow(10.0, 5.0) + Math.pow(10.0, 6.2) + Math.pow(10.0, 1.3)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(38.1, 16.2, 18.1), log10(Math.pow(10.0, 38.1) + Math.pow(10.0, 16.2) + Math.pow(10.0, 18.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-38.1, 6.2, 26.6), log10(Math.pow(10.0, -38.1) + Math.pow(10.0, 6.2) + Math.pow(10.0, 26.6)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-19.1, -37.1, -45.1), log10(Math.pow(10.0, -19.1) + Math.pow(10.0, -37.1) + Math.pow(10.0, -45.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-29.1, -27.6, -26.2), log10(Math.pow(10.0, -29.1) + Math.pow(10.0, -27.6) + Math.pow(10.0, -26.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-0.12345, -0.23456, -0.34567), log10(Math.pow(10.0, -0.12345) + Math.pow(10.0, -0.23456) + Math.pow(10.0, -0.34567)), requiredPrecision);
+        Assert.assertEquals(MathUtils.approximateLog10SumLog10(-15.7654, -17.0101, -17.9341), log10(Math.pow(10.0, -15.7654) + Math.pow(10.0, -17.0101) + Math.pow(10.0, -17.9341)), requiredPrecision);
+
+        // magnitude of the sum doesn't matter, so we can combinatorially test this via partitions of unity
+        double[] mult_partitionFactor = new double[]{0.999, 0.98, 0.95, 0.90, 0.8, 0.5, 0.3, 0.1, 0.05, 0.001};
+        int[] n_partitions = new int[]{2, 4, 8, 16, 32, 64, 128, 256, 512, 1028};
+        for (double alpha : mult_partitionFactor) {
+            double log_alpha = log10(alpha);
+            double log_oneMinusAlpha = log10(1 - alpha);
+            for (int npart : n_partitions) {
+                double[] multiplicative = new double[npart];
+                double[] equal = new double[npart];
+                double remaining_log = 0.0;  // realspace = 1
+                for (int i = 0; i < npart - 1; i++) {
+                    equal[i] = -log10(npart);
+                    double piece = remaining_log + log_alpha; // take a*remaining, leaving remaining-a*remaining = (1-a)*remaining
+                    multiplicative[i] = piece;
+                    remaining_log = remaining_log + log_oneMinusAlpha;
+                }
+                equal[npart - 1] = -log10(npart);
+                multiplicative[npart - 1] = remaining_log;
+                Assert.assertEquals(MathUtils.approximateLog10SumLog10(equal), 0.0, requiredPrecision, String.format("Did not sum to one: k=%d equal partitions.", npart));
+                Assert.assertEquals(MathUtils.approximateLog10SumLog10(multiplicative), 0.0, requiredPrecision, String.format("Did not sum to one: k=%d multiplicative partitions with alpha=%f", npart, alpha));
+            }
+        }
+    }
+
     @Test
     public void testLog10sumLog10() {
         final double requiredPrecision = 1E-14;
 
         final double log3 = 0.477121254719662;
         Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0, 0.0, 0.0}), log3, requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {0.0, 0.0, 0.0}, 0), log3, requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0, 0.0, 0.0}, 0), log3, requiredPrecision);
         Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0, 0.0, 0.0}, 0, 3), log3, requiredPrecision);
 
         final double log2 = 0.301029995663981;
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {0.0, 0.0, 0.0}, 0, 2), log2, requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {0.0, 0.0, 0.0}, 0, 1), 0.0, requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0, 0.0, 0.0}, 0, 2), log2, requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0, 0.0, 0.0}, 0, 1), 0.0, requiredPrecision);
 
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {0.0}), 0.0, requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-5.15}), -5.15, requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {130.0}), 130.0, requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-0.145}), -0.145, requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0}), 0.0, requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-5.15}), -5.15, requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{130.0}), 130.0, requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-0.145}), -0.145, requiredPrecision);
 
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {0.0, 0.0}), Math.log10(Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-1.0, 0.0}), Math.log10(Math.pow(10.0, -1.0) + Math.pow(10.0, 0.0)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {0.0, -1.0}), Math.log10(Math.pow(10.0, 0.0) + Math.pow(10.0, -1.0)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-2.2, -3.5}), Math.log10(Math.pow(10.0, -2.2) + Math.pow(10.0, -3.5)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-1.0, -7.1}), Math.log10(Math.pow(10.0, -1.0) + Math.pow(10.0, -7.1)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {5.0, 6.2}), Math.log10(Math.pow(10.0, 5.0) + Math.pow(10.0, 6.2)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {38.1, 16.2}), Math.log10(Math.pow(10.0, 38.1) + Math.pow(10.0, 16.2)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-38.1, 6.2}), Math.log10(Math.pow(10.0, -38.1) + Math.pow(10.0, 6.2)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-19.1, -37.1}), Math.log10(Math.pow(10.0, -19.1) + Math.pow(10.0, -37.1)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-29.1, -27.6}), Math.log10(Math.pow(10.0, -29.1) + Math.pow(10.0, -27.6)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-0.12345, -0.23456}), Math.log10(Math.pow(10.0, -0.12345) + Math.pow(10.0, -0.23456)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-15.7654, -17.0101}), Math.log10(Math.pow(10.0, -15.7654) + Math.pow(10.0, -17.0101)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0, 0.0}), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-1.0, 0.0}), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0, -1.0}), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, -1.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-2.2, -3.5}), log10(Math.pow(10.0, -2.2) + Math.pow(10.0, -3.5)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-1.0, -7.1}), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, -7.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{5.0, 6.2}), log10(Math.pow(10.0, 5.0) + Math.pow(10.0, 6.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{38.1, 16.2}), log10(Math.pow(10.0, 38.1) + Math.pow(10.0, 16.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-38.1, 6.2}), log10(Math.pow(10.0, -38.1) + Math.pow(10.0, 6.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-19.1, -37.1}), log10(Math.pow(10.0, -19.1) + Math.pow(10.0, -37.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-29.1, -27.6}), log10(Math.pow(10.0, -29.1) + Math.pow(10.0, -27.6)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-0.12345, -0.23456}), log10(Math.pow(10.0, -0.12345) + Math.pow(10.0, -0.23456)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-15.7654, -17.0101}), log10(Math.pow(10.0, -15.7654) + Math.pow(10.0, -17.0101)), requiredPrecision);
 
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {0.0, 0.0, 0.0}), Math.log10(Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-1.0, 0.0, 0.0}), Math.log10(Math.pow(10.0, -1.0) + Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {0.0, -1.0, -2.5}), Math.log10(Math.pow(10.0, 0.0) + Math.pow(10.0, -1.0) + Math.pow(10.0, -2.5)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-2.2, -3.5, -1.1}), Math.log10(Math.pow(10.0, -2.2) + Math.pow(10.0, -3.5) + Math.pow(10.0, -1.1)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-1.0, -7.1, 0.5}), Math.log10(Math.pow(10.0, -1.0) + Math.pow(10.0, -7.1) + Math.pow(10.0, 0.5)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {5.0, 6.2, 1.3}), Math.log10(Math.pow(10.0, 5.0) + Math.pow(10.0, 6.2) + Math.pow(10.0, 1.3)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {38.1, 16.2, 18.1}), Math.log10(Math.pow(10.0, 38.1) + Math.pow(10.0, 16.2) + Math.pow(10.0, 18.1)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-38.1, 6.2, 26.6}), Math.log10(Math.pow(10.0, -38.1) + Math.pow(10.0, 6.2) + Math.pow(10.0, 26.6)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-19.1, -37.1, -45.1}), Math.log10(Math.pow(10.0, -19.1) + Math.pow(10.0, -37.1) + Math.pow(10.0, -45.1)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-29.1, -27.6, -26.2}), Math.log10(Math.pow(10.0, -29.1) + Math.pow(10.0, -27.6) + Math.pow(10.0, -26.2)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-0.12345, -0.23456, -0.34567}), Math.log10(Math.pow(10.0, -0.12345) + Math.pow(10.0, -0.23456) + Math.pow(10.0, -0.34567)), requiredPrecision);
-        Assert.assertEquals(MathUtils.log10sumLog10(new double[] {-15.7654, -17.0101, -17.9341}), Math.log10(Math.pow(10.0, -15.7654) + Math.pow(10.0, -17.0101) + Math.pow(10.0, -17.9341)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0, 0.0, 0.0}), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-1.0, 0.0, 0.0}), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, 0.0) + Math.pow(10.0, 0.0)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{0.0, -1.0, -2.5}), log10(Math.pow(10.0, 0.0) + Math.pow(10.0, -1.0) + Math.pow(10.0, -2.5)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-2.2, -3.5, -1.1}), log10(Math.pow(10.0, -2.2) + Math.pow(10.0, -3.5) + Math.pow(10.0, -1.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-1.0, -7.1, 0.5}), log10(Math.pow(10.0, -1.0) + Math.pow(10.0, -7.1) + Math.pow(10.0, 0.5)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{5.0, 6.2, 1.3}), log10(Math.pow(10.0, 5.0) + Math.pow(10.0, 6.2) + Math.pow(10.0, 1.3)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{38.1, 16.2, 18.1}), log10(Math.pow(10.0, 38.1) + Math.pow(10.0, 16.2) + Math.pow(10.0, 18.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-38.1, 6.2, 26.6}), log10(Math.pow(10.0, -38.1) + Math.pow(10.0, 6.2) + Math.pow(10.0, 26.6)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-19.1, -37.1, -45.1}), log10(Math.pow(10.0, -19.1) + Math.pow(10.0, -37.1) + Math.pow(10.0, -45.1)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-29.1, -27.6, -26.2}), log10(Math.pow(10.0, -29.1) + Math.pow(10.0, -27.6) + Math.pow(10.0, -26.2)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-0.12345, -0.23456, -0.34567}), log10(Math.pow(10.0, -0.12345) + Math.pow(10.0, -0.23456) + Math.pow(10.0, -0.34567)), requiredPrecision);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{-15.7654, -17.0101, -17.9341}), log10(Math.pow(10.0, -15.7654) + Math.pow(10.0, -17.0101) + Math.pow(10.0, -17.9341)), requiredPrecision);
 
         // magnitude of the sum doesn't matter, so we can combinatorially test this via partitions of unity
-        double[] mult_partitionFactor = new double[]{0.999,0.98,0.95,0.90,0.8,0.5,0.3,0.1,0.05,0.001};
-        int[] n_partitions = new int[] {2,4,8,16,32,64,128,256,512,1028};
-        for ( double alpha : mult_partitionFactor ) {
-            double log_alpha = Math.log10(alpha);
-            double log_oneMinusAlpha = Math.log10(1-alpha);
-            for ( int npart : n_partitions ) {
+        double[] mult_partitionFactor = new double[]{0.999, 0.98, 0.95, 0.90, 0.8, 0.5, 0.3, 0.1, 0.05, 0.001};
+        int[] n_partitions = new int[]{2, 4, 8, 16, 32, 64, 128, 256, 512, 1028};
+        for (double alpha : mult_partitionFactor) {
+            double log_alpha = log10(alpha);
+            double log_oneMinusAlpha = log10(1 - alpha);
+            for (int npart : n_partitions) {
                 double[] multiplicative = new double[npart];
                 double[] equal = new double[npart];
                 double remaining_log = 0.0;  // realspace = 1
-                for ( int i = 0 ; i < npart-1; i++ ) {
-                    equal[i] = -Math.log10(npart);
+                for (int i = 0; i < npart - 1; i++) {
+                    equal[i] = -log10(npart);
                     double piece = remaining_log + log_alpha; // take a*remaining, leaving remaining-a*remaining = (1-a)*remaining
                     multiplicative[i] = piece;
                     remaining_log = remaining_log + log_oneMinusAlpha;
                 }
-                equal[npart-1] = -Math.log10(npart);
-                multiplicative[npart-1] = remaining_log;
-                Assert.assertEquals(MathUtils.log10sumLog10(equal),0.0,requiredPrecision);
-                Assert.assertEquals(MathUtils.log10sumLog10(multiplicative),0.0,requiredPrecision,String.format("Did not sum to one: nPartitions=%d, alpha=%f",npart,alpha));
+                equal[npart - 1] = -log10(npart);
+                multiplicative[npart - 1] = remaining_log;
+                Assert.assertEquals(MathUtils.log10sumLog10(equal), 0.0, requiredPrecision);
+                Assert.assertEquals(MathUtils.log10sumLog10(multiplicative), 0.0, requiredPrecision, String.format("Did not sum to one: nPartitions=%d, alpha=%f", npart, alpha));
             }
+        }
+    }
+
+    @Test
+    public void testlog10sumLog10EdgeCases(){
+        final double requiredPrecision = 1E-14;
+
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{3.0, 2.0, 1.0}, 2, 1), Double.NEGATIVE_INFINITY);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY}), Double.NEGATIVE_INFINITY);
+        Assert.assertEquals(MathUtils.log10sumLog10(new double[]{3.0, 2.0, 1.0}), log10(Math.pow(10.0, 3.0) + Math.pow(10.0, 2.0) + Math.pow(10.0, 1.0)), requiredPrecision);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testlog10sumLog10ErrorNaN(){
+        MathUtils.log10sumLog10(new double[]{Double.NaN, 1.0});
+    }
+
+    @Test
+    public void testNormalize(){
+        final double error = 1e-6;
+        final double[] normalized = MathUtils.normalizeFromLog10(new double[]{3.0, 2.0, 1.0});
+        final double[] normalizedLog = MathUtils.normalizeFromLog10(new double[]{3.0, 2.0, 1.0}, true);
+        final double[] normalizedLogInLog = MathUtils.normalizeFromLog10(new double[]{3.0, 2.0, 1.0}, true, true);
+        final double[] normalizedExpected    = {0.9009009009009008, 0.09009009009009009, 0.009009009009009009};  //sum of those is 1
+        final double[] normalizedLogExpected = {-0.04532297878665748, -1.0453229787866574, -2.0453229787866576}; //sum of 10^ those is 1
+        final double[] normalizedLogInLogExpected = {0.0, -1.0, -2.0};
+        for (int i = 0; i < normalized.length; i++){
+            Assert.assertEquals(normalizedExpected[i], normalized[i], error);
+        }
+        for (int i = 0; i < normalizedLog.length; i++){
+            Assert.assertEquals(normalizedLogExpected[i], normalizedLog[i], error);
+        }
+        for (int i = 0; i < normalizedLogInLog.length; i++){
+            Assert.assertEquals(normalizedLogInLogExpected[i], normalizedLogInLog[i], error);
         }
     }
 
@@ -136,9 +322,9 @@ public final class MathUtilsUnitTests {
         int med_start = 200;
         int large_start = 12342;
         for ( int i = 1; i < 1000; i++ ) {
-            log10factorial_small += Math.log10(i+small_start);
-            log10factorial_middle += Math.log10(i+med_start);
-            log10factorial_large += Math.log10(i+large_start);
+            log10factorial_small += log10(i + small_start);
+            log10factorial_middle += log10(i + med_start);
+            log10factorial_large += log10(i + large_start);
             Assert.assertEquals(MathUtils.log10Factorial(small_start+i),log10factorial_small,1e-6);
             Assert.assertEquals(MathUtils.log10Factorial(med_start+i),log10factorial_middle,1e-3);
             Assert.assertEquals(MathUtils.log10Factorial(large_start+i),log10factorial_large,1e-1);
@@ -178,6 +364,12 @@ public final class MathUtilsUnitTests {
     }
 
     @Test
+    public void testSumRange() {
+        long[] longTest = {-1,0,1,2,3};
+        Assert.assertEquals(MathUtils.sum(longTest, 1, 4), 3);
+    }
+
+    @Test
     public void testMean() {
         double[] test = {0,1,101};
         Assert.assertEquals(MathUtils.mean(test, 0, 0), Double.NaN);
@@ -199,6 +391,25 @@ public final class MathUtilsUnitTests {
         double[] prom = MathUtils.promote(test);
         for (int i = 0; i < test.length; i++) {
             Assert.assertEquals(test[i], prom[i], 1e-14);
+        }
+    }
+
+    @Test
+    public void testCompareDoubles(){
+        Assert.assertEquals(MathUtils.compareDoubles(0.1, 0.2), 1);
+        Assert.assertEquals(MathUtils.compareDoubles(0.2, 0.1), -1);
+        Assert.assertEquals(MathUtils.compareDoubles(0.1, 0.1), 0);
+        Assert.assertEquals(MathUtils.compareDoubles(0.1, 0.1+(1e-7)), 0);
+        Assert.assertEquals(MathUtils.compareDoubles(0.1, 0.1+(1e-7), 1e-8), 1);
+    }
+
+    @Test
+    public void testNormalizeFromReal(){
+        final double error = 1e-6;
+        final double[] actual = MathUtils.normalizeFromRealSpace(new double[]{1.0, 2.0, 3.0});
+        final double[] expected =  {1.0/6.0, 2.0/6.0, 3.0/6.0};
+        for (int i = 0; i < actual.length; i++){
+            Assert.assertEquals(expected[i], actual[i], error);
         }
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/RandomDNAUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/RandomDNAUnitTest.java
@@ -1,0 +1,72 @@
+package org.broadinstitute.hellbender.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public final class RandomDNAUnitTest {
+
+    private int[] counts(final byte[] bytes){
+        final int[] b= new int[4];
+        for(int i=0; i < bytes.length; i++){
+            switch (bytes[i]){
+                case 'A': b[0]++; break;
+                case 'C': b[1]++; break;
+                case 'G': b[2]++; break;
+                case 'T': b[3]++; break;
+                default: throw new IllegalStateException("illegal base:" + bytes[i]);
+            }
+        }
+        return b;
+    }
+    @Test
+    public void testBases1(){
+        int[] results = new int[4];
+
+        final int n = 1000;
+        final int m = 13;
+        for (int i= 0; i < n; i++) {
+            final byte[] b = new RandomDNA().nextBases(m);
+            final int[] b0 = counts(b);
+            results = pairwiseAdd(results, b0);
+        }
+
+        checkResults(results, n, m);
+    }
+
+    @Test
+    public void testBases(){
+        int[] results = new int[4];
+
+        final int n = 1000;
+        final int m = 13;
+        for (int i= 0; i < n; i++) {
+            final byte[] b = new byte[m];
+            new RandomDNA().nextBases(b);
+            final int[] b0 = counts(b);
+            results = pairwiseAdd(results, b0);
+        }
+
+        checkResults(results, n, m);
+    }
+
+    public void checkResults(final int[] results, final int n, final int m) {
+        final double[] dresults = MathUtils.promote(results);
+        final double mean = MathUtils.mean(dresults, 0, dresults.length);
+        final double std = MathUtils.stddev(dresults, 0, dresults.length);
+        final double expectedMean = (n*m)/4.0;
+        final double s = std; // not really because it's the population not the sample dtd but it'll do
+        Assert.assertTrue(mean < expectedMean + 2 * s / Math.sqrt(n * m), "unexpected mean:" + mean);
+        Assert.assertTrue(mean > expectedMean-2*s/Math.sqrt(n*m), "unexpected mean:" +mean);
+    }
+
+    private int[] pairwiseAdd(int[] a, int[] b) {
+        if (a.length != b.length){
+            throw  new IllegalArgumentException();
+        }
+        final int[] results = new int[a.length];
+        for (int i = 0; i < a.length; i++) {
+            results[i] = a[i] + b[i];
+        }
+        return results;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -11,6 +11,8 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.*;
 
+import static java.util.Arrays.asList;
+
 /**
  * Testing framework for general purpose utilities class.
  *
@@ -18,9 +20,54 @@ import java.util.*;
 public final class UtilsUnitTest extends BaseTest {
 
     @Test
+    public void testReverse(){
+        Assert.assertEquals(asList(2,1,0), Utils.reverse(asList(0,1,2)));
+    }
+
+    @Test
+    public void testMakePermutations(){
+//        * if objects = [A, B, C]
+//        * if N = 1 => [[A], [B], [C]]
+//        * if N = 2 => [[A, A], [B, A], [C, A], [A, B], [B, B], [C, B], [A, C], [B, C], [C, C]]
+
+        final List<List<String>> p1 = Utils.makePermutations(asList("A", "B", "C"), 1, false);
+        final List<List<String>> r1 = Utils.makePermutations(asList("A", "B", "C"), 1, true);
+
+        final List<List<String>> p2 = Utils.makePermutations(asList("A", "B", "C"), 2, false);
+        final List<List<String>> r2 = Utils.makePermutations(asList("A", "B", "C"), 2, true);
+
+        Assert.assertEquals(asList(asList("A"), asList("B"), asList("C")), p1);
+        Assert.assertEquals(asList(asList("A"), asList("B"), asList("C")), r1);
+
+        Assert.assertEquals(asList(asList("B", "A"), asList("C", "A"), asList("A", "B"), asList("C", "B"), asList("A", "C"), asList("B", "C")), p2);
+        Assert.assertEquals(asList(asList("A", "A"), asList("B", "A"), asList("C", "A"), asList("A", "B"), asList("B", "B"), asList("C", "B"), asList("A", "C"), asList("B", "C"), asList("C", "C")), r2);
+
+    }
+
+    @Test
+    public void testJoinCollection() {
+        Assert.assertEquals("0-1-2", Utils.join("-", asList(0, 1, 2)));
+        Assert.assertEquals("0", Utils.join("-", asList(0)));
+        Assert.assertEquals("", Utils.join("-", asList()));
+    }
+
+    @Test
+    public void testCons() {
+        final List<Integer> list = asList(0, 1, 2, 3);
+        Assert.assertEquals(asList(6, 0, 1, 2, 3), Utils.cons(6, list));
+    }
+
+    @Test
+    public void testDupString() {
+        Assert.assertEquals("ababab", Utils.dupString("ab", 3));
+        Assert.assertEquals("aaa", Utils.dupString('a', 3));
+        Assert.assertEquals(new byte[]{(byte)'a',(byte)'a',(byte)'a'}, Utils.dupBytes((byte)'a', 3));
+    }
+
+    @Test
     public void testAppend() {
-        for ( int leftSize : Arrays.asList(0, 1, 2, 3) ) {
-            for ( final int rightSize : Arrays.asList(0, 1, 2) ) {
+        for ( int leftSize : asList(0, 1, 2, 3) ) {
+            for ( final int rightSize : asList(0, 1, 2) ) {
                 final List<Integer> left = new LinkedList<>();
                 for ( int i = 0; i < leftSize; i++ ) left.add(i);
                 final List<Integer> total = new LinkedList<>();
@@ -41,7 +88,7 @@ public final class UtilsUnitTest extends BaseTest {
     public void testWarnUserLines(){
         String message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut" +
                 " labore et dolore magna aliqua.";
-        Assert.assertEquals(Utils.warnUserLines(message), new ArrayList<>(Arrays.asList(
+        Assert.assertEquals(Utils.warnUserLines(message), new ArrayList<>(asList(
                 "**********************************************************************",
                 "* WARNING:",
                 "* ",

--- a/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/clipping/ReadClipperUnitTest.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMRecord;
-import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.CigarUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.ReadClipperTestUtils;
@@ -160,7 +159,7 @@ public final class ReadClipperUnitTest extends BaseTest {
             for (int nLowQualBases = 0; nLowQualBases < readLength; nLowQualBases++) {
 
                 /**  create a read with nLowQualBases in the left tail */
-                Utils.fillArrayWithByte(quals, HIGH_QUAL);
+                Arrays.fill(quals, HIGH_QUAL);
                 for (int addLeft = 0; addLeft < nLowQualBases; addLeft++)
                     quals[addLeft] = LOW_QUAL;
                 read.setBaseQualities(quals);
@@ -168,7 +167,7 @@ public final class ReadClipperUnitTest extends BaseTest {
                 checkClippedReadsForLowQualEnds(read, clipLeft, LOW_QUAL, nLowQualBases);
 
                 /** create a read with nLowQualBases in the right tail */
-                Utils.fillArrayWithByte(quals, HIGH_QUAL);
+                Arrays.fill(quals, HIGH_QUAL);
                 for (int addRight = 0; addRight < nLowQualBases; addRight++)
                     quals[readLength - addRight - 1] = LOW_QUAL;
                 read.setBaseQualities(quals);
@@ -177,7 +176,7 @@ public final class ReadClipperUnitTest extends BaseTest {
 
                 /** create a read with nLowQualBases on both tails */
                 if (nLowQualBases <= readLength / 2) {
-                    Utils.fillArrayWithByte(quals, HIGH_QUAL);
+                    Arrays.fill(quals, HIGH_QUAL);
                     for (int addBoth = 0; addBoth < nLowQualBases; addBoth++) {
                         quals[addBoth] = LOW_QUAL;
                         quals[readLength - addBoth - 1] = LOW_QUAL;

--- a/src/test/java/org/broadinstitute/hellbender/utils/collections/IndexedSetUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/collections/IndexedSetUnitTest.java
@@ -1,0 +1,328 @@
+package org.broadinstitute.hellbender.utils.collections;
+
+import org.broadinstitute.hellbender.utils.Utils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+/**
+ * Tests the working of {@link IndexedSet}
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public final class IndexedSetUnitTest {
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInitError(){
+        final Collection<String> c = null;
+        final IndexedSet<String> is = new IndexedSet<>(c);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testEqualsError(){
+        final String[] c = {"a", "b"};
+        final IndexedSet<String> is = new IndexedSet<>(c);
+        is.equals(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInitError_nullColl(){
+        final Collection<String> c = Arrays.asList("a", null);
+        final IndexedSet<String> is = new IndexedSet<>(c);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInitError2(){
+        final String[] c = null;
+        final IndexedSet<String> is = new IndexedSet<>(c);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInitError3(){
+        final String[] c = {"a", null};
+        final IndexedSet<String> is = new IndexedSet<>(c);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInitError4(){
+        final String[] c = {"a", "b"};
+        final IndexedSet<String> is = new IndexedSet<>(c);
+        is.add(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInitError5(){
+        final String[] c = {"a", "b"};
+        final IndexedSet<String> is = new IndexedSet<>(c);
+        is.indexOf(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testInitError6(){
+        final String[] c = {"a", "b"};
+        final IndexedSet<String> is = new IndexedSet<>(c);
+        is.remove(null);
+    }
+
+    @Test
+    public void testRemove(){
+        final String[] c = {"a", "b"};
+        final IndexedSet<String> is = new IndexedSet<>(c);
+        final boolean cC = is.remove("c");
+        Assert.assertEquals(cC, false);
+
+        final boolean cb = is.remove("b");
+        Assert.assertEquals(cb, true);
+    }
+
+    @Test
+    public void testEquals(){
+        final String[] c = {"a", "b"};
+        final String[] c1 = {"a", "B"};
+        final String[] c3 = {"a", "b", "c"};
+        final IndexedSet<String> is1 = new IndexedSet<>(c);
+        final IndexedSet<String> is2 = new IndexedSet<>(c);
+        final IndexedSet<String> is3 = new IndexedSet<>(c1);
+        final IndexedSet<String> is4 = new IndexedSet<>(c3);
+        Assert.assertEquals(is1, is2);
+        Assert.assertEquals(is1, is1);
+
+        Assert.assertTrue(is1.equals(is1));
+        Assert.assertTrue(is1.equals((Object)is1));
+
+        final String nullString = null;
+        Assert.assertFalse(is1.equals(nullString));
+        Assert.assertFalse(is1.equals("a,b"));
+
+        Assert.assertNotEquals(is1, is3);
+        Assert.assertNotEquals(is2, is3);
+        Assert.assertNotEquals(is1, is4);
+        Assert.assertNotEquals(is2, is4);
+        Assert.assertNotEquals(is3, is4);
+
+        Assert.assertEquals(is1.hashCode(), is2.hashCode());
+        Assert.assertNotEquals(is1.hashCode(), is3.hashCode());
+        Assert.assertNotEquals(is2.hashCode(), is3.hashCode());
+    }
+
+    @Test(dataProvider = "initialCapacityElementCountMaxElementData")
+    public void testCompositionBySingleElementAddition(final int initialCapacity,
+                                                       final int elementCount, final int maxElement) {
+        final Random rnd = Utils.getRandomGenerator();
+        final IndexedSet<Integer> subject = new IndexedSet<>(initialCapacity);
+
+        final Set<Integer> elementSet = new LinkedHashSet<>();
+
+        for (int i = 0; i < elementCount; i++) {
+            final int nextElement = rnd.nextInt(maxElement + 1);
+            final boolean isNewElement = ! elementSet.contains(nextElement);
+            Assert.assertEquals(subject.add(nextElement), elementSet.add(nextElement));
+            Assert.assertEquals(subject.size(), elementSet.size());
+            if (isNewElement)
+                Assert.assertEquals(subject.indexOf(nextElement), elementSet.size() - 1);
+        }
+        assertEquals(subject, elementSet);
+    }
+
+    @Test(dataProvider = "initialCapacityElementCountMaxElementData")
+    public void testCompositionByCollectionAddition(final int initialCapacity,
+                                                    final int elementCount, final int maxElement) {
+        final IndexedSet<Integer> subject = new IndexedSet<>(initialCapacity);
+        final List<Integer> elementList = generateElementCollection(elementCount,maxElement);
+
+
+        Assert.assertEquals(subject.addAll(elementList), !elementList.isEmpty());
+
+        final Set<Integer> elementSet = new LinkedHashSet<>(elementCount);
+        elementSet.addAll(elementList);
+
+        assertEquals(subject,elementSet);
+    }
+
+    @Test(dataProvider = "elementCountMaxElementData")
+    public void testCompositionByCollectionConstructor(final int elementCount, final int maxElement) {
+        final List<Integer> elementList = generateElementCollection(elementCount, maxElement);
+
+        final IndexedSet<Integer> subject = new IndexedSet<>(elementList);
+
+        final Set<Integer> elementSet = new LinkedHashSet<>(elementList);
+        assertEquals(subject,elementSet);
+        Assert.assertFalse(subject.addAll(elementList));
+    }
+
+    private List<Integer> generateElementCollection(final int elementCount, final int maxElement) {
+        final Random rnd = Utils.getRandomGenerator();
+
+        final List<Integer> elementList = new ArrayList<>(elementCount);
+        for (int i = 0; i < elementCount; i++)
+            elementList.add(rnd.nextInt(maxElement + 1));
+        return elementList;
+    }
+
+    @Test(dataProvider = "elementCountMaxElementData",
+          dependsOnMethods = {"testCompositionByCollectionConstructor"})
+    public void testLookupByIndex(final int elementCount, final int maxElement) {
+        final List<Integer> elementList = generateElementCollection(elementCount, maxElement);
+        final IndexedSet<Integer> subject = new IndexedSet<>(elementList);
+        final Set<Integer> elementSet = new LinkedHashSet<>(elementList);
+        final Integer[] elementArray = elementSet.toArray(new Integer[elementSet.size()]);
+
+        final List<Integer> subjectList = subject.asList();
+        for (int i = 0; i < subject.size(); i++) {
+            final int element = elementArray[i];
+            final int subjectElement = subject.get(i);
+            final int subjectListElement = subjectList.get(i);
+            Assert.assertEquals(subjectElement, element);
+            Assert.assertEquals(subjectListElement, element);
+        }
+    }
+
+    @Test(dataProvider = "elementCountMaxElementData",
+            dependsOnMethods = {"testCompositionByCollectionConstructor"})
+    public void testIndexOf(final int elementCount, final int maxElement) {
+        final List<Integer> elementList = generateElementCollection(elementCount, maxElement);
+        final IndexedSet<Integer> subject = new IndexedSet<>(elementList);
+        final Set<Integer> elementSet = new LinkedHashSet<>(elementList);
+        final Integer[] elementArray = elementSet.toArray(new Integer[elementSet.size()]);
+
+        final List<Integer> subjectList = subject.asList();
+        for (int i = 0; i < subject.size(); i++) {
+            final int element = elementArray[i];
+            final int listElement = subjectList.get(i);
+            final int subjectIndex = subject.indexOf(element);
+            Assert.assertEquals(listElement, element);
+            Assert.assertEquals(subjectIndex, i);
+            Assert.assertEquals(subject.indexOf(-element - 1), -1);
+        }
+    }
+
+    @Test(dataProvider = "elementCountMaxElementData",
+            dependsOnMethods = {"testCompositionByCollectionConstructor","testIndexOf"})
+    public void testRemoveHalf(final int elementCount, final int maxElement) {
+        final List<Integer> elementList = generateElementCollection(elementCount, maxElement);
+        final IndexedSet<Integer> subject = new IndexedSet<>(elementList);
+        final Set<Integer> elementSet = new LinkedHashSet<>(elementList);
+        final int removeCount = (subject.size() + 1) / 2;
+        final Random rnd = Utils.getRandomGenerator();
+        for (int i = 0; i < removeCount; i++) {
+            final int removeIndex = rnd.nextInt(subject.size());
+            final int removeElement = subject.get(removeIndex);
+            subject.remove(removeElement);
+            elementSet.remove(removeElement);
+        }
+
+        assertEquals(subject,elementSet);
+    }
+
+    @Test(dataProvider = "elementCountMaxElementData",
+            dependsOnMethods = {"testCompositionByCollectionConstructor","testIndexOf"})
+    public void testRemoveAll(final int elementCount, final int maxElement) {
+        final List<Integer> elementList = generateElementCollection(elementCount, maxElement);
+        final IndexedSet<Integer> subject = new IndexedSet<>(elementList);
+        final Set<Integer> elementSet = new LinkedHashSet<>(elementList);
+        final int removeCount = subject.size();
+        final Random rnd = Utils.getRandomGenerator();
+        for (int i = 0; i < removeCount; i++) {
+            final int removeIndex = rnd.nextInt(subject.size());
+            final int removeElement = subject.get(removeIndex);
+            subject.remove(removeElement);
+            elementSet.remove(removeElement);
+        }
+
+        assertEquals(subject,elementSet);
+    }
+
+    @Test(dataProvider = "elementCountMaxElementData",
+            dependsOnMethods = {"testCompositionByCollectionConstructor"})
+    public void testClear(final int elementCount, final int maxElement) {
+        final List<Integer> elementList = generateElementCollection(elementCount, maxElement);
+        final IndexedSet<Integer> subject = new IndexedSet<>(elementList);
+        final Set<Integer> elementSet = new LinkedHashSet<>(elementList);
+        subject.clear();
+        elementSet.clear();
+
+        assertEquals(subject, elementSet);
+    }
+
+    @Test(dataProvider = "elementCountMaxElementData",
+            dependsOnMethods = {"testCompositionByCollectionConstructor","testIndexOf"})
+    public void testRemoveAndAdd(final int elementCount, final int maxElement) {
+        final List<Integer> elementList = generateElementCollection(elementCount, maxElement);
+        final IndexedSet<Integer> subject = new IndexedSet<>(elementList);
+        final Set<Integer> elementSet = new LinkedHashSet<>(elementList);
+        final int removeCount = subject.size();
+        final Random rnd = Utils.getRandomGenerator();
+        for (int i = 0; i < removeCount; i++) {
+            final int removeIndex = rnd.nextInt(subject.size());
+            final int removeElement = subject.get(removeIndex);
+            subject.remove(removeElement);
+            elementSet.remove(removeElement);
+        }
+        subject.addAll(elementList);
+        elementSet.addAll(elementList);
+
+        assertEquals(subject, elementSet);
+    }
+
+    private final int[] INITIAL_CAPACITY = { 0, 10, 100 };
+
+    private final int[] ELEMENT_COUNT = { 0, 1, 10, 100 , 1000 };
+
+    private final int[] MAX_ELEMENT = { 0, 1, 5, 10, 50, 100, 500 };
+
+    @DataProvider(name="initialCapacityElementCountMaxElementData")
+    public Object[][] initialCapacityElementCountMaxElementData() {
+        final Object[][] result = new Object[INITIAL_CAPACITY.length * ELEMENT_COUNT.length * MAX_ELEMENT.length][];
+
+        int nextIndex = 0;
+
+        for (int i = 0; i < INITIAL_CAPACITY.length; i++)
+            for (int j = 0; j < ELEMENT_COUNT.length; j++)
+                for (int k = 0; k < MAX_ELEMENT.length; k++)
+                    result[nextIndex++] = new Object[] { INITIAL_CAPACITY[i], ELEMENT_COUNT[j], MAX_ELEMENT[k]};
+
+        return result;
+    }
+
+    @DataProvider(name="elementCountMaxElementData")
+    public Object[][] elementCountMaxElementData() {
+        final Object[][] result = new Object[ELEMENT_COUNT.length * MAX_ELEMENT.length][];
+
+        int nextIndex = 0;
+
+            for (int j = 0; j < ELEMENT_COUNT.length; j++)
+                for (int k = 0; k < MAX_ELEMENT.length; k++)
+                    result[nextIndex++] = new Object[] { ELEMENT_COUNT[j], MAX_ELEMENT[k]};
+
+        return result;
+    }
+
+    /**
+     * Asserts that an indexed-set is equivalent to a insertion-sorted set provided.
+     * @param subject  the indexed-set to test.
+     * @param elementSet the insertion-sorted set.
+     */
+    private void assertEquals(final IndexedSet<Integer> subject, final Set<Integer> elementSet) {
+        Assert.assertEquals(subject.size(), elementSet.size());
+        final List<Integer> subjectList = subject.asList();
+        Assert.assertEquals(subjectList.size(), elementSet.size());
+        final Iterator<Integer> subjectIterator = subject.iterator();
+        final Iterator<Integer> elementSetIterator = subject.iterator();
+
+        final ListIterator<Integer> subjectListIterator = subjectList.listIterator();
+
+        while (subjectIterator.hasNext()) {
+            Assert.assertTrue(elementSetIterator.hasNext(), "less elements in indexed-set than in the equivalent hash-set");
+            Assert.assertTrue(subjectListIterator.hasNext());
+
+            final Integer nextElement;
+            Assert.assertEquals(nextElement = subjectIterator.next(), elementSetIterator.next(), "elements in indexed-set do not follow the same order as equivalent linked hash-set's");
+            Assert.assertEquals(subjectListIterator.next(), nextElement);
+            Assert.assertEquals(subject.indexOf(nextElement), subjectListIterator.previousIndex());
+        }
+        Assert.assertFalse(elementSetIterator.hasNext());
+        Assert.assertFalse(subjectListIterator.hasNext());
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/genotyper/AlleleListUnitTester.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/genotyper/AlleleListUnitTester.java
@@ -1,0 +1,126 @@
+package org.broadinstitute.hellbender.utils.genotyper;
+
+import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.hellbender.utils.RandomDNA;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.testng.Assert;
+import org.testng.SkipException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Helper class for those unit-test classes that test on implementations of SampleList.
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public final class AlleleListUnitTester {
+
+    private static final Random rnd = Utils.getRandomGenerator();
+    private static final RandomDNA rndDNA = new RandomDNA(rnd);
+
+    /**
+     * Test that the contents of an allele-list are the ones expected.
+     * <p/>
+     * <p>
+     * This method perform various consistency check involving all the {@link org.broadinstitute.gatk.utils.genotyper.AlleleList} interface methods.
+     * Therefore calling this method is equivalent to a thorough check of the {@link org.broadinstitute.gatk.utils.genotyper.AlleleList} aspect of
+     * the {@code actual} argument.
+     * </p>
+     *
+     * @param actual   the sample-list to assess.
+     * @param expected the expected sample-list.
+     * @throws IllegalArgumentException if {@code expected} is {@code null} or contains
+     *                                  {@code null}s which is an indication of an bug in the testing code.
+     * @throws RuntimeException         if there is some testing assertion exception which
+     *                                  is an indication of an actual bug the code that is been tested.
+     */
+    public static <A extends Allele> void assertAlleleList(final AlleleList<A> actual, final List<A> expected) {
+        if (expected == null)
+            throw new IllegalArgumentException("the expected list cannot be null");
+        final Set<A> expectedAlleleSet = new HashSet<>(expected.size());
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.alleleCount(), expected.size());
+        for (int i = 0; i < expected.size(); i++) {
+            final A expectedAllele = expected.get(i);
+            if (expectedAllele == null)
+                throw new IllegalArgumentException("the expected sample cannot be null");
+            if (expectedAllele.equals(NEVER_USE_ALLELE))
+                throw new IllegalArgumentException("you cannot use the forbidden sample name");
+            if (expectedAlleleSet.contains(expected.get(i)))
+                throw new IllegalArgumentException("repeated allele in the expected list, this is a test bug");
+            final A actualAllele = actual.alleleAt(i);
+            Assert.assertNotNull(actualAllele, "allele cannot be null");
+            Assert.assertFalse(expectedAlleleSet.contains(actualAllele), "repeated allele: " + actualAllele);
+            Assert.assertEquals(actualAllele, expectedAllele, "wrong allele order; index = " + i);
+            Assert.assertEquals(actual.alleleIndex(actualAllele), i, "allele index mismatch");
+            expectedAlleleSet.add(actualAllele);
+        }
+
+        Assert.assertEquals(actual.alleleIndex((A) NEVER_USE_ALLELE), -1);
+    }
+
+    /**
+     * Save to assume that this allele will never be used.
+     */
+    private static final Allele NEVER_USE_ALLELE = Allele.create(new String("ACTGACTGACTGACTGACTGACTGACTGACTGGTCAGTCAGTCAGTCAGTCAGTCA").getBytes(), false);
+
+    /**
+     * Generate testing alleles.
+     *
+     * <p>
+     *     Basically all are random alleles given the maximum allele length.
+     * </p>
+     *
+     * <p>
+     *     So with a low max-allele-length and high allele-count you can force repeats.
+     * </p>
+     *
+     * @param alleleCount number of alleles to generate.
+     * @param maxAlleleLength the maximum length of the allele in bases.
+     *
+     * @throws RuntimeException if {@code alleleCount} is negative or {@code maxAlleleLength} is less than 1.
+     * @return never {@code null}.
+     */
+    public static Allele[] generateRandomAlleles(final int alleleCount, final int maxAlleleLength) {
+        if (maxAlleleLength < 1)
+            throw new IllegalArgumentException("the max allele length cannot be less than 1");
+        final Allele[] result = new Allele[alleleCount];
+        for (int i = 0; i < alleleCount; i++) {
+            final int alleleLength = rnd.nextInt(maxAlleleLength) + 1;
+            result[i] = Allele.create(rndDNA.nextBases(alleleLength));
+        }
+        return result;
+    }
+
+    /**
+     * Generate testing alleles.
+     *
+     * <p>
+     *     Basically all are random alleles given the maximum allele length.
+     * </p>
+     *
+     * <p>
+     *     So with a low max-allele-length and high allele-count you can force repeats.
+     * </p>
+     *
+     * @param alleleCount number of alleles to generate.
+     * @param maxAlleleLength the maximum length of the allele in bases.
+     * @param skipIfRepeats throw an test-skip exception {@link SkipException} if the resulting allele-list
+     *                     has repeats, thus is size is less than {@code alleleCount}
+     *
+     * @throws RuntimeException if {@code alleleCount} is negative or {@code maxAlleleLength} is less than 1.
+     * @return never {@code null}.
+     */
+    static AlleleList<Allele> alleleList(final int alleleCount, final int maxAlleleLength, final boolean skipIfRepeats) {
+        final Allele[] alleles = AlleleListUnitTester.generateRandomAlleles(alleleCount,maxAlleleLength);
+        if (alleleCount > 0)
+            alleles[0] = Allele.create(alleles[0].getBases(), true);
+        final AlleleList<Allele> alleleList = new IndexedAlleleList<>(alleles);
+        if (skipIfRepeats && alleleList.alleleCount() != alleles.length)
+            throw new SkipException("repeated alleles, should be infrequent");
+        return alleleList;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/genotyper/AlleleListUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/genotyper/AlleleListUtilsUnitTest.java
@@ -1,0 +1,218 @@
+package org.broadinstitute.hellbender.utils.genotyper;
+
+import htsjdk.variant.variantcontext.Allele;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+/**
+ * Test {@link org.broadinstitute.gatk.utils.genotyper.AlleleListUtils}.
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public final class AlleleListUtilsUnitTest {
+
+    @Test
+    public void testEmptyList(){
+        final AlleleList<Allele> al = AlleleListUtils.emptyList();
+        Assert.assertEquals(al.alleleCount(), 0);
+        Assert.assertEquals(al.alleleIndex(null), -1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIndexOfReferenceNull(){
+        AlleleListUtils.indexOfReference(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testasListNull(){
+        AlleleListUtils.asList(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testEmptyListAdd(){
+        final AlleleList<Allele> al = AlleleListUtils.emptyList();
+        al.alleleAt(0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, dataProvider = "singleAlleleListData")
+    public void testEqualToNull(final List<Allele> alleles1){
+        final AlleleList<Allele> alleleList = new IndexedAlleleList<>(alleles1);
+        AlleleListUtils.equals(alleleList, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, dataProvider = "singleAlleleListData")
+    public void testEqualToNull1(final List<Allele> alleles1){
+        final AlleleList<Allele> alleleList = new IndexedAlleleList<>(alleles1);
+        AlleleListUtils.equals(null, alleleList);
+    }
+
+    @Test(dataProvider = "singleAlleleListData")
+    public void testAsList(final List<Allele> alleles1) {
+         final Allele[] uniqueAlleles = new LinkedHashSet<>(alleles1).toArray(new Allele[0]);
+         final AlleleList<Allele> alleleList = new IndexedAlleleList<>(alleles1);
+         final List<Allele> asList = AlleleListUtils.asList(alleleList);
+         final Allele[] asListArray = asList.toArray(new Allele[asList.size()]);
+         Assert.assertTrue(Arrays.equals(uniqueAlleles, asListArray));
+    }
+
+    @Test(dataProvider = "singleAlleleListData")
+    public void testIndexOfReference(final List<Allele> alleles1) {
+        final Allele[] uniqueAlleles = new LinkedHashSet<>(alleles1).toArray(new Allele[0]);
+        for (int i = 0; i < uniqueAlleles.length; i++) {
+            final Allele[] actualAlleles = uniqueAlleles.clone();
+            actualAlleles[i] = Allele.create(actualAlleles[i].getBases(), true);
+            final AlleleList<Allele> alleleList = new IndexedAlleleList<>(actualAlleles);
+            Assert.assertEquals(AlleleListUtils.indexOfReference(alleleList), i);
+        }
+        final AlleleList<Allele> alleleList = new IndexedAlleleList<>(uniqueAlleles);
+        Assert.assertEquals(AlleleListUtils.indexOfReference(alleleList), -1);
+    }
+
+    @Test(dataProvider = "twoAlleleListData", dependsOnMethods={"testAsList"})
+    public void testEquals(final List<Allele> alleles1, final List<Allele> alleles2) {
+        final AlleleList<Allele> alleleList1 = new IndexedAlleleList<>(alleles1);
+        final AlleleList<Allele> alleleList2 = new IndexedAlleleList<>(alleles2);
+        Assert.assertTrue(AlleleListUtils.equals(alleleList1, alleleList1));
+        Assert.assertTrue(AlleleListUtils.equals(alleleList2, alleleList2));
+        Assert.assertEquals(AlleleListUtils.equals(alleleList1, alleleList2),
+                Arrays.equals(AlleleListUtils.asList(alleleList1).toArray(new Allele[alleleList1.alleleCount()]),
+                        AlleleListUtils.asList(alleleList2).toArray(new Allele[alleleList2.alleleCount()]))
+        );
+        Assert.assertEquals(AlleleListUtils.equals(alleleList1, alleleList2),
+                AlleleListUtils.equals(alleleList2, alleleList1));
+    }
+
+    @Test(dataProvider = "singleAlleleListData", dependsOnMethods= "testEquals" )
+    public void testSelfPermutation(final List<Allele> alleles1) {
+        final AlleleList<Allele> originalAlleleList = new IndexedAlleleList<>(alleles1);
+        final AlleleListPermutation<Allele> selfPermutation = AlleleListUtils.permutation(originalAlleleList,originalAlleleList);
+        Assert.assertEquals(selfPermutation.fromSize(), originalAlleleList.alleleCount());
+        Assert.assertEquals(selfPermutation.toSize(), originalAlleleList.alleleCount());
+        Assert.assertTrue(selfPermutation.isNonPermuted());
+        Assert.assertFalse(selfPermutation.isPartial());
+        for (int i = 0; i < originalAlleleList.alleleCount(); i++) {
+            Assert.assertEquals(selfPermutation.alleleAt(i), originalAlleleList.alleleAt(i));
+
+            Assert.assertEquals(selfPermutation.fromIndex(i), i);
+            Assert.assertEquals(selfPermutation.toIndex(i), i);
+            Assert.assertEquals(selfPermutation.fromList(), selfPermutation.toList());
+            AlleleListUnitTester.assertAlleleList(originalAlleleList, selfPermutation.fromList());
+        }
+        Assert.assertTrue(AlleleListUtils.equals(selfPermutation, originalAlleleList));
+    }
+
+    private final Random rnd = Utils.getRandomGenerator();
+
+    @Test(dataProvider = "singleAlleleListData", dependsOnMethods = "testEquals")
+    public void testSubsetPermutation(final List<Allele> alleles1) {
+        final List<Allele> subsetAlleles = new ArrayList<>(alleles1.size());
+        for (final Allele allele : alleles1)
+            if (rnd.nextBoolean()) subsetAlleles.add(allele);
+        final AlleleList<Allele> originalAlleleList = new IndexedAlleleList<>(alleles1);
+        final AlleleList<Allele> targetAlleleList = new IndexedAlleleList<>(subsetAlleles);
+        final AlleleListPermutation<Allele> subset = AlleleListUtils.permutation(originalAlleleList,targetAlleleList);
+        if (originalAlleleList.alleleCount() == targetAlleleList.alleleCount())
+            throw new SkipException("no real subset");
+        Assert.assertTrue(subset.isPartial());
+        Assert.assertFalse(subset.isNonPermuted());
+        Assert.assertEquals(subset.fromSize(), originalAlleleList.alleleCount());
+        Assert.assertEquals(subset.toSize(), targetAlleleList.alleleCount());
+        AlleleListUnitTester.assertAlleleList(originalAlleleList,subset.fromList());
+        AlleleListUnitTester.assertAlleleList(targetAlleleList,subset.toList());
+
+        for (int i = 0; i < targetAlleleList.alleleCount(); i++)
+            Assert.assertEquals(subset.fromIndex(i), originalAlleleList.alleleIndex(targetAlleleList.alleleAt(i)));
+
+        for (int j = 0; j < originalAlleleList.alleleCount(); j++) {
+            final Allele allele = originalAlleleList.alleleAt(j);
+            Assert.assertEquals(subset.toIndex(j), targetAlleleList.alleleIndex(allele));
+        }
+
+        Assert.assertTrue(AlleleListUtils.equals(subset, targetAlleleList));
+    }
+
+    @Test(dataProvider = "singleAlleleListData", dependsOnMethods = {"testAsList","testEquals"})
+    public void testShufflePermutation(final List<Allele> alleles1) {
+        final AlleleList<Allele> originalAlleleList = new IndexedAlleleList<>(alleles1);
+        if (originalAlleleList.alleleCount() <= 1)
+            throw new SkipException("non-shuffle allele-list");
+
+        final Allele[] targetAlleleArray = AlleleListUtils.asList(originalAlleleList).toArray(new Allele[originalAlleleList.alleleCount()]);
+        final int[] fromIndex = new int[targetAlleleArray.length];
+        for (int i = 0; i < fromIndex.length; i++)
+            fromIndex[i] = i;
+
+        for (int i = 0; i < targetAlleleArray.length - 1; i++) {
+            final int swapIndex = rnd.nextInt(targetAlleleArray.length - i - 1);
+            final int otherIndex = fromIndex[swapIndex + i + 1];
+            final Allele other = targetAlleleArray[swapIndex + i + 1];
+            fromIndex[swapIndex + i + 1] = fromIndex[i];
+            fromIndex[i] = otherIndex;
+            targetAlleleArray[swapIndex + i + 1] = targetAlleleArray[i];
+            targetAlleleArray[i] = other;
+        }
+        final AlleleList<Allele> targetAlleleList = new IndexedAlleleList<>(targetAlleleArray);
+
+        final AlleleListPermutation<Allele> permutation = AlleleListUtils.permutation(originalAlleleList,targetAlleleList);
+        Assert.assertFalse(permutation.isNonPermuted());
+        AlleleListUnitTester.assertAlleleList(originalAlleleList,permutation.fromList());
+        AlleleListUnitTester.assertAlleleList(targetAlleleList,permutation.toList());
+        Assert.assertFalse(permutation.isPartial());
+        Assert.assertEquals(permutation.fromSize(), originalAlleleList.alleleCount());
+        Assert.assertEquals(permutation.toSize(), targetAlleleList.alleleCount());
+        for (int i = 0; i < permutation.fromSize(); i++) {
+            Assert.assertEquals(permutation.toIndex(i), targetAlleleList.alleleIndex(originalAlleleList.alleleAt(i)));
+            Assert.assertEquals(permutation.fromIndex(i), originalAlleleList.alleleIndex(targetAlleleList.alleleAt(i)));
+            Assert.assertEquals(permutation.fromIndex(i), fromIndex[i]);
+        }
+        Assert.assertTrue(AlleleListUtils.equals(permutation, targetAlleleList));
+
+    }
+
+
+    private List<Allele>[] alleleLists;
+
+    @BeforeClass
+    public void setUp() {
+        alleleLists = new List[ALLELE_COUNT.length * MAX_ALLELE_LENGTH.length];
+        int nextIndex = 0;
+        for (int i = 0; i < ALLELE_COUNT.length; i++)
+            for (int j = 0; j < MAX_ALLELE_LENGTH.length; j++)
+                alleleLists[nextIndex++] = Arrays.asList(AlleleListUnitTester.generateRandomAlleles(ALLELE_COUNT[i], MAX_ALLELE_LENGTH[j]));
+    }
+
+    private static final int[] ALLELE_COUNT = { 0, 1, 5, 10, 20};
+
+    private static final int[] MAX_ALLELE_LENGTH = { 1, 2, 3, 10 };
+
+    @DataProvider(name="singleAlleleListData")
+    public Object[][] singleAlleleListData() {
+        final Object[][] result = new Object[alleleLists.length][];
+        for (int i = 0; i < alleleLists.length; i++)
+            result[i] = new Object[] { alleleLists[i]};
+        return result;
+    }
+
+    @DataProvider(name="twoAlleleListData")
+    public Object[][] twoAlleleListData() {
+        final Object[][] result = new Object[alleleLists.length * alleleLists.length][];
+        int index = 0;
+        for (int i = 0; i < alleleLists.length; i++)
+            for (int j = 0; j < alleleLists.length; j++)
+                result[index++] = new Object[] { alleleLists[i], alleleLists[j]};
+        return result;
+    }
+
+
+
+
+
+
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/genotyper/IndexedAlleleListUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/genotyper/IndexedAlleleListUnitTest.java
@@ -1,0 +1,59 @@
+package org.broadinstitute.hellbender.utils.genotyper;
+
+import htsjdk.variant.variantcontext.Allele;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static org.broadinstitute.hellbender.utils.genotyper.AlleleListUnitTester.assertAlleleList;
+
+/**
+ * Tests {@link org.broadinstitute.gatk.utils.genotyper.IndexedSampleList}.
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public final class IndexedAlleleListUnitTest {
+
+    @Test
+    public void testEmptyConstructor() {
+        final IndexedAlleleList<Allele> subject = new IndexedAlleleList<>();
+        assertAlleleList(subject, Collections.EMPTY_LIST);
+    }
+
+    @Test(dataProvider= "alleleCountMaxAlleleLengthData")
+    public void testArrayConstructor(final int alleleCount, final int maxAlleleLength) {
+        final Allele[] alleles = AlleleListUnitTester.generateRandomAlleles(alleleCount, maxAlleleLength);
+
+        final LinkedHashSet<Allele> nonRepeatedAlleles = new LinkedHashSet<>(Arrays.asList(alleles));
+        final IndexedAlleleList<Allele> subject = new IndexedAlleleList<>(alleles);
+        assertAlleleList(subject, Arrays.asList(nonRepeatedAlleles.toArray(new Allele[nonRepeatedAlleles.size()])));
+    }
+
+    @Test(dataProvider= "alleleCountMaxAlleleLengthData")
+    public void testCollectionConstructor(final int alleleCount, final int maxAlleleLength) {
+        final Allele[] alleles = AlleleListUnitTester.generateRandomAlleles(alleleCount, maxAlleleLength);
+
+        final List<Allele> alleleList = Arrays.asList(alleles);
+        final LinkedHashSet<Allele> nonRepeatedAlleles = new LinkedHashSet<>(Arrays.asList(alleles));
+        final IndexedAlleleList<Allele> subject = new IndexedAlleleList<>(alleleList);
+        assertAlleleList(subject, Arrays.asList(nonRepeatedAlleles.toArray(new Allele[nonRepeatedAlleles.size()])));
+    }
+
+    private static final int[] SAMPLE_COUNT = { 0, 1, 5, 10, 20};
+
+    private static final int[] MAX_ALLELE_LENGTH = { 1, 2, 3, 10 };
+
+    @DataProvider(name="alleleCountMaxAlleleLengthData")
+    public Object[][] alleleCountMaxAlleleLengthData() {
+        final Object[][] result = new Object[SAMPLE_COUNT.length * MAX_ALLELE_LENGTH.length][];
+        int nextIndex = 0;
+        for (int i = 0; i < SAMPLE_COUNT.length; i++)
+            for (int j = 0; j < MAX_ALLELE_LENGTH.length; j++)
+                result[nextIndex++] = new Object[] { SAMPLE_COUNT[i], MAX_ALLELE_LENGTH[j]};
+        return result;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMMModelUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMMModelUnitTest.java
@@ -1,0 +1,293 @@
+package org.broadinstitute.hellbender.utils.pairhmm;
+
+import org.broadinstitute.hellbender.utils.QualityUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * Unit tests for {@link PairHMMModel}
+ *
+ * @author Valentin Ruano-Rubio &lt;valentin@broadinstitute.org&gt;
+ */
+public final class PairHMMModelUnitTest extends BaseTest {
+
+    final double TOLERANCE = 1E-9;
+
+    @Test(dataProvider="qualToProbsDataProvider")
+    public void testQualToProbs(final int insQual, final int delQual, final int gcp, final double[] expected) {
+        final double[] actual = PairHMMModel.qualToTransProbs((byte)insQual,(byte)delQual,(byte)gcp);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.length, PairHMMModel.TRANS_PROB_ARRAY_LENGTH);
+        assertEqualsDoubleArray(actual,expected,TOLERANCE);
+        Assert.assertEquals(actual.length, PairHMMModel.TRANS_PROB_ARRAY_LENGTH);
+    }
+
+    @Test(dataProvider="qualToProbsDataProvider")
+    public void testQualToProbsLog10(final int insQuals, final int delQual, final int gcp, final double[] expected) {
+        final double[] logExpected = new double[expected.length];
+        for (int i = 0; i < logExpected.length; i++)
+            logExpected[i] = Math.log10(expected[i]);
+        final double[] actual = PairHMMModel.qualToTransProbsLog10((byte)insQuals,(byte)delQual,(byte)gcp);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.length, PairHMMModel.TRANS_PROB_ARRAY_LENGTH);
+        assertEqualsDoubleArray(actual,logExpected,TOLERANCE);
+    }
+
+    @Test(dataProvider="qualToProbsDataProvider")
+    public void testQualToProbsFill(final int insQual, final int delQual, final int gcp, final double[] expected) {
+        final double[] actual = new double[PairHMMModel.TRANS_PROB_ARRAY_LENGTH];
+        PairHMMModel.qualToTransProbs(actual, (byte) insQual, (byte) delQual, (byte) gcp);
+        assertEqualsDoubleArray(actual,expected,TOLERANCE);
+    }
+
+    @Test(dataProvider="qualToTransDataProvider")
+    public void testQualsToTransProbs(final byte[] insQuals, final byte[] delQuals, final byte[] gapQuals, final double[][] expected) {
+        final double[][] actual = PairHMMModel.qualToTransProbs(insQuals,delQuals,gapQuals);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.length, expected.length);
+        Assert.assertNotNull(actual[0]);
+        Assert.assertEquals(actual[0].length, expected[0].length);
+        for (int i = 0; i < actual.length ; i++)
+            assertEqualsDoubleArray(actual[i],expected[i],TOLERANCE);
+    }
+
+    @Test(dataProvider="qualToTransDataProvider")
+    public void testQualsToTransProbsLog10(final byte[] insQuals, final byte[] delQuals, final byte[] gapQuals, final double[][] expected) {
+        final double[][] actual = PairHMMModel.qualToTransProbsLog10(insQuals,delQuals,gapQuals);
+        final double[][] logExpected = new double[expected.length][expected[0].length];
+        for (int i = 1; i < expected.length; i++)
+            for (int j = 0; j < expected[0].length; j++)
+                logExpected[i][j] = Math.log10(expected[i][j]);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.length, logExpected.length);
+        Assert.assertNotNull(actual[0]);
+        Assert.assertEquals(actual[0].length, logExpected[0].length);
+        for (int i = 0; i < actual.length ; i++)
+            assertEqualsDoubleArray(actual[i],logExpected[i],TOLERANCE);
+    }
+
+    @Test(dataProvider="qualToTransDataProvider")
+    public void testQualsToTransProbsLog10Fill(final byte[] insQuals, final byte[] delQuals, final byte[] gapQuals, final double[][] expected) {
+        final double[][] actual = PairHMMModel.createTransitionMatrix(insQuals.length);
+        PairHMMModel.qualToTransProbsLog10(actual,insQuals,delQuals,gapQuals);
+        final double[][] logExpected = new double[expected.length][expected[0].length];
+        for (int i = 1; i < expected.length; i++)
+            for (int j = 0; j < expected[0].length; j++)
+                logExpected[i][j] = Math.log10(expected[i][j]);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.length, logExpected.length);
+        Assert.assertNotNull(actual[0]);
+        Assert.assertEquals(actual[0].length, logExpected[0].length);
+        for (int i = 0; i < actual.length ; i++)
+            assertEqualsDoubleArray(actual[i],logExpected[i],TOLERANCE);
+    }
+
+    @Test(dataProvider="qualToTransDataProvider")
+    public void testQualsToTransProbsFill(final byte[] insQuals, final byte[] delQuals, final byte[] gapQuals, final double[][] expected) {
+        final double[][] actual = PairHMMModel.createTransitionMatrix(insQuals.length);
+        PairHMMModel.qualToTransProbs(actual,insQuals,delQuals,gapQuals);
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.length, expected.length);
+        Assert.assertNotNull(actual[0]);
+        Assert.assertEquals(actual[0].length, expected[0].length);
+        for (int i = 0; i < actual.length ; i++)
+            assertEqualsDoubleArray(actual[i],expected[i],TOLERANCE);
+    }
+    @Test(dataProvider="qualToProbsDataProvider")
+    public void testQualToProbsLog10Fill(final int insQuals, final int delQual, final int gcp, final double[] expected) {
+        final double[] logExpected = new double[expected.length];
+        for (int i = 0; i < logExpected.length; i++)
+            logExpected[i] = Math.log10(expected[i]);
+        final double[] actual = new double[PairHMMModel.TRANS_PROB_ARRAY_LENGTH];
+        PairHMMModel.qualToTransProbsLog10(actual, (byte) insQuals, (byte) delQual, (byte) gcp);
+        assertEqualsDoubleArray(actual,logExpected,TOLERANCE);
+    }
+
+
+    @DataProvider(name="qualToTransDataProvider")
+    public Iterator<Object[]> qualToTransDataProvider() {
+        return new Iterator<Object[]>() {
+
+            private final Iterator<Integer> readLengthIterator = readLengthIterator();
+            private Iterator<int[]> qualsIterator = qualIterator();
+
+            @Override
+            public boolean hasNext() {
+                return readLengthIterator.hasNext();
+            }
+
+            @Override
+            public Object[] next() {
+                final int readLength = readLengthIterator.next();
+                double[][] matrix = new double[readLength+1][PairHMMModel.TRANS_PROB_ARRAY_LENGTH];
+                final byte[] insQuals = new byte[readLength];
+                final byte[] delQuals = new byte[readLength];
+                final byte[] gapQuals = new byte[readLength];
+                for (int i = 0; i < readLength; i++) {
+                    if (!qualsIterator.hasNext())
+                        qualsIterator = qualIterator();
+                    final int[] quals = qualsIterator.next();
+                    final int insQual = quals[0];
+                    final int delQual = quals[1];
+                    final int gapQual = quals[2];
+                    final double[] trans = qualsToProbs(insQual, delQual, gapQual);
+                    matrix[i+1] = trans;
+                    insQuals[i] = (byte)insQual;
+                    delQuals[i] = (byte)delQual;
+                    gapQuals[i] = (byte)gapQual;
+                }
+
+                return new Object[] { insQuals, delQuals, gapQuals, matrix };
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+
+    @DataProvider(name="qualToProbsDataProvider")
+    public Iterator<Object[]> qualToProbsDataProvider() {
+        return new Iterator<Object[]>() {
+            private final Iterator<int[]> qualsIterator = qualIterator();
+
+            @Override
+            public boolean hasNext() {
+                return qualsIterator.hasNext();
+            }
+
+            @Override
+            public Object[] next() {
+                final int[] quals = qualsIterator.next();
+                final int insQual = quals[0];
+                final int delQual = quals[1];
+                final int gapQual = quals[2];
+
+                final double[] trans = qualsToProbs(insQual, delQual, gapQual);
+
+
+                return new Object[] { insQual, delQual, gapQual, trans };
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    private double[] qualsToProbs(final int insQual, final int delQual, final int gapQual) {
+        final double[] trans = new double[PairHMMModel.TRANS_PROB_ARRAY_LENGTH];
+        final double matchToMatch = PairHMMModel.matchToMatchProb(insQual, delQual);
+        final double matchToInsert = QualityUtils.qualToErrorProb(insQual);
+        final double matchToDeletion = QualityUtils.qualToErrorProb(delQual);
+        final double indelToMatch = QualityUtils.qualToProb(gapQual);
+        final double indelToIndel = QualityUtils.qualToErrorProb(gapQual);
+
+        trans[PairHMMModel.matchToMatch] = matchToMatch;
+        trans[PairHMMModel.matchToInsertion] = matchToInsert;
+        trans[PairHMMModel.matchToDeletion] = matchToDeletion;
+        trans[PairHMMModel.indelToMatch] = indelToMatch;
+        trans[PairHMMModel.deletionToDeletion] = trans[PairHMMModel.insertionToInsertion] = indelToIndel;
+        return trans;
+    }
+
+    private Iterator<Integer> readLengthIterator() {
+        return Arrays.asList(READ_LENGTHS).iterator();
+    }
+
+    private Iterator<int[]> qualIterator() {
+        final int totalCount = INS_QUALS.length * DEL_QUALS.length * GAP_QUALS.length;
+
+        return new Iterator<int[]>() {
+
+            private int i = 0;
+
+            @Override
+            public boolean hasNext() {
+                return i < totalCount;
+            }
+
+            @Override
+            public int[] next() {
+                final int gap = i % GAP_QUALS.length;
+                final int indelGroup = i / GAP_QUALS.length;
+                final int del = indelGroup % DEL_QUALS.length;
+                final int ins = indelGroup % DEL_QUALS.length;
+                i++;
+                return new int[] { INS_QUALS[ins], DEL_QUALS[del], GAP_QUALS[gap]};
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+
+
+    @Test(dataProvider = "dualTestDataProvider")
+    public void testDoubleQualToProb(final int insQual, final int delQual, final double log10Expected, final double expected) {
+        Assert.assertEquals(PairHMMModel.matchToMatchProb(insQual, delQual), expected, TOLERANCE);
+        Assert.assertEquals(PairHMMModel.matchToMatchProb(delQual, insQual), expected, TOLERANCE);
+        Assert.assertEquals(PairHMMModel.matchToMatchProbLog10(insQual, delQual), log10Expected, TOLERANCE);
+        Assert.assertEquals(PairHMMModel.matchToMatchProbLog10(delQual, insQual), log10Expected, TOLERANCE);
+        Assert.assertEquals(PairHMMModel.matchToMatchProb((byte) insQual, (byte) delQual), expected, TOLERANCE);
+        Assert.assertEquals(PairHMMModel.matchToMatchProbLog10((byte) insQual, (byte) delQual), log10Expected, TOLERANCE);
+    }
+
+    @DataProvider(name = "dualTestDataProvider")
+    private Iterator<Object[]> dualTestDataProvider() {
+        final int[] testQuals = new int[] { 0, 1, 2, 5, 10, 13, 17, 20, 23, 27, 30, 43, 57, 70, 100, 200, 254};
+
+        return new Iterator<Object[]>() {
+            private int i = 0;
+            private int j = 0;
+
+            @Override
+            public Object[] next() {
+
+                final int qual1 =  testQuals[i];
+                final int qual2 =  testQuals[j];
+
+                final double errorProb1 = Math.pow(10, -0.1 * qual1);
+                final double errorProb2 = Math.pow(10, -0.1 * qual2);
+                final double expected = Math.max(0, (1 - (errorProb1 + errorProb2)));
+                final Object[] result = new Object[] { qual1, qual2, Math.log10(Math.min(1, expected)), Math.min(1, expected)};
+
+                if (++j >= testQuals.length) {
+                    i++;
+                    j = i;
+                }
+                return result;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean hasNext() {
+                return i < testQuals.length;
+            }
+        };
+    }
+
+
+    private static int[] INS_QUALS = {30, 45, 20, 10, 5, 60, 123 };
+
+    private static int[] DEL_QUALS = {30, 45, 20, 10, 5, 60, 123 };
+
+    private static int[] GAP_QUALS = {10, 20, 5};
+
+    private static Integer[] READ_LENGTHS = { 0, 1, 5, 20, 100, 250};
+}

--- a/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMMUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/pairhmm/PairHMMUnitTest.java
@@ -1,0 +1,720 @@
+package org.broadinstitute.hellbender.utils.pairhmm;
+
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.utils.BaseUtils;
+import org.broadinstitute.hellbender.utils.MathUtils;
+import org.broadinstitute.hellbender.utils.QualityUtils;
+import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.genotyper.LikelihoodMatrix;
+import org.broadinstitute.hellbender.utils.haplotype.Haplotype;
+import org.broadinstitute.hellbender.utils.read.ArtificialSAMUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+public final class PairHMMUnitTest extends BaseTest {
+    private final static boolean ALLOW_READS_LONGER_THAN_HAPLOTYPE = true;
+    private final static boolean DEBUG = false;
+    final static boolean EXTENSIVE_TESTING = true;
+    final N2MemoryPairHMM exactHMM = new Log10PairHMM(true); // the log truth implementation
+    final N2MemoryPairHMM originalHMM = new Log10PairHMM(false); // the reference implementation
+    final N2MemoryPairHMM loglessHMM = new LoglessPairHMM();
+
+    @BeforeClass
+    public void initialize() {
+        exactHMM.doNotUseTristateCorrection();
+        originalHMM.doNotUseTristateCorrection();
+        loglessHMM.doNotUseTristateCorrection();
+    }
+
+    private List<N2MemoryPairHMM> getHMMs() {
+        return Arrays.asList(exactHMM, originalHMM, loglessHMM);
+    }
+
+    // --------------------------------------------------------------------------------
+    //
+    // Provider
+    //
+    // --------------------------------------------------------------------------------
+
+    private class BasicLikelihoodTestProvider {
+        final String ref, nextRef, read;
+        final byte[] refBasesWithContext, nextRefBasesWithContext, readBasesWithContext;
+        final int baseQual, insQual, delQual, gcp;
+        final int expectedQual;
+        final boolean left, right;
+        final static String CONTEXT = "ACGTAATGACGATTGCA";
+        final static String LEFT_FLANK = "GATTTATCATCGAGTCTGC";
+        final static String RIGHT_FLANK = "CATGGATCGTTATCAGCTATCTCGAGGGATTCACTTAACAGTTTTA";
+
+        public BasicLikelihoodTestProvider(final String ref, final String nextRef, final String read, final int baseQual, final int insQual, final int delQual, final int expectedQual, final int gcp ) {
+            this(ref, nextRef, read, baseQual, insQual, delQual, expectedQual, gcp, false, false);
+        }
+
+        public BasicLikelihoodTestProvider(final String ref, final String nextRef, final String read, final int baseQual, final int insQual, final int delQual, final int expectedQual, final int gcp, final boolean left, final boolean right) {
+            this.baseQual = baseQual;
+            this.delQual = delQual;
+            this.insQual = insQual;
+            this.gcp = gcp;
+            this.read = read;
+            this.ref = ref;
+            this.nextRef = nextRef;
+            this.expectedQual = expectedQual;
+            this.left = left;
+            this.right = right;
+
+            refBasesWithContext = asBytes(ref, left, right);
+            nextRefBasesWithContext = asBytes(nextRef, left, right);
+            readBasesWithContext = asBytes(read, false, false);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("ref=%s nextRef=%s read=%s b/i/d/c quals = %d/%d/%d/%d l/r flank = %b/%b e[qual]=%d", ref, nextRef, read, baseQual, insQual, delQual, gcp, left, right, expectedQual);
+        }
+
+        public double expectedLogL() {
+            return (expectedQual / -10.0) + 0.03 + Math.log10(1.0 / refBasesWithContext.length);
+        }
+
+        public double getTolerance(final PairHMM hmm) {
+            if ( hmm instanceof Log10PairHMM ) {
+                return ((Log10PairHMM)hmm).isDoingExactLog10Calculations() ? toleranceFromExact() : toleranceFromReference();
+            } else
+                return toleranceFromTheoretical();
+        }
+
+        public double toleranceFromTheoretical() {
+            return 0.2;
+        }
+
+        public double toleranceFromReference() {
+            return 1E-3; // has to be very tolerant -- this approximation is quite approximate
+        }
+
+        public double toleranceFromExact() {
+            return 1E-9;
+        }
+
+        public double calcLogL( final PairHMM pairHMM, boolean anchorIndel ) {
+            pairHMM.initialize(readBasesWithContext.length, refBasesWithContext.length);
+            return pairHMM.computeReadLikelihoodGivenHaplotypeLog10(
+                    refBasesWithContext, readBasesWithContext,
+                    qualAsBytes(baseQual, false, anchorIndel), qualAsBytes(insQual, true, anchorIndel), qualAsBytes(delQual, true, anchorIndel),
+                    qualAsBytes(gcp, false, anchorIndel), true, nextRefBasesWithContext);
+        }
+
+        private byte[] asBytes(final String bases, final boolean left, final boolean right) {
+            if(bases == null)
+                return null;
+            else
+                return ( (left ? LEFT_FLANK : "") + CONTEXT + bases + CONTEXT + (right ? RIGHT_FLANK : "")).getBytes();
+        }
+
+        private byte[] qualAsBytes(final int phredQual, final boolean doGOP, final boolean anchorIndel) {
+            final byte phredQuals[] = new byte[readBasesWithContext.length];
+
+            if( anchorIndel ) {
+                // initialize everything to MASSIVE_QUAL so it cannot be moved by HMM
+                Arrays.fill(phredQuals, (byte) 100);
+
+                // update just the bases corresponding to the provided micro read with the quality scores
+                if( doGOP ) {
+                    phredQuals[CONTEXT.length()] = (byte)phredQual;
+                } else {
+                    for ( int i = 0; i < read.length(); i++)
+                        phredQuals[i + CONTEXT.length()] = (byte)phredQual;
+                }
+            } else {
+                Arrays.fill(phredQuals, (byte) phredQual);
+            }
+
+            return phredQuals;
+        }
+    }
+
+    @DataProvider(name = "BasicLikelihoodTestProvider")
+    public Object[][] makeBasicLikelihoodTests() {
+        // context on either side is ACGTTGCA REF ACGTTGCA
+        // test all combinations
+        final List<Integer> baseQuals = EXTENSIVE_TESTING ? Arrays.asList(10, 20, 30, 40, 50) : Arrays.asList(30);
+        final List<Integer> indelQuals = EXTENSIVE_TESTING ? Arrays.asList(20, 30, 40, 50) : Arrays.asList(40);
+        final List<Integer> gcps = EXTENSIVE_TESTING ? Arrays.asList(8, 10, 20) : Arrays.asList(10);
+        final List<Integer> sizes = EXTENSIVE_TESTING ? Arrays.asList(2, 3, 4, 5, 7, 8, 9, 10, 20, 30, 35) : Arrays.asList(2);
+
+        final List<Object[]> tests = new ArrayList<>();
+
+        for ( final int baseQual : baseQuals ) {
+            for ( final int indelQual : indelQuals ) {
+                for ( final int gcp : gcps ) {
+
+                    // test substitutions
+                    for ( final byte refBase : BaseUtils.BASES ) {
+                        for ( final byte readBase : BaseUtils.BASES ) {
+                            final String ref  = new String(new byte[]{refBase});
+                            final String read = new String(new byte[]{readBase});
+                            final int expected = refBase == readBase ? 0 : baseQual;
+                            // runBasicLikelihoodTests uses calcLogL(), which runs HMM with recacheReads=true. Since we will not cache, should pass null in place of a nextRef
+                            tests.add(new Object[]{new BasicLikelihoodTestProvider(ref, null, read, baseQual, indelQual, indelQual, expected, gcp)});
+                        }
+                    }
+
+                    // test insertions and deletions
+                    for ( final int size : sizes ) {
+                        for ( final byte base : BaseUtils.BASES ) {
+                            final int expected = indelQual + (size - 2) * gcp;
+
+                            for ( boolean insertionP : Arrays.asList(true, false)) {
+                                final String small = Utils.dupString((char) base, 1);
+                                final String big = Utils.dupString((char) base, size);
+
+                                final String ref = insertionP ? small : big;
+                                final String read = insertionP ? big : small;
+
+                                // runBasicLikelihoodTests uses calcLogL(), which runs HMM with recacheReads=true. Since we will not cache, should pass null in place of a nextRef
+                                tests.add(new Object[]{new BasicLikelihoodTestProvider(ref, null, read, baseQual, indelQual, indelQual, expected, gcp)});
+                                tests.add(new Object[]{new BasicLikelihoodTestProvider(ref, null, read, baseQual, indelQual, indelQual, expected, gcp, true, false)});
+                                tests.add(new Object[]{new BasicLikelihoodTestProvider(ref, null, read, baseQual, indelQual, indelQual, expected, gcp, false, true)});
+                                tests.add(new Object[]{new BasicLikelihoodTestProvider(ref, null, read, baseQual, indelQual, indelQual, expected, gcp, true, true)});
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @DataProvider(name = "OptimizedLikelihoodTestProvider")
+    public Object[][] makeOptimizedLikelihoodTests() {
+        Utils.resetRandomGenerator();
+        final Random random = Utils.getRandomGenerator();
+        final List<Integer> baseQuals = EXTENSIVE_TESTING ? Arrays.asList(10, 30, 40, 60) : Arrays.asList(30);
+        final List<Integer> indelQuals = EXTENSIVE_TESTING ? Arrays.asList(20, 40, 60) : Arrays.asList(40);
+        final List<Integer> gcps = EXTENSIVE_TESTING ? Arrays.asList(10, 20, 30) : Arrays.asList(10);
+        final List<Integer> sizes = EXTENSIVE_TESTING ? Arrays.asList(3, 20, 50, 90, 160) : Arrays.asList(2);
+
+        final List<Object[]> tests = new ArrayList<>();
+
+        for ( final int baseQual : baseQuals ) {
+            for ( final int indelQual : indelQuals ) {
+                for ( final int gcp : gcps ) {
+                    for ( final int refSize : sizes ) {
+                        for ( final int readSize : sizes ) {
+                            String ref = "";
+                            String read = "";
+                            for( int iii = 0; iii < refSize; iii++) {
+                                ref += (char) BaseUtils.BASES[random.nextInt(4)];
+                            }
+                            for( int iii = 0; iii < readSize; iii++) {
+                                read += (char) BaseUtils.BASES[random.nextInt(4)];
+                            }
+
+                            for ( final boolean leftFlank : Arrays.asList(true, false) )
+                                for ( final boolean rightFlank : Arrays.asList(true, false) )
+                                    // runOptimizedLikelihoodTests uses calcLogL(), which runs HMM with recacheReads=true. Since we will not cache, should pass null in place of a nextRef
+                                    tests.add(new Object[]{new BasicLikelihoodTestProvider(ref, null, read, baseQual, indelQual, indelQual, -0, gcp, leftFlank, rightFlank)});
+                        }
+                    }
+                }
+            }
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(enabled = !DEBUG, dataProvider = "BasicLikelihoodTestProvider")
+    public void testBasicLikelihoods(BasicLikelihoodTestProvider cfg) {
+        if ( ALLOW_READS_LONGER_THAN_HAPLOTYPE || cfg.read.length() <= cfg.ref.length() ) {
+            final double exactLogL = cfg.calcLogL( exactHMM, true );
+            for ( final PairHMM hmm : getHMMs() ) {
+                final double actualLogL = cfg.calcLogL( hmm, true );
+                final double expectedLogL = cfg.expectedLogL();
+
+                // compare to our theoretical expectation with appropriate tolerance
+                Assert.assertEquals(actualLogL, expectedLogL, cfg.toleranceFromTheoretical(), "Failed with hmm " + hmm);
+                // compare to the exact reference implementation with appropriate tolerance
+                Assert.assertEquals(actualLogL, exactLogL, cfg.getTolerance(hmm), "Failed with hmm " + hmm);
+                Assert.assertTrue(MathUtils.goodLog10Probability(actualLogL), "Bad log10 likelihood " + actualLogL);
+            }
+        }
+    }
+
+    @Test(enabled = !DEBUG, dataProvider = "OptimizedLikelihoodTestProvider")
+    public void testOptimizedLikelihoods(BasicLikelihoodTestProvider cfg) {
+        if ( ALLOW_READS_LONGER_THAN_HAPLOTYPE || cfg.read.length() <= cfg.ref.length() ) {
+            final double exactLogL = cfg.calcLogL( exactHMM, false );
+
+            for ( final PairHMM hmm : getHMMs() ) {
+                final double calculatedLogL = cfg.calcLogL( hmm, false );
+                // compare to the exact reference implementation with appropriate tolerance
+                Assert.assertEquals(calculatedLogL, exactLogL, cfg.getTolerance(hmm), String.format("Test: logL calc=%.2f expected=%.2f for %s with hmm %s", calculatedLogL, exactLogL, cfg.toString(), hmm));
+                Assert.assertTrue(MathUtils.goodLog10Probability(calculatedLogL), "Bad log10 likelihood " + calculatedLogL);
+            }
+        }
+    }
+
+    @Test(enabled = !DEBUG)
+    public void testMismatchInEveryPositionInTheReadWithCenteredHaplotype() {
+        final byte[] haplotype1 = "TTCTCTTCTGTTGTGGCTGGTT".getBytes();
+        final byte matchQual = 90;
+        final byte mismatchQual = 20;
+        final byte indelQual = 80;
+        final int offset = 2;
+        final byte[] gop = new byte[haplotype1.length - 2 * offset];
+        Arrays.fill(gop, indelQual);
+        final byte[] gcp = new byte[haplotype1.length - 2 * offset];
+        Arrays.fill(gcp, indelQual);
+        loglessHMM.initialize(gop.length, haplotype1.length);
+
+        for( int k = 0; k < haplotype1.length - 2 * offset; k++ ) {
+            final byte[] quals = new byte[haplotype1.length - 2 * offset];
+            Arrays.fill(quals, matchQual);
+            // one base mismatches the haplotype
+            quals[k] = mismatchQual;
+            final byte[] mread = Arrays.copyOfRange(haplotype1,offset,haplotype1.length-offset);
+            // change single base at position k to C. If it's a C, change to T
+            mread[k] = ( mread[k] == (byte)'C' ? (byte)'T' : (byte)'C');
+            final double res1 = loglessHMM.computeReadLikelihoodGivenHaplotypeLog10(haplotype1, mread, quals, gop, gop, gcp, true, null);
+            final double expected = Math.log10(1.0/haplotype1.length * Math.pow(QualityUtils.qualToProb(matchQual), mread.length-1) * QualityUtils.qualToErrorProb(mismatchQual));
+            Assert.assertEquals(res1, expected, 1e-2);
+        }
+    }
+
+
+    @Test(enabled = ! DEBUG)
+    public void testMismatchInEveryPositionInTheRead() {
+        final byte[] haplotype1 = "TTCTCTTCTGTTGTGGCTGGTT".getBytes();
+        final byte matchQual = 90;
+        final byte mismatchQual = 20;
+        final byte indelQual = 80;
+
+        final int offset = 2;
+        final byte[] gop = new byte[haplotype1.length - offset];
+        Arrays.fill(gop, indelQual);
+        final byte[] gcp = new byte[haplotype1.length - offset];
+        Arrays.fill(gcp, indelQual);
+        loglessHMM.initialize(gop.length, haplotype1.length);
+
+        for( int k = 0; k < haplotype1.length - offset; k++ ) {
+            final byte[] quals = new byte[haplotype1.length - offset];
+            Arrays.fill(quals, matchQual);
+            // one base mismatches the haplotype with low qual
+            quals[k] = mismatchQual;
+            final byte[] mread = Arrays.copyOfRange(haplotype1,offset,haplotype1.length);
+            // change single base at position k to C. If it's a C, change to T
+            mread[k] = ( mread[k] == (byte)'C' ? (byte)'T' : (byte)'C');
+            final double res1 = loglessHMM.computeReadLikelihoodGivenHaplotypeLog10(haplotype1, mread, quals, gop, gop, gcp, true , null);
+            final double expected = Math.log10(1.0/haplotype1.length * Math.pow(QualityUtils.qualToProb(matchQual), mread.length-1) * QualityUtils.qualToErrorProb(mismatchQual));
+            Assert.assertEquals(res1, expected, 1e-2);
+        }
+    }
+
+    @DataProvider(name = "HMMProvider")
+    public Object[][] makeHMMProvider() {
+        List<Object[]> tests = new ArrayList<>();
+
+        for ( final int readSize : Arrays.asList(1, 2, 5, 10) ) {
+            for ( final int refSize : Arrays.asList(1, 2, 5, 10) ) {
+                if ( refSize > readSize ) {
+                    for ( final PairHMM hmm : getHMMs() )
+                        tests.add(new Object[]{hmm, readSize, refSize});
+                }
+            }
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(enabled = !DEBUG, dataProvider = "HMMProvider")
+    void testMultipleReadMatchesInHaplotype(final PairHMM hmm, final int readSize, final int refSize) {
+        final byte[] readBases =  Utils.dupBytes((byte)'A', readSize);
+        final byte[] refBases = ("CC" + new String(Utils.dupBytes((byte)'A', refSize)) + "GGA").getBytes();
+        final byte baseQual = 20;
+        final byte insQual = 37;
+        final byte delQual = 37;
+        final byte gcp = 10;
+        hmm.initialize(readBases.length, refBases.length);
+        // running HMM with no haplotype caching. Should therefore pass null in place of nextRef bases
+        final double d = hmm.computeReadLikelihoodGivenHaplotypeLog10( refBases, readBases,
+                Utils.dupBytes(baseQual, readBases.length),
+                Utils.dupBytes(insQual, readBases.length),
+                Utils.dupBytes(delQual, readBases.length),
+                Utils.dupBytes(gcp, readBases.length), true, null);
+        Assert.assertTrue(d <= 0.0, "Likelihoods should be <= 0 but got " + d);
+    }
+
+    @Test(enabled = !DEBUG, dataProvider = "HMMProvider")
+    void testAllMatchingRead(final PairHMM hmm, final int readSize, final int refSize) {
+        final byte[] readBases =  Utils.dupBytes((byte)'A', readSize);
+        final byte[] refBases = Utils.dupBytes((byte) 'A', refSize);
+        final byte baseQual = 20;
+        final byte insQual = 100;
+        final byte delQual = 100;
+        final byte gcp = 100;
+        hmm.initialize(readBases.length, refBases.length);
+        // running HMM with no haplotype caching. Should therefore pass null in place of nextRef bases
+        double d = hmm.computeReadLikelihoodGivenHaplotypeLog10( refBases, readBases,
+                Utils.dupBytes(baseQual, readBases.length),
+                Utils.dupBytes(insQual, readBases.length),
+                Utils.dupBytes(delQual, readBases.length),
+                Utils.dupBytes(gcp, readBases.length), true, null);
+        double expected = getExpectedMathingLikelihood(readBases, refBases, baseQual, insQual);
+        Assert.assertEquals(d, expected, 1e-3, "Likelihoods should sum to just the error prob of the read " + String.format("readSize=%d refSize=%d", readSize, refSize));
+    }
+
+    private double getExpectedMathingLikelihood(byte[] readBases, byte[] refBases, byte baseQual, byte insQual) {
+        double expected =  0;
+        final double initialCondition = ((double) Math.abs(refBases.length - readBases.length + 1))/refBases.length;
+        if (readBases.length < refBases.length) {
+            expected = Math.log10(initialCondition * Math.pow(QualityUtils.qualToProb(baseQual), readBases.length));
+        } else if (readBases.length > refBases.length) {
+            expected = Math.log10(initialCondition * Math.pow(QualityUtils.qualToProb(baseQual), refBases.length) * Math.pow(QualityUtils.qualToErrorProb(insQual), readBases.length - refBases.length));
+        }
+        return expected;
+    }
+
+    @DataProvider(name = "HMMProviderWithBigReads")
+    public Object[][] makeBigReadHMMProvider() {
+        List<Object[]> tests = new ArrayList<>();
+
+        final String read1 = "ACCAAGTAGTCACCGT";
+        final String ref1  = "ACCAAGTAGTCACCGTAACG";
+
+        for ( final int nReadCopies : Arrays.asList(1, 2, 10, 20, 50) ) {
+            for ( final int nRefCopies : Arrays.asList(1, 2, 10, 20, 100) ) {
+                if ( nRefCopies > nReadCopies ) {
+                    for ( final PairHMM hmm : getHMMs() ) {
+                        final String read = Utils.dupString(read1, nReadCopies);
+                        final String ref  = Utils.dupString(ref1, nRefCopies);
+                        tests.add(new Object[]{hmm, read, ref});
+                    }
+                }
+            }
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(enabled = !DEBUG, dataProvider = "HMMProviderWithBigReads")
+    void testReallyBigReads(final PairHMM hmm, final String read, final String ref) {
+        final byte[] readBases =  read.getBytes();
+        final byte[] refBases = ref.getBytes();
+        final byte baseQual = 30;
+        final byte insQual = 40;
+        final byte delQual = 40;
+        final byte gcp = 10;
+        hmm.initialize(readBases.length, refBases.length);
+        // running HMM with no haplotype caching. Should therefore pass null in place of nextRef bases
+        hmm.computeReadLikelihoodGivenHaplotypeLog10( refBases, readBases,
+                Utils.dupBytes(baseQual, readBases.length),
+                Utils.dupBytes(insQual, readBases.length),
+                Utils.dupBytes(delQual, readBases.length),
+                Utils.dupBytes(gcp, readBases.length), true, null);
+    }
+
+    @Test(enabled = !DEBUG)
+    void testPreviousBadValue() {
+        final byte[] readBases = "A".getBytes();
+        final byte[] refBases =  "AT".getBytes();
+        final byte baseQual = 30;
+        final byte insQual = 40;
+        final byte delQual = 40;
+        final byte gcp = 10;
+        // running HMMs with no haplotype caching. Should therefore pass null in place of nextRef bases
+        exactHMM.initialize(readBases.length, refBases.length);
+        exactHMM.computeReadLikelihoodGivenHaplotypeLog10( refBases, readBases,
+                Utils.dupBytes(baseQual, readBases.length),
+                Utils.dupBytes(insQual, readBases.length),
+                Utils.dupBytes(delQual, readBases.length),
+                Utils.dupBytes(gcp, readBases.length), true, null);
+
+        loglessHMM.initialize(readBases.length, refBases.length);
+        loglessHMM.computeReadLikelihoodGivenHaplotypeLog10( refBases, readBases,
+                Utils.dupBytes(baseQual, readBases.length),
+                Utils.dupBytes(insQual, readBases.length),
+                Utils.dupBytes(delQual, readBases.length),
+                Utils.dupBytes(gcp, readBases.length), true, null);
+    }
+
+    @DataProvider(name = "JustHMMProvider")
+    public Object[][] makeJustHMMProvider() {
+        List<Object[]> tests = new ArrayList<>();
+
+        for ( final PairHMM hmm : getHMMs() ) {
+            tests.add(new Object[]{hmm});
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(enabled = !DEBUG, dataProvider = "JustHMMProvider")
+    void testMaxLengthsBiggerThanProvidedRead(final PairHMM hmm) {
+        final byte[] readBases = "CTATCTTAGTAAGCCCCCATACCTGCAAATTTCAGGATGTCTCCTCCAAAAATCAACA".getBytes();
+        final byte[] refBases =  "CTATCTTAGTAAGCCCCCATACCTGCAAATTTCAGGATGTCTCCTCCAAAAATCAAAACTTCTGAGAAAAAAAAAAAAAATTAAATCAAACCCTGATTCCTTAAAGGTAGTAAAAAAACATCATTCTTTCTTAGTGGAATAGAAACTAGGTCAAAAGAACAGTGATTC".getBytes();
+
+        final byte[] quals = new byte[]{35,34,31,32,35,34,32,31,36,30,31,32,36,34,33,32,32,32,33,32,30,35,33,35,36,36,33,33,33,32,32,32,37,33,36,35,33,32,34,31,36,35,35,35,35,33,34,31,31,30,28,27,26,29,26,25,29,29};
+        final byte[] insQual = new byte[]{46,46,46,46,46,47,45,46,45,48,47,44,45,48,46,43,43,42,48,48,45,47,47,48,48,47,48,45,38,47,45,39,47,48,47,47,48,46,49,48,49,48,46,47,48,44,44,43,39,32,34,36,46,48,46,44,45,45};
+        final byte[] delQual = new byte[]{44,44,44,43,45,44,43,42,45,46,45,43,44,47,45,40,40,40,45,46,43,45,45,44,46,46,46,43,35,44,43,36,44,45,46,46,44,44,47,43,47,45,45,45,46,45,45,46,44,35,35,35,45,47,45,44,44,43};
+        final byte[] gcp = Utils.dupBytes((byte) 10, delQual.length);
+        hmm.initialize(readBases.length + 100, refBases.length + 100);
+        for ( int nExtraMaxSize = 0; nExtraMaxSize < 100; nExtraMaxSize++ ) {
+            // running HMM with no haplotype caching. Should therefore pass null in place of nextRef bases
+            hmm.computeReadLikelihoodGivenHaplotypeLog10( refBases, readBases, quals, insQual, delQual, gcp, true, null);
+        }
+    }
+
+    @Test(dataProvider = "JustHMMProvider")
+    public void testLikelihoodsFromHaplotypes(final PairHMM hmm){
+        final int readSize= 10;
+        final int refSize = 20;
+        final byte[] readBases =  Utils.dupBytes((byte)'A', readSize);
+        final byte[] refBases = Utils.dupBytes((byte) 'A', refSize);
+        final byte baseQual = 20;
+        final byte insQual = 100;
+        final byte gcp = 100;
+
+        final Haplotype refH= new Haplotype(refBases, true);
+
+        final byte[] readQuals= Utils.dupBytes(baseQual, readBases.length);
+        final List<SAMRecord> reads = Arrays.asList(ArtificialSAMUtils.createArtificialRead(readBases, readQuals, readBases.length + "M"));
+        final Map<SAMRecord, byte[]> gpcs = buildGapContinuationPenalties(reads, gcp);
+
+        hmm.computeLikelihoods(matrix(Arrays.asList(refH)), Collections.emptyList(), gpcs);
+        Assert.assertEquals(hmm.getLikelihoodArray(), null);
+
+        hmm.computeLikelihoods(matrix(Arrays.asList(refH)), reads, gpcs);
+        final double expected = getExpectedMathingLikelihood(readBases, refBases, baseQual, insQual);
+        final double[] la = hmm.getLikelihoodArray();
+
+        Assert.assertEquals(la.length, 1);
+        Assert.assertEquals(la[0], expected, 1e-3, "Likelihoods should sum to just the error prob of the read " + String.format("readSize=%d refSize=%d", readSize, refSize));
+
+    }
+
+    private LikelihoodMatrix<Haplotype> matrix(final List<Haplotype> haplotypes) {
+        return new LikelihoodMatrix<Haplotype>() {
+            @Override
+            public List<SAMRecord> reads() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<Haplotype> alleles() {
+                return haplotypes;
+            }
+
+            @Override
+            public void set(int alleleIndex, int readIndex, double value) {
+//                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public double get(int alleleIndex, int readIndex) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int alleleIndex(Haplotype allele) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int readIndex(SAMRecord read) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int alleleCount() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int readCount() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Haplotype alleleAt(int alleleIndex) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public SAMRecord readAt(int readIndex) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void copyAlleleLikelihoods(int alleleIndex, double[] dest, int offset) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    private static Map<SAMRecord, byte[]> buildGapContinuationPenalties(final List<SAMRecord> processedReads, final byte gcp) {
+        final Map<SAMRecord,byte[]> result = new HashMap<>(processedReads.size());
+        for (final SAMRecord read : processedReads) {
+            final byte[] readGcpArray = new byte[read.getReadLength()];
+            Arrays.fill(readGcpArray,gcp);
+            result.put(read,readGcpArray);
+        }
+        return result;
+    }
+    
+    @DataProvider(name = "HaplotypeIndexingProvider")
+    public Object[][] makeHaplotypeIndexingProvider() {
+        List<Object[]> tests = new ArrayList<>();
+
+        // First difference (root2, root3) is the base position immediately following first difference (root1, root2)
+        final String root1    = "ACGTGTCAAACCGGGTT";
+        final String root2    = "ACGTGTCACACTGGGTT"; // differs in two locations from root1
+        final String root3    = "ACGTGTCACTCCGCGTT"; // differs in two locations from root2
+
+        final String read1    = "ACGTGTCACACTGGATT"; // 1 diff from 2, 2 diff from root1, 2 diff from root3
+        final String read2    = root1; // same as root1
+        final String read3    = root2; // same as root2
+        final String read4    = "ACGTGTCACACTGGATTCGAT";
+        final String read5    = "CCAGTAACGTGTCACACTGGATTCGAT";
+
+//        for ( final String read : Arrays.asList(read2) ) {
+        for ( final String read : Arrays.asList(read1, read2, read3, read4, read5) ) {
+            for ( final PairHMM hmm : getHMMs() ) {
+//                int readLength = read.length(); {
+                for ( int readLength = 10; readLength < read.length(); readLength++ ) {
+                    final String myRead = read.substring(0, readLength);
+                    tests.add(new Object[]{hmm, root1, root2, root3, myRead});
+                }
+            }
+        }
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(enabled = !DEBUG, dataProvider = "HaplotypeIndexingProvider")
+    void testHaplotypeIndexing(final PairHMM hmm, final String root1, final String root2, final String root3, final String read) {
+        final double TOLERANCE = 1e-9;
+        final String prefix   = "AACCGGTTTTTGGGCCCAAACGTACGTACAGTTGGTCAACATCGATCAGGTTCCGGAGTAC";
+
+        final int maxReadLength = read.length();
+        final int maxHaplotypeLength = prefix.length() + root1.length();
+
+        // the initialization occurs once, at the start of the evalution of reads
+        hmm.initialize(maxReadLength, maxHaplotypeLength);
+
+        for ( int prefixStart = prefix.length(); prefixStart >= 0; prefixStart-- ) {
+            final String myPrefix = prefix.substring(prefixStart, prefix.length());
+            final String hap1 = myPrefix + root1;
+            final String hap2 = myPrefix + root2;
+            final String hap3 = myPrefix + root3;
+
+            final int hapStart = PairHMM.findFirstPositionWhereHaplotypesDiffer(hap1.getBytes(), hap2.getBytes());
+
+            // Run the HMM on the first haplotype, peaking ahead the second, to set up caching
+            // Then run on the second haplotype in both cached and uncached mode, and verify that results are the same
+            // When evaluating actual2, it is important that we both apply old caching from hap1 and set up new caching for hap3, to ensure read/write operations do not cause conflicts
+            final double actual1 = testHaplotypeIndexingCalc(hmm, hap1, hap2, read, 0, true);
+            final double actual2 = testHaplotypeIndexingCalc(hmm, hap2, hap3, read, hapStart, false);
+            final double expected2 = testHaplotypeIndexingCalc(hmm, hap2, null, read, 0, true);
+            Assert.assertEquals(actual2, expected2, TOLERANCE, "HMM " + hmm.getClass() + " Caching calculation failed for read " + read + " against haplotype with prefix '" + myPrefix
+                    + "' expected " + expected2 + " but got " + actual2 + " with hapStart of " + hapStart);
+        }
+    }
+
+    private double testHaplotypeIndexingCalc(final PairHMM hmm, final String hap, final String nextHap, final String read, final int hapStart, final boolean recache) {
+        final byte[] readBases = read.getBytes();
+        // if not peaking ahead to capture info for a future cache run, the next haplotype will be null, and this should be passed to HMM
+        final byte[] nextHapBases = nextHap == null ? null : nextHap.getBytes();
+        final byte[] baseQuals = Utils.dupBytes((byte)30, readBases.length);
+        final byte[] insQuals = Utils.dupBytes((byte)45, readBases.length);
+        final byte[] delQuals = Utils.dupBytes((byte)40, readBases.length);
+        final byte[] gcp = Utils.dupBytes((byte) 10, readBases.length);
+        double d = hmm.computeReadLikelihoodGivenHaplotypeLog10(hap.getBytes(), readBases, baseQuals, insQuals, delQuals, gcp, recache, nextHapBases);
+        Assert.assertTrue(MathUtils.goodLog10Probability(d), "Likelihoods = " + d + " was bad for read " + read + " and ref " + hap + " with hapStart " + hapStart);
+        return d;
+    }
+
+    @Test(enabled = !DEBUG)
+    public void testFindFirstPositionWhereHaplotypesDiffer() {
+        for ( int haplotypeSize1 = 10; haplotypeSize1 < 30; haplotypeSize1++ ) {
+            for ( int haplotypeSize2 = 10; haplotypeSize2 < 50; haplotypeSize2++ ) {
+                final int maxLength = Math.max(haplotypeSize1, haplotypeSize2);
+                final int minLength = Math.min(haplotypeSize1, haplotypeSize2);
+                for ( int differingSite = 0; differingSite < maxLength + 1; differingSite++) {
+                    for ( final boolean oneIsDiff : Arrays.asList(true, false) ) {
+                        final byte[] hap1 = Utils.dupBytes((byte)'A', haplotypeSize1);
+                        final byte[] hap2 = Utils.dupBytes((byte)'A', haplotypeSize2);
+                        final int expected = oneIsDiff
+                                ? makeDiff(hap1, differingSite, minLength)
+                                : makeDiff(hap2, differingSite, minLength);
+                        final int actual = PairHMM.findFirstPositionWhereHaplotypesDiffer(hap1, hap2);
+                        Assert.assertEquals(actual, expected, "Bad differing site for " + new String(hap1) + " vs. " + new String(hap2));
+                    }
+                }
+            }
+        }
+    }
+
+    private int makeDiff(final byte[] bytes, final int site, final int minSize) {
+        if ( site < bytes.length ) {
+            bytes[site] = 'C';
+            return Math.min(site, minSize);
+        } else
+            return minSize;
+    }
+
+    @DataProvider(name = "UninitializedHMMs")
+    public Object[][] makeUninitializedHMMs() {
+        List<Object[]> tests = new ArrayList<>();
+
+        final Log10PairHMM myLog10PairHMM = new Log10PairHMM(true);
+        myLog10PairHMM.doNotUseTristateCorrection();
+        tests.add(new Object[]{myLog10PairHMM});
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(enabled = true, expectedExceptions = IllegalStateException.class, dataProvider = "UninitializedHMMs")
+    public void testNoInitializeCall(final PairHMM hmm) {
+        byte[] readBases = "A".getBytes();
+        byte[] refBases =  "AT".getBytes();
+        byte[] baseQuals = Utils.dupBytes((byte)30, readBases.length);
+
+        // didn't call initialize => should exception out
+        double d = hmm.computeReadLikelihoodGivenHaplotypeLog10( refBases, readBases,
+                baseQuals, baseQuals, baseQuals, baseQuals, true, null);
+    }
+
+    @Test(enabled = true, expectedExceptions = IllegalArgumentException.class, dataProvider = "JustHMMProvider")
+    public void testHapTooLong(final PairHMM hmm) {
+        byte[] readBases = "AAA".getBytes();
+        byte[] refBases =  "AAAT".getBytes();
+        byte[] baseQuals = Utils.dupBytes((byte)30, readBases.length);
+
+        hmm.initialize(3, 3);
+        double d = hmm.computeReadLikelihoodGivenHaplotypeLog10( refBases, readBases,
+                baseQuals, baseQuals, baseQuals, baseQuals, true, null);
+    }
+
+    @Test(enabled = true, expectedExceptions = IllegalArgumentException.class, dataProvider = "JustHMMProvider")
+    public void testReadTooLong(final PairHMM hmm) {
+        byte[] readBases = "AAA".getBytes();
+        byte[] refBases =  "AAAT".getBytes();
+        byte[] baseQuals = Utils.dupBytes((byte)30, readBases.length);
+
+        hmm.initialize(2, 3);
+        double d = hmm.computeReadLikelihoodGivenHaplotypeLog10( refBases, readBases,
+                baseQuals, baseQuals, baseQuals, baseQuals, true, null);
+    }
+
+    @Test
+    public void dumpMatrices(){
+        //doesn't test anything other than not-blowing up
+        getHMMs().forEach(hmm -> hmm.initialize(3, 3));
+        getHMMs().forEach(hmm -> hmm.dumpMatrices());
+    }
+}


### PR DESCRIPTION
PairHMMs ported - for now, including the JNI ones (may delete them in the future)
but not including FastLoglessPairHMM for now (it may only be used in the graph likelihood engine and that engine may not be used)

as per internal discussions, all PairHMMs will be public.

@vruano please review and advise on keeping or deleting FastLoglessPairHMM and the graph based likelihood engine. 