### PR TITLE
suppress exception from onShutdown if doWork threw

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -90,14 +90,28 @@ public abstract class CommandLineProgram {
      * Template method that runs the startup hook, doWork and then the shutdown hook.
      */
     public final Object runTool(){
+        boolean doWorkCompleted = false;
         try {
             logger.info("Initializing engine");
             onStartup();
             logger.info("Done initializing engine");
+            Object result =  doWork();
+            doWorkCompleted = true;
             return doWork();
         } finally {
-            logger.info("Shutting down engine");
-            onShutdown();
+            try {
+                logger.info("Shutting down engine");
+                onShutdown();
+            } catch ( Exception e){
+                //if onShutdown throws an exception we don't want it to suppress an earlier exception in doWork or onStartup
+                if(doWorkCompleted ){
+                    throw e;
+                } else {
+                    logger.error("The following exception occured in onShutdown, but a previous exception was already in progress.");
+                    logger.error(e.getMessage());
+                    e.printStackTrace();
+                }
+            }
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineProgramUnitTest.java
@@ -1,0 +1,44 @@
+package org.broadinstitute.hellbender.cmdline;
+
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.testng.annotations.Test;
+
+public class CommandLineProgramUnitTest {
+
+    @Test(expectedExceptions = UserException.BadInput.class)
+    public void testExceptionInDoWorkNotSurpressedByExceptionInOnShutdown() {
+
+        CommandLineProgram clp = new CommandLineProgram(){
+
+            @Override
+            protected Object doWork() {
+                throw new UserException.BadInput("fail");
+            }
+
+            @Override
+            protected void onShutdown(){
+                throw new GATKException("another fail");
+            }
+        };
+        clp.runTool();
+    }
+
+    @Test(expectedExceptions = GATKException.class)
+    public void testExceptionInOnShutdownPropagatesIfNoEarlierExceptionOccurs(){
+        CommandLineProgram clp = new CommandLineProgram(){
+
+            @Override
+            protected Object doWork() {
+                return 0;
+            }
+
+            @Override
+            protected void onShutdown(){
+                throw new GATKException("fail");
+            }
+        };
+        clp.runTool();
+    }
+
+}


### PR DESCRIPTION
if doWork or onStartup in CommandLineProgram throw an exception then suppress any exception throw in onShutdown
fixes #528 

I still think every effort should be made to avoid an exception in onShutdown though.  