### PR TITLE
Allow user to set log4j logging level.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -1,14 +1,16 @@
 package org.broadinstitute.hellbender.cmdline;
 
+import htsjdk.samtools.util.Log;
+import org.broadinstitute.hellbender.utils.LoggingUtils;
+
 import htsjdk.samtools.metrics.Header;
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.metrics.StringHeader;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.net.InetAddress;
@@ -46,14 +48,8 @@ public abstract class CommandLineProgram {
             "It is unlikely these will ever need to be accessed by the command line program")
     public SpecialArgumentsCollection specialArgumentsCollection = new SpecialArgumentsCollection();
 
-    public enum VERBOSITY_LEVEL {
-        ERROR,
-        WARNING,
-        INFO,
-        DEBUG;
-    }
     @Argument(doc = "Control verbosity of logging.", common=true)
-    public VERBOSITY_LEVEL VERBOSITY = VERBOSITY_LEVEL.INFO;
+    public Log.LogLevel VERBOSITY = Log.LogLevel.INFO;
 
     @Argument(doc = "Whether to suppress job-summary info on System.err.", common=true)
     public Boolean QUIET = false;
@@ -122,6 +118,8 @@ public abstract class CommandLineProgram {
         this.defaultHeaders.add(new StringHeader(commandLine));
         this.defaultHeaders.add(new StringHeader("Started on: " +
                                 startDateTime.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG))));
+
+        LoggingUtils.setLoggingLevel(VERBOSITY);  // propagate the VERBOSITY level to logging frameworks
 
         for (final File f : TMP_DIR) {
             // Intentionally not checking the return values, because it may be that the program does not

--- a/src/main/java/org/broadinstitute/hellbender/utils/LoggingUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/LoggingUtils.java
@@ -1,0 +1,80 @@
+package org.broadinstitute.hellbender.utils;
+
+import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+import htsjdk.samtools.util.Log;
+import com.google.common.collect.EnumHashBiMap;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+
+/**
+ * Logging utilities.
+ *
+ * Hellbender tools use the Picard Log.LogLevel enum as the type for VERBOSITY command line arguments (ideally
+ * we would use a log4j level enum, but each log4j level is represented by a static object so there is no
+ * proper built-in enum that is compatible with the command line argument framework). Therefore we use the
+ * Picard enum as the Hellbender currency and convert back and forth between that and the log4j namespace
+ * as necessary. Note that the two namespaces have very similar, but not identical level names, and log4j
+ * has a wider set of level values than those supported by the Picard enum.
+ */
+ public class LoggingUtils {
+
+    // Map between the logging level used throughout Hellbender code (which is the Picard Log.LogLevel enum),
+    // and the log4j log Level values.
+    private static EnumHashBiMap<Log.LogLevel, Level> loggingLevelNamespaceMap;
+    private static String badLevelValue = "Unrecognized verbosity level. Must be one of (DEBUG/ERROR/INFO/WARNING)";
+
+    private static EnumHashBiMap<Log.LogLevel, Level> getLoggingLevelNamespaceMap() {
+        if (null == loggingLevelNamespaceMap) {
+            loggingLevelNamespaceMap = EnumHashBiMap.create(Log.LogLevel.class);
+
+            loggingLevelNamespaceMap.put(Log.LogLevel.DEBUG, Level.DEBUG);
+            loggingLevelNamespaceMap.put(Log.LogLevel.ERROR, Level.ERROR);
+            loggingLevelNamespaceMap.put(Log.LogLevel.WARNING, Level.WARN);
+            loggingLevelNamespaceMap.put(Log.LogLevel.INFO, Level.INFO);
+        }
+        return loggingLevelNamespaceMap;
+    }
+
+    //  We're leaking the log4j Level type through these APIS, but they're only for testing
+    @VisibleForTesting
+    public static Log.LogLevel levelFromLog4jLevel(Level log4jLevel) {
+        try {
+            return getLoggingLevelNamespaceMap().inverse().get(log4jLevel);
+        }
+        catch (IllegalArgumentException e) {
+                throw new GATKException.ShouldNeverReachHereException(badLevelValue, e);
+        }
+    }
+
+    public static Level levelToLog4jLevel(Log.LogLevel picardLevel) {
+        try {
+            return getLoggingLevelNamespaceMap().get(picardLevel);
+        }
+        catch (IllegalArgumentException e) {
+            throw new GATKException.ShouldNeverReachHereException(badLevelValue, e);
+        }
+    }
+
+    /**
+     * Propagate the verbosity level to both Picard and log4j.
+     */
+    public static void setLoggingLevel(final Log.LogLevel VERBOSITY) {
+
+        // Call the Picard API to establish the logging level used by Picard
+        Log.setGlobalLogLevel(VERBOSITY);
+
+        // Now establish the logging level used by log4j by propagating the requested
+        // logging level to all loggers associated with our logging configuration.
+        final LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+        final Configuration loggerContextConfig = loggerContext.getConfiguration();
+        final String contextClassName = LoggingUtils.class.getName();
+        final LoggerConfig loggerConfig = loggerContextConfig.getLoggerConfig(contextClassName);
+
+        loggerConfig.setLevel(levelToLog4jLevel(VERBOSITY));
+        loggerContext.updateLoggers();
+    }
+}


### PR DESCRIPTION
This PR dynamically sets the logging level for command line tools at runtime using the current version of log4j (we were headed down a path of downgrading to a previous version of log4j in order to implement this). However, it uses an API that is normally used in code for extending log4j rather than acting as a client to it, and requires an explicit cast of the value returned from LogManager.getContext. The Apache project site illustrates the use of this api in the first line of code in an example here: https://logging.apache.org/log4j/2.x/manual/customconfig.html#AddingToCurrent.

We need to decide if we want to take this and stay on the current version or continue with the downgrade…