### PR TITLE
Allow use of SparkPipelineRunner for dataflow tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ task downloadGsaLibFile(type: Download) {
 
 repositories {
     mavenCentral()
+    maven {
+        url "https://repository.cloudera.com/artifactory/cloudera-repos/" // spark-dataflow
+    }
 }
 
 jacocoTestReport {
@@ -84,6 +87,13 @@ dependencies {
     compile 'com.google.cloud.genomics:google-genomics-utils:v1beta2-0.23'
     compile 'com.google.appengine.tools:appengine-gcs-client:0.4.4'
     compile 'org.testng:testng:6.9.4' //compile instead of testCompile because it is needed for test infrastructure that needs to be packaged
+    compile 'com.cloudera.dataflow.spark:spark-dataflow:0.1.0'
+    compile('org.apache.spark:spark-core_2.10:1.3.1') {
+        // JUL is used by Google Dataflow as the backend logger, so exclude jul-to-slf4j to avoid a loop
+        exclude module: 'jul-to-slf4j'
+        exclude module: 'javax.servlet'
+        exclude module: 'servlet-api'
+    }
 
     //needed for DataflowAssert
     testCompile 'org.hamcrest:hamcrest-all:1.3'
@@ -130,6 +140,9 @@ test {
     useTestNG{
         excludeGroups 'cloud', 'bucket'
     }
+
+    // ensure dataflowRunner is passed to the test VM if specified on the command line
+    systemProperty "dataflowRunner", System.getProperty("dataflowRunner")
 
     // set heap size for the test JVM(s)
     minHeapSize = "1G"

--- a/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.hellbender;
 
+import com.google.common.base.Strings;
+import org.broadinstitute.hellbender.engine.dataflow.DataflowCommandLineProgram;
+import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 
 import java.io.File;
@@ -12,6 +15,8 @@ import java.util.*;
  * Utility class for CommandLine Program testing.
  */
 public abstract class CommandLineProgramTest extends BaseTest {
+
+    public static final String PROPERTY_DATAFLOW_RUNNER = "dataflowRunner";
 
     /**
      * Returns the location of the resource directory. The default implementation points to the common directory for tools.
@@ -79,5 +84,31 @@ public abstract class CommandLineProgramTest extends BaseTest {
         File file =  outputFile.orElseThrow(() -> new IOException("No dataflow output file find for prefix: "+ pathPrefix.getAbsolutePath()));
         file.deleteOnExit();
         return file;
+    }
+
+    /**
+     * Adds arguments to the given <code>args</code> to set the dataflow
+     * runner if specified by the <code>dataflowRunner</code> system property (which
+     * should be the unqualified class name of the runner).
+     */
+    public static void addDataflowRunnerArgs(ArgumentsBuilder args) {
+        String dataflowRunner = System.getProperty(PROPERTY_DATAFLOW_RUNNER);
+        if (!Strings.isNullOrEmpty(dataflowRunner)) {
+            args.add("--runner");
+            args.add(DataflowCommandLineProgram.getRunnerTypeName(dataflowRunner));
+        }
+    }
+
+    /**
+     * Adds arguments to the given <code>args</code> to set the dataflow
+     * runner if specified by the <code>dataflowRunner</code> system property (which
+     * should be the unqualified class name of the runner).
+     */
+    public static void addDataflowRunnerArgs(List<String> args) {
+        String dataflowRunnerProperty = System.getProperty(PROPERTY_DATAFLOW_RUNNER);
+        if (!Strings.isNullOrEmpty(dataflowRunnerProperty)) {
+            args.add("--runner");
+            args.add(DataflowCommandLineProgram.getRunnerTypeName(dataflowRunnerProperty));
+        }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -27,6 +27,13 @@ import java.util.function.Consumer;
  */
 @SuppressWarnings("unchecked")
 public abstract class BaseTest {
+
+    static {
+        // set properties for the local Spark runner
+        System.setProperty("spark.driver.allowMultipleContexts", "true");
+        System.setProperty("spark.ui.enabled", "false");
+    }
+
     public static final Logger logger = LogManager.getLogger("org.broadinstitute.gatk");
 
     private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/GATKTestPipeline.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/GATKTestPipeline.java
@@ -1,0 +1,41 @@
+package org.broadinstitute.hellbender.engine.dataflow;
+
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.common.base.Strings;
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+
+
+/**
+ * A creator of test pipelines for use in tests that can be configured to run using any
+ * dataflow runner.
+ */
+public class GATKTestPipeline {
+
+    static {
+        System.setProperty("spark.driver.allowMultipleContexts", "true");
+        System.setProperty("spark.ui.enabled", "false");
+    }
+
+    /**
+     * Creates and returns a new test pipeline.
+     *
+     * <p>If the <code>dataflowRunner</code> system property is set to the unqualified
+     * class name of a <code>PipelineRunner</code> subclass then a new instance of that
+     * class will be used as the runner. Otherwise the method delegates to
+     * {@link com.google.cloud.dataflow.sdk.testing.TestPipeline#create}, which creates
+     * either a local runner or a cloud runner.
+     */
+    public static Pipeline create() {
+        String dataflowRunnerProperty = System.getProperty(CommandLineProgramTest.PROPERTY_DATAFLOW_RUNNER);
+        if (!Strings.isNullOrEmpty(dataflowRunnerProperty)) {
+            PipelineOptions options = PipelineOptionsFactory.fromArgs(
+                new String[] { "--runner=" + dataflowRunnerProperty }).create();
+            return Pipeline.create(options);
+        } else {
+            return com.google.cloud.dataflow.sdk.testing.TestPipeline.create();
+        }
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/CountBasesDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/CountBasesDataflowIntegrationTest.java
@@ -25,6 +25,7 @@ public final class CountBasesDataflowIntegrationTest extends CommandLineProgramT
         args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME);
         File placeHolder = createTempFile("countbasestest", ".txt");
         args.add(placeHolder.getPath());
+        addDataflowRunnerArgs(args);
 
         runCommandLine(args.getArgsArray());
         File outputFile = findDataflowOutput(placeHolder);

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/CountReadsDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/CountReadsDataflowIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.hellbender.tools.dataflow.pipelines;
 
+import com.google.common.base.Strings;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
@@ -39,7 +40,7 @@ public final class CountReadsDataflowIntegrationTest extends CommandLineProgramT
         args.add("--"+ StandardArgumentDefinitions.INPUT_LONG_NAME); args.add(ORIG_BAM.getAbsolutePath());
         args.add(interval_args);
         args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME); args.add(placeHolder);
-
+        addDataflowRunnerArgs(args);
 
         this.runCommandLine(args.getArgsArray());
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/DataflowReadsPipelineTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/DataflowReadsPipelineTest.java
@@ -4,7 +4,6 @@ package org.broadinstitute.hellbender.tools.dataflow.pipelines;
 import com.google.api.services.genomics.model.Read;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
-import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
 import com.google.common.collect.ImmutableList;
@@ -12,6 +11,7 @@ import com.google.common.collect.Lists;
 import htsjdk.samtools.SamReaderFactory;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.engine.dataflow.PTransformSAM;
+import org.broadinstitute.hellbender.engine.dataflow.GATKTestPipeline;
 import org.broadinstitute.hellbender.engine.filters.ReadFilter;
 import org.broadinstitute.hellbender.tools.dataflow.transforms.CountBasesDataflowTransform;
 import org.broadinstitute.hellbender.transformers.ReadTransformer;
@@ -23,7 +23,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.UnaryOperator;
 
 
 public final class DataflowReadsPipelineTest {
@@ -83,7 +82,7 @@ public final class DataflowReadsPipelineTest {
     @Test(dataProvider = "configurations", groups = {"dataflow"})
     public void testTransformersAndFilters(List<ReadFilter> filters, List<ReadTransformer> transformers, long expectedCounts){
         RuntimeConfigurablePipeline rcp = new RuntimeConfigurablePipeline(new CountBasesDataflowTransform(), filters, transformers);
-        Pipeline p = TestPipeline.create();
+        Pipeline p = GATKTestPipeline.create();
         DataflowWorkarounds.registerGenomicsCoders(p);
         String bam = "src/test/resources/org/broadinstitute/hellbender/tools/count_reads_sorted.bam";
         PCollection<Read> preads = DataflowUtils.getReadsFromLocalBams(p, Lists.newArrayList(new SimpleInterval("chr7", 1, 404)), Lists.newArrayList(new File(bam)));

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/FlagStatDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/FlagStatDataflowIntegrationTest.java
@@ -35,6 +35,9 @@ public final class FlagStatDataflowIntegrationTest extends CommandLineProgramTes
         File placeHolder = createTempFile("flagStatTest", ".txt");
         args.add(placeHolder.getPath());
 
+        addDataflowRunnerArgs(args);
+
+
         runCommandLine(args);
 
         File outputFile = findDataflowOutput(placeHolder);
@@ -59,6 +62,9 @@ public final class FlagStatDataflowIntegrationTest extends CommandLineProgramTes
         args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME);
         File placeHolder = createTempFile("flagStatTest", ".txt");
         args.add(placeHolder.getPath());
+
+        addDataflowRunnerArgs(args);
+
 
         runCommandLine(args);
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/PrintReadsDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/PrintReadsDataflowIntegrationTest.java
@@ -31,6 +31,7 @@ public final class PrintReadsDataflowIntegrationTest extends CommandLineProgramT
         args.add("--L"); args.add("chr7:1-202");
         args.add("--L"); args.add("chr8:1-202");
         args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME); args.add(placeHolder.getPath());
+        addDataflowRunnerArgs(args);
 
         runCommandLine(args);
         File outputFile = findDataflowOutput(placeHolder);

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/CountBasesTransformUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/CountBasesTransformUnitTest.java
@@ -4,13 +4,13 @@ import com.google.api.services.genomics.model.Read;
 import com.google.appengine.repackaged.com.google.common.collect.Lists;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
-import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.genomics.dataflow.readers.bam.ReadConverter;
 import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
 import htsjdk.samtools.SAMRecord;
 import org.broadinstitute.hellbender.engine.dataflow.PTransformSAM;
+import org.broadinstitute.hellbender.engine.dataflow.GATKTestPipeline;
 import org.broadinstitute.hellbender.utils.read.ArtificialSAMUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +32,7 @@ public final class CountBasesTransformUnitTest {
     @Test(dataProvider = "sams", groups= {"dataflow"})
     public void countBasesTest(List<SAMRecord> sams, long expected){
         List<Read> reads = sams.stream().map(ReadConverter::makeRead).collect(Collectors.toList());
-        Pipeline p = TestPipeline.create();
+        Pipeline p = GATKTestPipeline.create();
         DataflowWorkarounds.registerGenomicsCoders(p);
         PCollection<Read> preads = p.apply(Create.of(reads));
         PTransformSAM<Long> transform = new CountBasesDataflowTransform();

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/CountReadsTransformUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/CountReadsTransformUnitTest.java
@@ -3,11 +3,11 @@ package org.broadinstitute.hellbender.tools.dataflow.transforms;
 import com.google.api.services.genomics.model.Read;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
-import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
+import org.broadinstitute.hellbender.engine.dataflow.GATKTestPipeline;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,7 +31,7 @@ public final class CountReadsTransformUnitTest extends BaseTest{
     public void testCountReadsTransform(long numberOfReads){
         List<Read> reads = Collections.nCopies((int)numberOfReads, new Read() );
 
-        Pipeline p = TestPipeline.create();
+        Pipeline p = GATKTestPipeline.create();
         DataflowWorkarounds.registerGenomicsCoders(p);
         PTransform<PCollection<Read>, PCollection<Long>> countReads = new CountReadsDataflowTransform();
         PCollection<Long> presult = p.apply(Create.of(reads)).apply(countReads);

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/FlagStatTransformUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/FlagStatTransformUnitTest.java
@@ -3,12 +3,12 @@ package org.broadinstitute.hellbender.tools.dataflow.transforms;
 import com.google.api.services.genomics.model.Read;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
-import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
 import com.google.common.collect.Lists;
 import htsjdk.samtools.SAMRecord;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.dataflow.GATKTestPipeline;
 import org.broadinstitute.hellbender.tools.FlagStat;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.DataflowUtils;
@@ -23,7 +23,7 @@ public final class FlagStatTransformUnitTest {
     @Test(groups = "dataflow")
     public void testFlagStatDataflowTransform(){
         File bam = new File(BaseTest.publicTestDir, "org/broadinstitute/hellbender/tools/dataflow/pipelines/FlagStatDataflow/flag_stat.bam");
-        Pipeline p = TestPipeline.create();
+        Pipeline p = GATKTestPipeline.create();
         DataflowWorkarounds.registerGenomicsCoders(p);
         List<SimpleInterval> intervals = Lists.newArrayList(new SimpleInterval("chr1", 1, 101),
                 new SimpleInterval("chr2", 1, 101),

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/PrintReadsTransformUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/PrintReadsTransformUnitTest.java
@@ -4,15 +4,13 @@ import com.google.api.services.genomics.model.Read;
 import com.google.appengine.repackaged.com.google.common.collect.Lists;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
-import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Create;
-import com.google.cloud.dataflow.sdk.transforms.DoFn;
-import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.genomics.dataflow.readers.bam.ReadConverter;
 import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
 import htsjdk.samtools.SAMRecord;
 import org.broadinstitute.hellbender.engine.dataflow.PTransformSAM;
+import org.broadinstitute.hellbender.engine.dataflow.GATKTestPipeline;
 import org.broadinstitute.hellbender.utils.read.ArtificialSAMUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -40,7 +38,7 @@ public final class PrintReadsTransformUnitTest {
                 // but our standard if false, google genomics defaults to true instead, but both are ok...
         .map(SAMRecord::getSAMString).collect(Collectors.toSet());
 
-        Pipeline p = TestPipeline.create();
+        Pipeline p = GATKTestPipeline.create();
         DataflowWorkarounds.registerGenomicsCoders(p);
         PCollection<Read> preads = p.apply(Create.of(reads));
         PTransformSAM<String> transform = new PrintReadsDataflowTransform();


### PR DESCRIPTION
Set the system property 'dataflowRunner' to the simple classname of the
runner you wish to use. E.g.

gradle test -Dtest.single=CountBasesDataflowUnitTest -DdataflowRunner=SparkPipelineRunner