### PR TITLE
moving to sudo-less build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: java
+addons:
+  apt:
+    sources:
+    - r-packages-precise
+    packages:
+    - r-base
 jdk:
 - oraclejdk8
 env:
@@ -10,7 +16,6 @@ cache:
   directories:
   - ~/.gradle
 before_install:
-- sudo apt-get install -y r-base-dev
 - wget -N https://downloads.gradle.org/distributions/gradle-2.2.1-bin.zip
 - unzip gradle-2.2.1-bin.zip
 - export PATH=`pwd`/gradle-2.2.1/bin:$PATH


### PR DESCRIPTION
travis got their act together and enabled at installation of the base R packages in their container build
this removes all uses of sudo so we can make use of the container builds which have faster dispatch