### PR TITLE
Update to spark-dataflow 0.1.1 and fix unit tests that are failing wh…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     compile 'com.google.cloud.genomics:google-genomics-utils:v1beta2-0.23'
     compile 'com.google.appengine.tools:appengine-gcs-client:0.4.4'
     compile 'org.testng:testng:6.9.4' //compile instead of testCompile because it is needed for test infrastructure that needs to be packaged
-    compile 'com.cloudera.dataflow.spark:spark-dataflow:0.1.0'
+    compile 'com.cloudera.dataflow.spark:spark-dataflow:0.1.1'
     compile('org.seqdoop:hadoop-bam:7.0.0') {
         exclude module: 'htsjdk'
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/DataflowCommandLineProgramUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/DataflowCommandLineProgramUnitTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.engine.dataflow;
 
 import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.common.collect.Lists;
@@ -14,7 +15,7 @@ public final class DataflowCommandLineProgramUnitTest {
 
     @Test(expectedExceptions = UserException.class)
     public void testUserExceptionUnwrapping(){
-        Pipeline p = GATKTestPipeline.create();
+        Pipeline p = TestPipeline.create(); // use regular pipeline as Spark doesn't return user exceptions yet
         PCollection<String> pstrings = p.apply(Create.of(Lists.newArrayList("Some", "Values")));
         pstrings.apply(DataflowUtils.throwException(new UserException("fail")));
         DataflowCommandLineProgram.runPipeline(p);

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSourceTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsSourceTest.java
@@ -14,6 +14,7 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
+import org.apache.spark.SparkException;
 import org.broadinstitute.hellbender.dev.pipelines.bqsr.BaseRecalOutput;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
@@ -81,7 +82,7 @@ public final class ReadsSourceTest extends BaseTest {
         p.run();
     }
 
-    @Test(expectedExceptions = SAMException.class)
+    @Test(expectedExceptions = { SAMException.class, SparkException.class }) // Spark doesn't unwrap exceptions
     public void testGetInvalidPCollectionLocalStrict() throws Throwable {
         // ValidationStringency.STRICT should trigger an error on an invalid file
         try {


### PR DESCRIPTION
…en running on Spark. These are tests that rely on user exceptions being returned to the driver, which Spark does not yet support. (If there's a better way of excluding tests, then please let me know.)

The upgrade includes some changes to the runner that fix some of the failing tests too.