### PR TITLE
stop test from putting file in hellbender root dir

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/dev/CalibrationTablesBuilderIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/dev/CalibrationTablesBuilderIntegrationTest.java
@@ -103,7 +103,7 @@ public final class CalibrationTablesBuilderIntegrationTest extends CommandLinePr
     }
     @Test(dataProvider = "BQSRTest")
     public void testBQSR(BQSRTest params) throws IOException {
-        String outputDest = "test-table-pre.txt";
+        String outputDest = createTempFile("test-table-pre",".txt").getAbsolutePath();
 
         // 1. Grab the needed inputs.
         String toolCmdLine = String.format(params.getCommandLine(), outputDest);


### PR DESCRIPTION
`CalibrationTablesBuilderIntegrationTest` was creating a file called `test-table-pre.txt` in the hellbender root directory.

It now creates a temporary file instead.