### PR TITLE
Allow dataflow command line programs to run on a Hadoop/Spark cluster.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter() // for shadow plugin
      }
 
     dependencies {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.3.1'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.1'
     }
 }
 
@@ -21,6 +23,7 @@ apply plugin: "jacoco"
 apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 mainClassName = "org.broadinstitute.hellbender.Main"
 
@@ -88,17 +91,19 @@ dependencies {
     compile 'com.google.appengine.tools:appengine-gcs-client:0.4.4'
     compile 'org.testng:testng:6.9.4' //compile instead of testCompile because it is needed for test infrastructure that needs to be packaged
     compile 'com.cloudera.dataflow.spark:spark-dataflow:0.1.0'
-    compile('org.apache.spark:spark-core_2.10:1.3.1') {
-        // JUL is used by Google Dataflow as the backend logger, so exclude jul-to-slf4j to avoid a loop
-        exclude module: 'jul-to-slf4j'
-        exclude module: 'javax.servlet'
-        exclude module: 'servlet-api'
+    compile('org.seqdoop:hadoop-bam:7.0.0') {
+        exclude module: 'htsjdk'
     }
 
     //needed for DataflowAssert
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
-
+    testCompile('org.apache.spark:spark-core_2.10:1.3.1') {
+        // JUL is used by Google Dataflow as the backend logger, so exclude jul-to-slf4j to avoid a loop
+        exclude module: 'jul-to-slf4j'
+        exclude module: 'javax.servlet'
+        exclude module: 'servlet-api'
+    }
 
 }
 
@@ -191,6 +196,19 @@ task fatJar(type: Jar) {
     baseName = project.name + '-all'
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
+}
+
+shadowJar {
+    manifest {
+        attributes 'Implementation-Title': 'Hellbender',
+                'Implementation-Version': version,
+                'Main-Class': 'org.broadinstitute.hellbender.Main'
+    }
+    baseName = project.name + '-all'
+    classifier = 'spark'
+    mergeServiceFiles()
+    relocate 'com.google.common', 'org.broadinstitute.hellbender.relocated.com.google.common'
+    zip64 true
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/SimpleInterval.java
@@ -186,17 +186,17 @@ public final class SimpleInterval implements Locatable, Serializable {
     }
 
     /**
-     * Determines whether this interval overlaps the provided interval.
+     * Determines whether this interval overlaps the provided locatable.
      *
      * @param other interval to check
      * @return true if this interval overlaps other, otherwise false
      */
-    public final boolean overlaps( final SimpleInterval other ) {
-        if ( other == null ) {
+    public final boolean overlaps( final Locatable other ) {
+        if ( other == null || other.getContig() == null ) {
             return false;
         }
 
-        return this.contig.equals(other.contig) && this.start <= other.end && other.start <= this.end;
+        return this.contig.equals(other.getContig()) && this.start <= other.getEnd() && other.getStart() <= this.end;
     }
 
     /**
@@ -205,11 +205,11 @@ public final class SimpleInterval implements Locatable, Serializable {
      * @param other interval to check
      * @return true if this interval contains all of the bases spanned by other, otherwise false
      */
-    public final boolean contains( final SimpleInterval other ) {
-        if ( other == null ) {
+    public final boolean contains( final Locatable other ) {
+        if ( other == null || other.getContig() == null ) {
             return false;
         }
 
-        return this.contig.equals(other.contig) && this.start <= other.start && this.end >= other.end;
+        return this.contig.equals(other.getContig()) && this.start <= other.getStart() && this.end >= other.getEnd();
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/utils/dataflow/BucketUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/dataflow/BucketUtils.java
@@ -20,11 +20,19 @@ import java.nio.channels.Channels;
  */
 public final class BucketUtils {
     public static final String GCS_PREFIX = "gs://";
+    public static final String HDFS_PREFIX = "hdfs://";
 
     private BucketUtils(){} //private so that no one will instantiate this class
 
     public static boolean isCloudStorageUrl(String path) {
         return path.startsWith(GCS_PREFIX);
+    }
+
+    /**
+     * Returns true if the given path is a HDFS (Hadoop filesystem) URL.
+     */
+    public static boolean isHadoopUrl(String path) {
+        return path.startsWith(HDFS_PREFIX);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSourceTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSourceTest.java
@@ -4,7 +4,6 @@ import com.google.api.services.genomics.model.Read;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
-import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Count;
 import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.values.PCollection;

--- a/src/test/java/org/broadinstitute/hellbender/utils/dataflow/BucketUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/dataflow/BucketUtilsTest.java
@@ -8,6 +8,14 @@ public final class BucketUtilsTest {
     @Test
     public void testIsCloudStorageURL(){
         Assert.assertTrue(BucketUtils.isCloudStorageUrl("gs://a_bucket/bucket"));
+        Assert.assertFalse(BucketUtils.isCloudStorageUrl("hdfs://namenode/path/to/file"));
         Assert.assertFalse(BucketUtils.isCloudStorageUrl("localFile"));
+    }
+
+    @Test
+    public void testIsHadoopURL(){
+        Assert.assertFalse(BucketUtils.isHadoopUrl("gs://a_bucket/bucket"));
+        Assert.assertTrue(BucketUtils.isHadoopUrl("hdfs://namenode/path/to/file"));
+        Assert.assertFalse(BucketUtils.isHadoopUrl("localFile"));
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/dataflow/DataflowUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/dataflow/DataflowUtilsUnitTest.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.hellbender.utils.dataflow;
 
+import com.cloudera.dataflow.spark.EvaluationResult;
+import com.cloudera.dataflow.spark.SparkPipelineRunner;
 import com.google.api.services.genomics.model.Read;
 import com.google.appengine.repackaged.com.google.common.collect.Lists;
 import com.google.cloud.dataflow.sdk.Pipeline;
@@ -9,7 +11,9 @@ import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.transforms.DoFnTester;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.genomics.dataflow.readers.bam.ReadConverter;
+import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
 import htsjdk.samtools.ValidationStringency;
+import org.apache.hadoop.fs.Path;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
 import org.broadinstitute.hellbender.engine.dataflow.GATKTestPipeline;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
@@ -57,6 +61,21 @@ public final class DataflowUtilsUnitTest extends BaseTest {
         List<Read> output = tester.processBatch(inputFile);
 
         Assert.assertEquals(output, expected);
+    }
+
+
+    @Test
+    public void testGetReadsFromHadoopBam() {
+        List<SimpleInterval> intervals = Lists.newArrayList(new SimpleInterval("chr7:1-202"), new SimpleInterval("chr8:2-202"));
+        File inputFile = new File(getToolTestDataDir(), "example_reads.bam");
+        List<Read> expected = getReadsFromFile(intervals, inputFile);
+
+        Pipeline p = GATKTestPipeline.create();
+        DataflowWorkarounds.registerGenomicsCoders(p);
+        PCollection<Read> reads = DataflowUtils.getReadsFromHadoopBam(p, intervals, ValidationStringency.SILENT,
+                new Path(inputFile.getAbsoluteFile().toURI()).toString());
+        EvaluationResult result = SparkPipelineRunner.create().run(p);
+        Assert.assertEquals(expected, result.get(reads));
     }
 
     public List<Read> getReadsFromFile(List<SimpleInterval> intervals, File inputFile) {


### PR DESCRIPTION
This is achieved by i) using HadoopBAM to read BAM files from HDFS, and
ii) adding a shadowJar target to build app JAR suitable for running with Spark.

Note that this uses Spark's spark-submit script to run on the cluster - this is to avoid including the Spark classes in the hellbender JAR itself, so that it can run on different versions of Spark. We might consider making a runnable JAR at some point in the future though.

I tested this on a standalone cluster (running with Java 8) as follows:

```bash
export SPARK_HOME=~/sw/spark-1.3.1-bin-hadoop2.6/ 
PATH=$PATH:$SPARK_HOME/bin 
$SPARK_HOME/sbin/start-all.sh

export HADOOP_HOME=~/sw/hadoop-2.7.0
export HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop.pseudo/
export PATH=$PATH:$HADOOP_HOME/bin:$HADOOP_HOME/sbin
(cd $HADOOP_HOME; start-hdfs2)
hadoop fs -mkdir -p /user/$USER 
hadoop fs -put ~/workspace/hellbender/src/test/resources/org/broadinstitute/hellbender/tools/flag_stat.bam flag_stat.bam
hadoop fs -rmr out

SPARK_MASTER=spark://localhost:7077
spark-submit \
  --class org.broadinstitute.hellbender.Main \
  --master $SPARK_MASTER \
  build/libs/hellbender-GATK.4.alpha-*-all.jar CountBasesDataflow \
    --input hdfs://localhost/user/$USER/flag_stat.bam \
    --output hdfs://localhost/user/$USER/out/countbases \
    --runner SPARK \
    --sparkMaster $SPARK_MASTER
hadoop fs -getmerge out out
cat out
```