### PR TITLE
Move all logging to log4j.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/cmdline/ClassFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/ClassFinder.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.hellbender.cmdline;
 
-
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,7 +26,7 @@ public final class ClassFinder {
     // If not null, only look for classes in this jar
     private String jarPath = null;
 
-    private static final Log log = Log.getInstance(ClassFinder.class);
+    private static final Logger log = LogManager.getLogger();
 
     public ClassFinder() {
         loader = Thread.currentThread().getContextClassLoader();

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -5,10 +5,10 @@ import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.metrics.StringHeader;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Level;
 
 import java.io.File;
 import java.net.InetAddress;
@@ -46,8 +46,14 @@ public abstract class CommandLineProgram {
             "It is unlikely these will ever need to be accessed by the command line program")
     public SpecialArgumentsCollection specialArgumentsCollection = new SpecialArgumentsCollection();
 
+    public enum VERBOSITY_LEVEL {
+        ERROR,
+        WARNING,
+        INFO,
+        DEBUG;
+    }
     @Argument(doc = "Control verbosity of logging.", common=true)
-    public Log.LogLevel VERBOSITY = Log.LogLevel.INFO;
+    public VERBOSITY_LEVEL VERBOSITY = VERBOSITY_LEVEL.INFO;
 
     @Argument(doc = "Whether to suppress job-summary info on System.err.", common=true)
     public Boolean QUIET = false;
@@ -116,8 +122,6 @@ public abstract class CommandLineProgram {
         this.defaultHeaders.add(new StringHeader(commandLine));
         this.defaultHeaders.add(new StringHeader("Started on: " +
                                 startDateTime.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG))));
-
-        Log.setGlobalLogLevel(VERBOSITY);
 
         for (final File f : TMP_DIR) {
             // Intentionally not checking the return values, because it may be that the program does not

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectAlignmentSummaryMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectAlignmentSummaryMetrics.java
@@ -6,7 +6,8 @@ import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
@@ -45,7 +46,7 @@ import java.util.*;
 public final class CollectAlignmentSummaryMetrics extends SinglePassSamProgram {
     static final String USAGE = "Produces from a SAM or BAM a file containing summary alignment metrics";
     
-    private static final Log log = Log.getInstance(CollectAlignmentSummaryMetrics.class);
+    private static final Logger log = LogManager.getLogger();
 
     // Usage and parameters
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectBaseDistributionByCycle.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectBaseDistributionByCycle.java
@@ -6,8 +6,9 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.StringUtil;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
@@ -39,7 +40,7 @@ public final class CollectBaseDistributionByCycle extends SinglePassSamProgram {
 
     private HistogramGenerator hist;
     private String plotSubtitle = "";
-    private final Log log = Log.getInstance(CollectBaseDistributionByCycle.class);
+    private final Logger log = LogManager.getLogger(CollectBaseDistributionByCycle.class);
 
     @Override
     protected void setup(final SAMFileHeader header, final File samFile) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetrics.java
@@ -6,7 +6,8 @@ import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
@@ -31,7 +32,8 @@ import java.util.*;
         programGroup = QCProgramGroup.class
 )
 public final class CollectInsertSizeMetrics extends SinglePassSamProgram {
-    private static final Log log = Log.getInstance(CollectInsertSizeMetrics.class);
+    private static final Logger log = LogManager.getLogger(CollectInsertSizeMetrics.class);
+
     private static final String R_SCRIPT = "insertSizeHistogram.R";
 
     @Argument(shortName="H", doc="File to write insert size Histogram chart to.")

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectOxoGMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectOxoGMetrics.java
@@ -15,10 +15,10 @@ import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.ListMap;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.SamLocusIterator;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.StringUtil;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
@@ -88,7 +88,6 @@ public final class CollectOxoGMetrics extends PicardCommandLineProgram {
     @Argument(doc = "For debugging purposes: stop after visiting this many sites with at least 1X coverage.")
     public int STOP_AFTER = Integer.MAX_VALUE;
 
-    private final Log log = Log.getInstance(CollectOxoGMetrics.class);
     private static final String UNKNOWN_LIBRARY = "UnknownLibrary";
     private static final String UNKNOWN_SAMPLE = "UnknownSample";
 
@@ -205,7 +204,7 @@ public final class CollectOxoGMetrics extends PicardCommandLineProgram {
         }
 
         // Load up dbSNP if available
-        log.info("Loading dbSNP File: " + DB_SNP);
+        logger.info("Loading dbSNP File: " + DB_SNP);
         final DbSnpBitSetUtil dbSnp;
         if (DB_SNP != null) dbSnp = new DbSnpBitSetUtil(DB_SNP, in.getFileHeader().getSequenceDictionary());
         else dbSnp = null;
@@ -229,7 +228,7 @@ public final class CollectOxoGMetrics extends PicardCommandLineProgram {
         }
         iterator.setSamFilters(filters);
 
-        log.info("Starting iteration.");
+        logger.info("Starting iteration.");
         long nextLogTime = 0;
         int sites = 0;
 
@@ -264,7 +263,7 @@ public final class CollectOxoGMetrics extends PicardCommandLineProgram {
             if (++sites % 100 == 0) {
                 final long now = System.currentTimeMillis();
                 if (now > nextLogTime) {
-                    log.info("Visited " + sites + " sites of interest. Last site: " + chrom + ":" + pos);
+                    logger.info("Visited " + sites + " sites of interest. Last site: " + chrom + ":" + pos);
                     nextLogTime = now + 60000;
                 }
             }
@@ -294,7 +293,7 @@ public final class CollectOxoGMetrics extends PicardCommandLineProgram {
             }
         }
 
-        log.info("Generated " + contexts.size() + " context strings.");
+        logger.info("Generated " + contexts.size() + " context strings.");
         return contexts;
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectQualityYieldMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectQualityYieldMetrics.java
@@ -6,13 +6,14 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 
@@ -48,14 +49,13 @@ public final class CollectQualityYieldMetrics extends PicardCommandLineProgram {
      * all the records accumulating metrics.  Finally writes metrics file
      */
     protected Object doWork() {
-        final Log log = Log.getInstance(getClass());
-        final ProgressLogger progress = new ProgressLogger(log);
+        final ProgressLogger progress = new ProgressLogger(logger);
 
         // Some quick parameter checking
         IOUtil.assertFileIsReadable(INPUT);
         IOUtil.assertFileIsWritable(OUTPUT);
 
-        log.info("Reading input file and calculating metrics.");
+        logger.info("Reading input file and calculating metrics.");
 
         final SamReader sam = SamReaderFactory.makeDefault().open(INPUT);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CompareMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/CompareMetrics.java
@@ -2,7 +2,7 @@ package org.broadinstitute.hellbender.tools.picard.analysis;
 
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.PositionalArguments;
@@ -28,8 +28,6 @@ public final class CompareMetrics extends PicardCommandLineProgram {
     @PositionalArguments(minElements = 2, maxElements = 2)
     public List<File> metricsFiles;
 
-    private static final Log log = Log.getInstance(CompareMetrics.class);
-
     @Override
     protected Object doWork() {
         IOUtil.assertFilesAreReadable(metricsFiles);
@@ -40,7 +38,7 @@ public final class CompareMetrics extends PicardCommandLineProgram {
             metricsB.read(new FileReader(metricsFiles.get(1)));
             final boolean areEqual = metricsA.areMetricsEqual(metricsB) && metricsA.areHistogramsEqual(metricsB);
             final String status = areEqual ? "EQUAL" : "NOT EQUAL";
-            log.info("Files " + metricsFiles.get(0) + " and " + metricsFiles.get(1) + "are " + status);
+            logger.info("Files " + metricsFiles.get(0) + " and " + metricsFiles.get(1) + "are " + status);
         } catch (final Exception e) {
             throw new GATKException(e.getMessage());
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/MeanQualityByCycle.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/MeanQualityByCycle.java
@@ -7,8 +7,9 @@ import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.StringUtil;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
@@ -55,7 +56,7 @@ public final class MeanQualityByCycle extends SinglePassSamProgram {
      */
     private String plotSubtitle = "";
 
-    private final Log log = Log.getInstance(MeanQualityByCycle.class);
+    private final Logger logger = LogManager.getLogger(this.getClass());
 
     private static class HistogramGenerator {
         final boolean useOriginalQualities;
@@ -160,7 +161,7 @@ public final class MeanQualityByCycle extends SinglePassSamProgram {
         metrics.write(OUTPUT);
 
         if (q.isEmpty() && oq.isEmpty()) {
-            log.warn("No valid bases found in input file. No plot will be produced.");
+            logger.warn("No valid bases found in input file. No plot will be produced.");
         }
         else if (PRODUCE_PLOT){
             // Now run R to generate a chart

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/QualityScoreDistribution.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/QualityScoreDistribution.java
@@ -7,8 +7,9 @@ import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.SequenceUtil;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
@@ -55,7 +56,7 @@ public final class QualityScoreDistribution extends SinglePassSamProgram {
      */
     private String plotSubtitle = "";
 
-    private final Log log = Log.getInstance(QualityScoreDistribution.class);
+    private final Logger log = LogManager.getLogger(QualityScoreDistribution.class);
 
     @Override
     protected void setup(final SAMFileHeader header, final File samFile) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/SinglePassSamProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/SinglePassSamProgram.java
@@ -9,13 +9,15 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.util.SequenceUtil;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.util.*;
@@ -41,7 +43,7 @@ public abstract class SinglePassSamProgram extends PicardCommandLineProgram {
     @Argument(doc = "Stop after processing N reads, mainly for debugging.")
     public long STOP_AFTER = 0;
 
-    private static final Log log = Log.getInstance(SinglePassSamProgram.class);
+    private static final Logger logger = LogManager.getLogger();
 
     /**
      * Final implementation of doWork() that checks and loads the input and optionally reference
@@ -82,7 +84,7 @@ public abstract class SinglePassSamProgram extends PicardCommandLineProgram {
             final SortOrder sort = in.getFileHeader().getSortOrder();
             if (sort != SortOrder.coordinate) {
                 if (assumeSorted) {
-                    log.warn("File reports sort order '" + sort + "', assuming it's coordinate sorted anyway.");
+                    logger.warn("File reports sort order '" + sort + "', assuming it's coordinate sorted anyway.");
                 } else {
                     throw new UserException("File " + input.getAbsolutePath() + " should be coordinate sorted but " +
                             "the header says the sort order is " + sort + ". If you believe the file " +
@@ -99,7 +101,7 @@ public abstract class SinglePassSamProgram extends PicardCommandLineProgram {
         }
 
 
-        final ProgressLogger progress = new ProgressLogger(log);
+        final ProgressLogger progress = new ProgressLogger(logger);
 
         for (final SAMRecord rec : in) {
             final ReferenceSequence ref;

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRnaSeqMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRnaSeqMetrics.java
@@ -9,8 +9,9 @@ import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.OverlapDetector;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
@@ -32,7 +33,7 @@ import java.util.*;
 )
 public final class CollectRnaSeqMetrics extends SinglePassSamProgram {
     private static final String R_SCRIPT = "rnaSeqCoverage.R";
-    private static final Log LOG = Log.getInstance(CollectRnaSeqMetrics.class);
+    private static final Logger LOG = LogManager.getLogger();
 
     @Argument(doc="Gene annotations in refFlat form.  Format described here: http://genome.ucsc.edu/goldenPath/gbdDescriptionsOld.html#RefFlat")
     public File REF_FLAT;

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRrbsMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRrbsMetrics.java
@@ -10,8 +10,7 @@ import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
@@ -20,6 +19,7 @@ import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.metrics.MetricAccumulationLevel;
 import org.broadinstitute.hellbender.utils.R.RScriptExecutor;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 import org.broadinstitute.hellbender.utils.io.Resource;
 
 import java.io.File;
@@ -75,8 +75,6 @@ public final class CollectRrbsMetrics extends PicardCommandLineProgram {
     public static final String SUMMARY_FILE_EXTENSION = "rrbs_summary_metrics";
     public static final String PDF_FILE_EXTENSION = "rrbs_qc.pdf";
 
-    private static final Log log = Log.getInstance(CollectRrbsMetrics.class);
-
     @Override
     protected Object doWork() {
         if (!METRICS_FILE_PREFIX.endsWith(".")) {
@@ -93,7 +91,7 @@ public final class CollectRrbsMetrics extends PicardCommandLineProgram {
         }
 
         final ReferenceSequenceFileWalker refWalker = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
-        final ProgressLogger progressLogger = new ProgressLogger(log);
+        final ProgressLogger progressLogger = new ProgressLogger(logger);
 
         final RrbsMetricsCollector metricsCollector = new RrbsMetricsCollector(METRIC_ACCUMULATION_LEVEL, samReader.getFileHeader().getReadGroups(),
                 C_QUALITY_THRESHOLD, NEXT_BASE_QUALITY_THRESHOLD, MINIMUM_READ_LENGTH, MAX_MISMATCH_RATE);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectTargetedMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectTargetedMetrics.java
@@ -11,14 +11,15 @@ import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.IntervalList;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.util.SequenceUtil;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.metrics.MetricAccumulationLevel;
 import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.util.*;
@@ -33,8 +34,6 @@ import java.util.*;
  * collects metric information for all reads in the INPUT sam file.
  */
 public abstract class CollectTargetedMetrics<METRIC extends MultiLevelMetrics, COLLECTOR extends TargetMetricsCollector<METRIC>> extends PicardCommandLineProgram {
-
-    private static final Log log = Log.getInstance(CalculateHsMetrics.class);
 
     protected abstract IntervalList getProbeIntervals();
 
@@ -111,7 +110,7 @@ public abstract class CollectTargetedMetrics<METRIC extends MultiLevelMetrics, C
                 getProbeSetName()
         );
 
-        final ProgressLogger progress = new ProgressLogger(log);
+        final ProgressLogger progress = new ProgressLogger(logger);
         for (final SAMRecord record : reader) {
             collector.acceptRecord(record, null);
             progress.record(record);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectWgsMetrics.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectWgsMetrics.java
@@ -12,15 +12,15 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.util.SamLocusIterator;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.QCProgramGroup;
 import org.broadinstitute.hellbender.utils.MathUtils;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.util.*;
@@ -58,8 +58,6 @@ public final class CollectWgsMetrics extends PicardCommandLineProgram {
 
     @Argument(doc = "Determines whether to include the base quality histogram in the metrics file.")
     public boolean INCLUDE_BQ_HISTOGRAM = false;
-
-    private final Log log = Log.getInstance(CollectWgsMetrics.class);
 
     /** Metrics for evaluating the performance of whole genome sequencing experiments. */
     public static class WgsMetrics extends MetricBase {
@@ -124,7 +122,7 @@ public final class CollectWgsMetrics extends PicardCommandLineProgram {
         IOUtil.assertFileIsReadable(REFERENCE_SEQUENCE);
 
         // Setup all the inputs
-        final ProgressLogger progress = new ProgressLogger(log, 10000000, "Processed", "loci");
+        final ProgressLogger progress = new ProgressLogger(logger, 10000000, "Processed", "loci");
         final ReferenceSequenceFileWalker refWalker = new ReferenceSequenceFileWalker(REFERENCE_SEQUENCE);
         final SamReader in = SamReaderFactory.makeDefault().referenceSequence(REFERENCE_SEQUENCE).open(INPUT);
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/TargetMetricsCollector.java
@@ -13,11 +13,12 @@ import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.FormatUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.OverlapDetector;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.StringUtil;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.metrics.MetricAccumulationLevel;
 import org.broadinstitute.hellbender.metrics.MultiLevelMetrics;
@@ -53,7 +54,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultiLevelMetri
     //The name of the set of probes used
     private final String probeSetName;
 
-    private static final Log log = Log.getInstance(TargetMetricsCollector.class);
+    private static final Logger log = LogManager.getLogger();
 
     //The interval list indicating the regions targeted by all probes
     private final IntervalList allProbes;

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/fastq/NormalizeFasta.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/fastq/NormalizeFasta.java
@@ -4,14 +4,13 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeIOException;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.MiscProgramGroup;
-
+import org.apache.logging.log4j.Logger;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -41,8 +40,6 @@ public final class NormalizeFasta extends CommandLineProgram {
     @Argument(doc="Truncate sequence names at first whitespace.")
     public boolean TRUNCATE_SEQUENCE_NAMES_AT_WHITESPACE=false;
 
-    private final Log log = Log.getInstance(NormalizeFasta.class);
-
     @Override
     protected Object doWork() {
         IOUtil.assertFileIsReadable(INPUT);
@@ -66,7 +63,7 @@ public final class NormalizeFasta extends CommandLineProgram {
                     out.newLine();
 
                     if (bases.length == 0) {
-                        log.warn("Sequence " + name + " contains 0 bases.");
+                        logger.warn("Sequence " + name + " contains 0 bases.");
                     }
                     else {
                         for (int i=0; i<bases.length; ++i) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/BedToIntervalList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/BedToIntervalList.java
@@ -7,20 +7,21 @@ import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.bed.BEDFeature;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.IntervalProgramGroup;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,8 +45,6 @@ public final class BedToIntervalList extends PicardCommandLineProgram {
     @Argument(shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "The output Picard Interval List")
     public File OUTPUT;
 
-    final Log LOG = Log.getInstance(getClass());
-
     @Override
     protected Object doWork() {
         IOUtil.assertFileIsReadable(INPUT);
@@ -61,7 +60,7 @@ public final class BedToIntervalList extends PicardCommandLineProgram {
              */
             final FeatureReader<BEDFeature> bedReader = AbstractFeatureReader.getFeatureReader(INPUT.getAbsolutePath(), new BEDCodec(BEDCodec.StartOffset.ZERO), false);
             final CloseableTribbleIterator<BEDFeature> iterator = bedReader.iterator();
-            final ProgressLogger progressLogger = new ProgressLogger(LOG, (int) 1e6);
+            final ProgressLogger progressLogger = new ProgressLogger(logger, (int) 1e6);
 
             while (iterator.hasNext()) {
                 final BEDFeature bedFeature = iterator.next();

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/IntervalListTools.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/IntervalListTools.java
@@ -7,9 +7,10 @@ import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.variant.vcf.VCFFileReader;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineParser;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
@@ -79,7 +80,7 @@ public final class IntervalListTools extends PicardCommandLineProgram {
     @Argument(doc = "Produce the inverse list", optional = true)
     public boolean INVERT = false;
 
-    private static final Log LOG = Log.getInstance(IntervalListTools.class);
+    private static final Logger LOG = LogManager.getLogger();
 
     public enum Action implements CommandLineParser.ClpEnum {
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/LiftOverIntervalList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/interval/LiftOverIntervalList.java
@@ -4,7 +4,8 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.liftover.LiftOver;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
@@ -18,7 +19,6 @@ import static htsjdk.samtools.liftover.LiftOver.DEFAULT_LIFTOVER_MINMATCH;
 import static htsjdk.samtools.util.IOUtil.assertFileIsReadable;
 import static htsjdk.samtools.util.IOUtil.assertFileIsWritable;
 import static htsjdk.samtools.util.IntervalList.fromFile;
-import static htsjdk.samtools.util.Log.getInstance;
 import static org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions.INPUT_SHORT_NAME;
 import static org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions.OUTPUT_SHORT_NAME;
 import static org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions.SEQUENCE_DICTIONARY_SHORT_NAME;
@@ -33,8 +33,6 @@ import static org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions.
         programGroup = IntervalProgramGroup.class
 )
 public final class LiftOverIntervalList extends PicardCommandLineProgram {
-
-    private static final Log LOG = getInstance(LiftOverIntervalList.class);
 
     @Argument(doc = "Interval list to be lifted over.", shortName = INPUT_SHORT_NAME)
     public File INPUT;
@@ -77,10 +75,10 @@ public final class LiftOverIntervalList extends PicardCommandLineProgram {
                 toIntervals.add(toInterval);
             } else {
                 anyFailed = true;
-                LOG.warn("Liftover failed for ", fromInterval, "(len ", fromInterval.length(), ")");
+                logger.warn("Liftover failed for ", fromInterval, "(len ", fromInterval.length(), ")");
                 final List<LiftOver.PartialLiftover> partials = liftOver.diagnosticLiftover(fromInterval);
                 for (final LiftOver.PartialLiftover partial : partials) {
-                    LOG.info(partial);
+                    logger.info(partial);
                 }
             }
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/AddOrReplaceReadGroups.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/AddOrReplaceReadGroups.java
@@ -2,12 +2,14 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.*;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.util.Arrays;
@@ -68,8 +70,6 @@ public final class AddOrReplaceReadGroups extends PicardCommandLineProgram {
     @Argument(shortName = "PM", doc = "Read Group platform model", optional = true)
     public String RGPM;
 
-    private final Log log = Log.getInstance(AddOrReplaceReadGroups.class);
-
     protected Object doWork() {
         IOUtil.assertFileIsReadable(INPUT);
         IOUtil.assertFileIsWritable(OUTPUT);
@@ -89,7 +89,7 @@ public final class AddOrReplaceReadGroups extends PicardCommandLineProgram {
         if (RGPG != null) rg.setProgramGroup(RGPG);
         if (RGPM != null) rg.setPlatformModel(RGPM);
 
-        log.info(String.format("Created read group ID=%s PL=%s LB=%s SM=%s%n", rg.getId(), rg.getPlatform(), rg.getLibrary(), rg.getSample()));
+        logger.info(String.format("Created read group ID=%s PL=%s LB=%s SM=%s%n", rg.getId(), rg.getPlatform(), rg.getLibrary(), rg.getSample()));
 
         // create the new header and output file
         final SAMFileHeader inHeader = in.getFileHeader();
@@ -101,7 +101,7 @@ public final class AddOrReplaceReadGroups extends PicardCommandLineProgram {
                 outHeader.getSortOrder() == inHeader.getSortOrder(),
                 OUTPUT)) {
 
-            final ProgressLogger progress = new ProgressLogger(log);
+            final ProgressLogger progress = new ProgressLogger(logger);
             for (final SAMRecord read : in) {
                 read.setAttribute(SAMTag.RG.name(), RGID);
                 outWriter.addAlignment(read);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/BuildBamIndex.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/BuildBamIndex.java
@@ -3,7 +3,7 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 
@@ -21,8 +21,6 @@ import java.net.URL;
         programGroup = ReadProgramGroup.class
 )
 public final class BuildBamIndex extends PicardCommandLineProgram {
-
-    private static final Log log = Log.getInstance(BuildBamIndex.class);
 
     @Argument(shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME,
             doc = "A BAM file or URL to process. Must be sorted in coordinate order.")
@@ -97,7 +95,7 @@ public final class BuildBamIndex extends PicardCommandLineProgram {
 
         BAMIndexer.createIndex(bam, OUTPUT);
 
-        log.info("Successfully wrote bam index file " + OUTPUT);
+        logger.info("Successfully wrote bam index file " + OUTPUT);
         CloserUtil.close(bam);
         return null;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CleanSam.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/CleanSam.java
@@ -2,9 +2,12 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.*;
+
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.utils.read.mergealignment.AbstractAlignmentMerger;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 
@@ -42,7 +45,7 @@ public final class CleanSam extends PicardCommandLineProgram {
         try (final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(reader.getFileHeader(), true, OUTPUT);
              final CloseableIterator<SAMRecord> it = reader.iterator()) {
 
-            final ProgressLogger progress = new ProgressLogger(Log.getInstance(CleanSam.class));
+            final ProgressLogger progress = new ProgressLogger(logger);
 
             // If the read (or its mate) maps off the end of the alignment, clip it
             while (it.hasNext()) {

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/DownsampleSam.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/DownsampleSam.java
@@ -3,10 +3,9 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.util.HashMap;
@@ -40,8 +39,6 @@ public final class DownsampleSam extends PicardCommandLineProgram {
     @Argument(shortName = "P", doc = "The probability of keeping any individual read, between 0 and 1.")
     public double PROBABILITY = 1;
 
-    private final Log log = Log.getInstance(DownsampleSam.class);
-
     @Override
     protected Object doWork() {
         IOUtil.assertFileIsReadable(INPUT);
@@ -56,7 +53,7 @@ public final class DownsampleSam extends PicardCommandLineProgram {
         try(final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(in.getFileHeader(), true, OUTPUT)) {
             final Map<String, Boolean> decisions = new HashMap<>();
 
-            final ProgressLogger progress = new ProgressLogger(log, (int) 1e7, "Read");
+            final ProgressLogger progress = new ProgressLogger(logger, (int) 1e7, "Read");
 
             for (final SAMRecord rec : in) {
                 if (rec.isSecondaryOrSupplementary()) continue;
@@ -84,7 +81,7 @@ public final class DownsampleSam extends PicardCommandLineProgram {
         finally {
             CloserUtil.close(in);
         }
-        log.info("Finished! Kept " + kept + " out of " + total + " reads.");
+        logger.info("Finished! Kept " + kept + " out of " + total + " reads.");
 
         return null;
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/FastqToSam.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/FastqToSam.java
@@ -4,10 +4,13 @@ import htsjdk.samtools.*;
 import htsjdk.samtools.fastq.FastqReader;
 import htsjdk.samtools.fastq.FastqRecord;
 import htsjdk.samtools.util.*;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -26,7 +29,8 @@ import java.util.List;
         programGroup = ReadProgramGroup.class
 )
 public final class FastqToSam extends PicardCommandLineProgram {
-    private static final Log LOG = Log.getInstance(FastqToSam.class);
+
+    private static final Logger LOG = LogManager.getLogger();
 
     @Argument(shortName="F1", doc="Input fastq file (optionally gzipped) for single end data, or first read in paired end data.")
     public File FASTQ;

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/FilterReads.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/FilterReads.java
@@ -5,11 +5,12 @@ import htsjdk.samtools.filter.AlignedFilter;
 import htsjdk.samtools.filter.FilteringIterator;
 import htsjdk.samtools.filter.ReadNameFilter;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -30,7 +31,7 @@ import java.text.DecimalFormat;
 )
 public final class FilterReads extends PicardCommandLineProgram {
 
-    private static final Log log = Log.getInstance(FilterReads.class);
+    private static final Logger log = LogManager.getLogger();
 
     private static enum Filter {
         includeAligned("OUTPUT SAM/BAM will contain aligned reads only. INPUT SAM/BAM must be in queryname SortOrder. (Note that *both* first and second of paired reads must be aligned to be included in the OUTPUT SAM or BAM)"),
@@ -86,10 +87,10 @@ public final class FilterReads extends PicardCommandLineProgram {
             fileHeader.setSortOrder(SORT_ORDER);
         }
         final boolean presorted = inputSortOrder.equals(fileHeader.getSortOrder());
-        log.info("Filtering [presorted=" + presorted + "] " + INPUT.getName() + " -> OUTPUT=" +
+        logger.info("Filtering [presorted=" + presorted + "] " + INPUT.getName() + " -> OUTPUT=" +
                 OUTPUT.getName() + " [sortorder=" + fileHeader.getSortOrder().name() + "]");
 
-        final ProgressLogger progress = new ProgressLogger(log, (int) 1e6, "Written");
+        final ProgressLogger progress = new ProgressLogger(logger, (int) 1e6, "Written");
 
         // create OUTPUT file
         try (final SAMFileWriter outputWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(fileHeader, presorted, OUTPUT)) {
@@ -102,7 +103,7 @@ public final class FilterReads extends PicardCommandLineProgram {
 
            filteringIterator.close();
        }
-       log.info(new DecimalFormat("#,###").format(progress.getCount()) + " SAMRecords written to " + OUTPUT.getName());
+       logger.info(new DecimalFormat("#,###").format(progress.getCount()) + " SAMRecords written to " + OUTPUT.getName());
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/GatherBamFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/GatherBamFiles.java
@@ -3,7 +3,8 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 
@@ -35,7 +36,7 @@ public final class GatherBamFiles extends PicardCommandLineProgram {
     @Argument(shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "The output BAM file to write.")
     public File OUTPUT;
 
-    private static final Log log = Log.getInstance(GatherBamFiles.class);
+    private static final Logger log = LogManager.getLogger();
 
     @Override
     protected Object doWork() {

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/MergeSamFiles.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/MergeSamFiles.java
@@ -3,11 +3,10 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
-
+import org.broadinstitute. hellbender.utils.runtime.ProgressLogger;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +22,6 @@ import java.util.List;
         programGroup = ReadProgramGroup.class
 )
 public final class MergeSamFiles extends PicardCommandLineProgram {
-    private static final Log log = Log.getInstance(MergeSamFiles.class);
 
     @Argument(shortName = "I", doc = "SAM or BAM input file", optional=false)
     public List<File> INPUT = new ArrayList<>();
@@ -89,12 +87,12 @@ public final class MergeSamFiles extends PicardCommandLineProgram {
         final boolean mergingSamRecordIteratorAssumeSorted;
 
         if (matchedSortOrders || SORT_ORDER == SAMFileHeader.SortOrder.unsorted || ASSUME_SORTED) {
-            log.info("Input files are in same order as output so sorting to temp directory is not needed.");
+            logger.info("Input files are in same order as output so sorting to temp directory is not needed.");
             headerMergerSortOrder = SORT_ORDER;
             mergingSamRecordIteratorAssumeSorted = ASSUME_SORTED;
             presorted = true;
         } else {
-            log.info("Sorting input files using temp directory " + TMP_DIR);
+            logger.info("Sorting input files using temp directory " + TMP_DIR);
             headerMergerSortOrder = SAMFileHeader.SortOrder.unsorted;
             mergingSamRecordIteratorAssumeSorted = false;
             presorted = false;
@@ -113,14 +111,14 @@ public final class MergeSamFiles extends PicardCommandLineProgram {
         try (final SAMFileWriter out = samFileWriterFactory.makeSAMOrBAMWriter(header, presorted, OUTPUT)) {
 
             // Lastly loop through and write out the records
-            final ProgressLogger progress = new ProgressLogger(log, PROGRESS_INTERVAL);
+            final ProgressLogger progress = new ProgressLogger(logger, PROGRESS_INTERVAL);
             while (iterator.hasNext()) {
                 final SAMRecord record = iterator.next();
                 out.addAlignment(record);
                 progress.record(record);
             }
 
-            log.info("Finished reading inputs.");
+            logger.info("Finished reading inputs.");
             CloserUtil.close(readers);
         }
         return null;

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/ReorderSam.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/ReorderSam.java
@@ -5,7 +5,7 @@ import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -46,8 +46,6 @@ public final class ReorderSam extends PicardCommandLineProgram {
             "are doing.")
     public boolean ALLOW_CONTIG_LENGTH_DISCORDANCE = false;
 
-    private final Log log = Log.getInstance(ReorderSam.class);
-
     @Override
     protected Object doWork() {
         IOUtil.assertFileIsReadable(INPUT);
@@ -73,7 +71,7 @@ public final class ReorderSam extends PicardCommandLineProgram {
         SAMFileHeader outHeader = ReadUtils.cloneSAMFileHeader(in.getFileHeader());
         outHeader.setSequenceDictionary(refDict);
 
-        log.info("Writing reads...");
+        logger.info("Writing reads...");
         if (in.hasIndex()) {
             try (final SAMFileWriter out = new SAMFileWriterFactory().makeSAMOrBAMWriter(outHeader, true, OUTPUT)) {
 
@@ -120,7 +118,7 @@ public final class ReorderSam extends PicardCommandLineProgram {
                             final Map<Integer, Integer> newOrder,
                             final String name) {
         long counter = 0;
-        log.info("  Processing " + name);
+        logger.info("  Processing " + name);
 
         while (it.hasNext()) {
             counter++;
@@ -144,7 +142,7 @@ public final class ReorderSam extends PicardCommandLineProgram {
         }
 
         it.close();
-        log.info("Wrote " + counter + " reads");
+        logger.info("Wrote " + counter + " reads");
     }
 
     /**
@@ -155,7 +153,7 @@ public final class ReorderSam extends PicardCommandLineProgram {
                                                              final SAMSequenceDictionary readsDict) {
         Map<Integer, Integer> newOrder = new HashMap<>();
 
-        log.info("Reordering SAM/BAM file:");
+        logger.info("Reordering SAM/BAM file:");
         for (final SAMSequenceRecord refRec : refDict.getSequences()) {
             final SAMSequenceRecord readsRec = readsDict.getSequence(refRec.getSequenceName());
 
@@ -165,13 +163,13 @@ public final class ReorderSam extends PicardCommandLineProgram {
                             readsRec.getSequenceName(), readsRec.getSequenceLength(),
                             refRec.getSequenceName(), refRec.getSequenceLength());
                     if (ALLOW_CONTIG_LENGTH_DISCORDANCE) {
-                        log.warn(msg);
+                        logger.warn(msg);
                     } else {
                         throw new UserException(msg);
                     }
                 }
 
-                log.info(String.format("  Reordering read contig %s [index=%d] to => ref contig %s [index=%d]%n",
+                logger.info(String.format("  Reordering read contig %s [index=%d] to => ref contig %s [index=%d]%n",
                         readsRec.getSequenceName(), readsRec.getSequenceIndex(),
                         refRec.getSequenceName(), refRec.getSequenceIndex()));
                 newOrder.put(readsRec.getSequenceIndex(), refRec.getSequenceIndex());
@@ -194,9 +192,9 @@ public final class ReorderSam extends PicardCommandLineProgram {
      * Helper function to print out a sequence dictionary
      */
     private void printDictionary(String name, SAMSequenceDictionary dict) {
-        log.info(name);
+        logger.info(name);
         for (final SAMSequenceRecord contig : dict.getSequences()) {
-            log.info("  SN=%s LN=%d%n", contig.getSequenceName(), contig.getSequenceLength());
+            logger.info("  SN=%s LN=%d%n", contig.getSequenceName(), contig.getSequenceLength());
         }
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/ReplaceSamHeader.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/ReplaceSamHeader.java
@@ -3,11 +3,11 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 
@@ -64,7 +64,7 @@ public final class ReplaceSamHeader extends PicardCommandLineProgram {
         }
         try (final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(replacementHeader, true, OUTPUT)) {
 
-            final ProgressLogger progress = new ProgressLogger(Log.getInstance(ReplaceSamHeader.class));
+            final ProgressLogger progress = new ProgressLogger(logger);
             for (final SAMRecord rec : recordReader) {
                 rec.setHeader(replacementHeader);
                 writer.addAlignment(rec);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SamFormatConverter.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SamFormatConverter.java
@@ -3,11 +3,11 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 
@@ -39,7 +39,7 @@ public final class SamFormatConverter extends PicardCommandLineProgram {
                 throw new UserException("Can't CREATE_INDEX unless sort order is coordinate");
             }
 
-            final ProgressLogger progress = new ProgressLogger(Log.getInstance(SamFormatConverter.class));
+            final ProgressLogger progress = new ProgressLogger(logger);
             for (final SAMRecord rec : reader) {
                 writer.addAlignment(rec);
                 progress.record(rec);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SamToFastq.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SamToFastq.java
@@ -5,10 +5,13 @@ import htsjdk.samtools.fastq.FastqRecord;
 import htsjdk.samtools.fastq.FastqWriter;
 import htsjdk.samtools.fastq.FastqWriterFactory;
 import htsjdk.samtools.util.*;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.util.*;
@@ -100,8 +103,6 @@ public final class SamToFastq extends PicardCommandLineProgram {
             "is not comprehensive, so there may be exceptions if this is set to true and there are paired reads with non-primary alignments.")
     public boolean INCLUDE_NON_PRIMARY_ALIGNMENTS = false;
 
-    private final Log log = Log.getInstance(SamToFastq.class);
-
     @Override
     protected Object doWork() {
         IOUtil.assertFileIsReadable(INPUT);
@@ -111,7 +112,7 @@ public final class SamToFastq extends PicardCommandLineProgram {
         factory.setCreateMd5(CREATE_MD5_FILE);
         final Map<SAMReadGroupRecord, FastqWriters> writers = generateWriters(reader.getFileHeader().getReadGroups(), factory);
 
-        final ProgressLogger progress = new ProgressLogger(log);
+        final ProgressLogger progress = new ProgressLogger(logger);
         for (final SAMRecord currentRecord : reader) {
             if (currentRecord.isSecondaryOrSupplementary() && !INCLUDE_NON_PRIMARY_ALIGNMENTS)
                 continue;

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SortSam.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/sam/SortSam.java
@@ -3,10 +3,11 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.*;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 
@@ -30,8 +31,6 @@ public final class SortSam extends PicardCommandLineProgram {
     @Argument(shortName = StandardArgumentDefinitions.SORT_ORDER_SHORT_NAME, doc = "Sort order of output file")
     public SAMFileHeader.SortOrder SORT_ORDER;
 
-    private final Log log = Log.getInstance(SortSam.class);
-
     @Override
     protected Object doWork() {
         IOUtil.assertFileIsReadable(INPUT);
@@ -41,15 +40,15 @@ public final class SortSam extends PicardCommandLineProgram {
         reader.getFileHeader().setSortOrder(SORT_ORDER);
         try (final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(reader.getFileHeader(), false, OUTPUT)) {
             writer.setProgressLogger(
-                    new ProgressLogger(log, (int) 1e7, "Wrote", "records from a sorting collection"));
+                    new ProgressLogger(logger, (int) 1e7, "Wrote", "records from a sorting collection"));
 
-            final ProgressLogger progress = new ProgressLogger(log, (int) 1e7, "Read");
+            final ProgressLogger progress = new ProgressLogger(logger, (int) 1e7, "Read");
             for (final SAMRecord rec : reader) {
                 writer.addAlignment(rec);
                 progress.record(rec);
             }
 
-            log.info("Finished reading inputs, merging and writing to output now.");
+            logger.info("Finished reading inputs, merging and writing to output now.");
 
         }
         CloserUtil.close(reader);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/GatherVcfs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/GatherVcfs.java
@@ -2,7 +2,15 @@ package org.broadinstitute.hellbender.tools.picard.vcf;
 
 import com.google.common.annotations.VisibleForTesting;
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.*;
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.CollectionUtil;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.PeekableIterator;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextComparator;
@@ -11,12 +19,16 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -47,7 +59,7 @@ public final class GatherVcfs extends PicardCommandLineProgram {
     @Argument(shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, doc = "Output VCF file.")
 	public File OUTPUT;
 
-    private static final Log log = Log.getInstance(GatherVcfs.class);
+    private static final Logger log = LogManager.getLogger();
 
     public GatherVcfs() {
         CREATE_INDEX = true;

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/MakeSitesOnlyVcf.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/MakeSitesOnlyVcf.java
@@ -4,8 +4,6 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.variant.variantcontext.GenotypesContext;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
@@ -14,12 +12,14 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.util.*;
@@ -64,7 +64,7 @@ public final class MakeSitesOnlyVcf extends PicardCommandLineProgram {
 		    throw new UserException("A sequence dictionary must be available (either through the input file or by setting it explicitly) when creating indexed output.");
 	    }
 
-        final ProgressLogger progress = new ProgressLogger(Log.getInstance(MakeSitesOnlyVcf.class), 10000);
+        final ProgressLogger progress = new ProgressLogger(logger, 10000);
 
         // Setup the site-only file writer
         final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/MergeVcfs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/MergeVcfs.java
@@ -5,9 +5,7 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.MergingIterator;
-import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextComparator;
 import htsjdk.variant.variantcontext.writer.Options;
@@ -16,13 +14,14 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFUtils;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
-
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 import java.io.File;
 import java.util.*;
 
@@ -54,15 +53,13 @@ public final class MergeVcfs extends PicardCommandLineProgram {
     @Argument(shortName = "D", doc = "The index sequence dictionary to use instead of the sequence dictionary in the input file", optional = true)
     public File SEQUENCE_DICTIONARY;
 
-    private final Log log = Log.getInstance(MergeVcfs.class);
-
     public MergeVcfs() {
         this.CREATE_INDEX = true;
     }
 
     @Override
     protected Object doWork() {
-        final ProgressLogger progress = new ProgressLogger(log, 10000);
+        final ProgressLogger progress = new ProgressLogger(logger, 10000);
         final List<String> sampleList = new ArrayList<>();
         final Collection<CloseableIterator<VariantContext>> iteratorCollection = new ArrayList<>(INPUT.size());
         final Collection<VCFHeader> headers = new HashSet<>(INPUT.size());

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/SplitVcfs.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/SplitVcfs.java
@@ -5,20 +5,20 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 
@@ -53,8 +53,6 @@ public final class SplitVcfs extends PicardCommandLineProgram {
     @Argument(doc = "If true an exception will be thrown if an event type other than SNP or indel is encountered")
     public Boolean STRICT = true;
 
-    private final Log log = Log.getInstance(SplitVcfs.class);
-
     public SplitVcfs() {
         this.CREATE_INDEX = true;
     }
@@ -62,7 +60,7 @@ public final class SplitVcfs extends PicardCommandLineProgram {
     @Override
     protected Object doWork() {
         IOUtil.assertFileIsReadable(INPUT);
-        final ProgressLogger progress = new ProgressLogger(log, 10000);
+        final ProgressLogger progress = new ProgressLogger(logger, 10000);
 
         final VCFFileReader fileReader = new VCFFileReader(INPUT);
         final VCFHeader fileHeader = fileReader.getFileHeader();
@@ -102,7 +100,7 @@ public final class SplitVcfs extends PicardCommandLineProgram {
             }
 
             if (incorrectVariantCount > 0) {
-                log.debug("Found " + incorrectVariantCount + " records that didn't match SNP or INDEL");
+                logger.debug("Found " + incorrectVariantCount + " records that didn't match SNP or INDEL");
             }
 
             CloserUtil.close(iterator);

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/VcfToIntervalList.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/VcfToIntervalList.java
@@ -2,7 +2,6 @@ package org.broadinstitute.hellbender.tools.picard.vcf;
 
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.IntervalList;
-import htsjdk.samtools.util.Log;
 import htsjdk.variant.vcf.VCFFileReader;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
@@ -25,7 +24,6 @@ import java.io.File;
 )
 public final class VcfToIntervalList extends PicardCommandLineProgram {
     // The following attributes define the command-line arguments
-    public static final Log LOG = Log.getInstance(VcfToIntervalList.class);
 
     @Argument(doc = "The BCF or VCF input file. The file format is determined by file extension.", shortName= StandardArgumentDefinitions.INPUT_SHORT_NAME)
     public File INPUT;

--- a/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/concordance/GenotypeConcordance.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/picard/vcf/concordance/GenotypeConcordance.java
@@ -4,19 +4,19 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.IntervalList;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.PeekableIterator;
-import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.variant.variantcontext.Genotype;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextComparator;
 import htsjdk.variant.vcf.VCFFileReader;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.VariantProgramGroup;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 import org.broadinstitute.hellbender.exceptions.UserException;
 
 import org.broadinstitute.hellbender.tools.picard.vcf.concordance.GenotypeConcordanceStates.*;
@@ -80,8 +80,7 @@ public final class GenotypeConcordance extends PicardCommandLineProgram {
     @Argument(doc="If true, use the VCF index, else iterate over the entire VCF.", optional = true)
     public boolean USE_VCF_INDEX = false;
 
-    private final Log log = Log.getInstance(GenotypeConcordance.class);
-    private final ProgressLogger progress = new ProgressLogger(log, 10000, "checked", "variants");
+    private final ProgressLogger progress = new ProgressLogger(logger, 10000, "checked", "variants");
 
     public static final String SUMMARY_METRICS_FILE_EXTENSION = ".genotype_concordance_summary_metrics";
     public static final String DETAILED_METRICS_FILE_EXTENSION = ".genotype_concordance_detail_metrics";
@@ -111,7 +110,7 @@ public final class GenotypeConcordance extends PicardCommandLineProgram {
         IntervalList intervals = null;
         SAMSequenceDictionary intervalsSamSequenceDictionary = null;
         if (usingIntervals) {
-            log.info("Loading up region lists.");
+            logger.info("Loading up region lists.");
             long genomeBaseCount = 0;
             for (final File f : INTERVALS) {
                 IOUtil.assertFileIsReadable(f);
@@ -128,7 +127,7 @@ public final class GenotypeConcordance extends PicardCommandLineProgram {
             if (intervals != null) {
                 intervals = intervals.uniqued();
             }
-            log.info("Finished loading up region lists.");
+            logger.info("Finished loading up region lists.");
         }
 
         final VCFFileReader truthReader = new VCFFileReader(TRUTH_VCF, USE_VCF_INDEX);
@@ -169,7 +168,7 @@ public final class GenotypeConcordance extends PicardCommandLineProgram {
         // A map to keep track of the count of Truth/Call States which we could not successfully classify
         final Map<String, Integer> unClassifiedStatesMap = new HashMap<>();
 
-        log.info("Starting iteration over variants.");
+        logger.info("Starting iteration over variants.");
         while (pairedIterator.hasNext()) {
             final VcTuple tuple = pairedIterator.next();
 
@@ -250,7 +249,7 @@ public final class GenotypeConcordance extends PicardCommandLineProgram {
         genotypeConcordanceContingencyMetricsFile.write(contingencyMetricsFile);
 
         for (final String condition : unClassifiedStatesMap.keySet()) {
-            log.info("Uncovered truth/call Variant Context Type Counts: " + condition + " " + unClassifiedStatesMap.get(condition));
+            logger.info("Uncovered truth/call Variant Context Type Counts: " + condition + " " + unClassifiedStatesMap.get(condition));
         }
 
         return null;

--- a/src/main/java/org/broadinstitute/hellbender/utils/gene/RefFlatReader.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/gene/RefFlatReader.java
@@ -1,8 +1,9 @@
 package org.broadinstitute.hellbender.utils.gene;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.OverlapDetector;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.utils.text.parsers.TabbedTextFileWithHeaderParser;
 
 import java.io.File;
@@ -13,7 +14,7 @@ import java.util.*;
  * internally consistent, e.g. transcripts on different chromosomes or different strands.
  */
 public final class RefFlatReader {
-    private static final Log LOG = Log.getInstance(RefFlatReader.class);
+    private static final Logger LOG = LogManager.getLogger();
     // These are in the order that columns appear in refFlat format.
     public enum RefFlatColumns{GENE_NAME, TRANSCRIPT_NAME, CHROMOSOME, STRAND, TX_START, TX_END, CDS_START, CDS_END,
         EXON_COUNT, EXON_STARTS, EXON_ENDS}

--- a/src/main/java/org/broadinstitute/hellbender/utils/iterators/MarkDuplicatesWithMateCigarIterator.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/iterators/MarkDuplicatesWithMateCigarIterator.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.utils.iterators;
 
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.*;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.markduplicates.*;
@@ -132,7 +133,7 @@ public final class MarkDuplicatesWithMateCigarIterator implements SAMRecordItera
         nextRecord = markDuplicatesAndGetTheNextAvailable(); // get one directly, or null
     }
 
-    public void logMemoryStats(final Log log) {
+    public void logMemoryStats(final Logger log) {
         System.gc();
         final Runtime runtime = Runtime.getRuntime();
         log.info("freeMemory: " + runtime.freeMemory() +

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/AbstractOpticalDuplicateFinderCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/AbstractOpticalDuplicateFinderCommandLineProgram.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.read.markduplicates;
 
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
 
@@ -11,7 +12,7 @@ import org.broadinstitute.hellbender.cmdline.PicardCommandLineProgram;
  * @author Tim Fennell
  */
 public abstract class AbstractOpticalDuplicateFinderCommandLineProgram extends PicardCommandLineProgram {
-    protected static Log LOG = Log.getInstance(AbstractOpticalDuplicateFinderCommandLineProgram.class);
+    protected static Logger LOG = LogManager.getLogger(AbstractOpticalDuplicateFinderCommandLineProgram.class);
 
 
     @Argument(doc = "Regular expression that can be used to parse read names in the incoming SAM file. Read names are " +
@@ -37,7 +38,7 @@ public abstract class AbstractOpticalDuplicateFinderCommandLineProgram extends P
 
     // Needed for testing
     public void setupOpticalDuplicateFinder() {
-        this.opticalDuplicateFinder = new OpticalDuplicateFinder(READ_NAME_REGEX, OPTICAL_DUPLICATE_PIXEL_DISTANCE, LOG);
+        this.opticalDuplicateFinder = new OpticalDuplicateFinder(READ_NAME_REGEX, OPTICAL_DUPLICATE_PIXEL_DISTANCE, logger);
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/OpticalDuplicateFinder.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/markduplicates/OpticalDuplicateFinder.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.hellbender.utils.read.markduplicates;
 
-import htsjdk.samtools.util.Log;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -28,7 +28,7 @@ public final class OpticalDuplicateFinder {
 
     private boolean warnedAboutRegexNotMatching = false;
 
-    private final Log log;
+    private final Logger log;
 
     public OpticalDuplicateFinder() {
         this(DEFAULT_READ_NAME_REGEX, DEFAULT_OPTICAL_DUPLICATE_DISTANCE);
@@ -46,7 +46,7 @@ public final class OpticalDuplicateFinder {
         this(readNameRegex, opticalDuplicatePixelDistance, null);
     }
 
-    public OpticalDuplicateFinder(final String readNameRegex, final int opticalDuplicatePixelDistance, final Log log) {
+    public OpticalDuplicateFinder(final String readNameRegex, final int opticalDuplicatePixelDistance, final Logger log) {
         this.readNameRegex = readNameRegex;
         this.opticalDuplicatePixelDistance = opticalDuplicatePixelDistance;
         this.log = log;

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/AbstractAlignmentMerger.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/AbstractAlignmentMerger.java
@@ -5,9 +5,12 @@ import htsjdk.samtools.filter.FilteringIterator;
 import htsjdk.samtools.filter.SamRecordFilter;
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker;
 import htsjdk.samtools.util.*;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.read.ReadUtils;
+import org.broadinstitute.hellbender.utils.runtime.ProgressLogger;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -40,8 +43,8 @@ public abstract class AbstractAlignmentMerger {
 
     private static final char[] RESERVED_ATTRIBUTE_STARTS = {'X', 'Y', 'Z'};
 
-    private final Log log = Log.getInstance(AbstractAlignmentMerger.class);
-    private final ProgressLogger progress = new ProgressLogger(this.log, 1000000, "Written to sorting collection in queryname order", "records");
+    private final Logger logger = LogManager.getLogger(AbstractAlignmentMerger.class);
+    private final ProgressLogger progress = new ProgressLogger(this.logger, 1000000, "Written to sorting collection in queryname order", "records");
 
     private final File unmappedBamFile;
     private final File targetBamFile;
@@ -155,7 +158,7 @@ public abstract class AbstractAlignmentMerger {
             if (!this.attributesToRetain.isEmpty()) {
                 for (String attribute : this.attributesToRemove) {
                     if (this.attributesToRetain.contains(attribute)) {
-                        log.info("Overriding retaining the " + attribute + " tag since remove overrides retain.");
+                        logger.info("Overriding retaining the " + attribute + " tag since remove overrides retain.");
                         this.attributesToRetain.remove(attribute);
                     }
                 }
@@ -353,8 +356,8 @@ public abstract class AbstractAlignmentMerger {
         final boolean presorted = this.sortOrder == SAMFileHeader.SortOrder.coordinate;
         final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(header, presorted, this.targetBamFile);
         writer.setProgressLogger(
-                new ProgressLogger(log, (int) 1e7, "Wrote", "records from a sorting collection"));
-        final ProgressLogger finalProgress = new ProgressLogger(log, 10000000, "Written in coordinate order to output", "records");
+                new ProgressLogger(logger, (int) 1e7, "Wrote", "records from a sorting collection"));
+        final ProgressLogger finalProgress = new ProgressLogger(logger, 10000000, "Written in coordinate order to output", "records");
 
         for (final SAMRecord rec : sorted) {
             if (!rec.getReadUnmappedFlag()) {
@@ -374,7 +377,7 @@ public abstract class AbstractAlignmentMerger {
         sorted.cleanup();
 
         CloserUtil.close(unmappedSam);
-        log.info("Wrote " + aligned + " alignment records and " + (alignedReadsOnly ? 0 : unmapped) + " unmapped reads.");
+        logger.info("Wrote " + aligned + " alignment records and " + (alignedReadsOnly ? 0 : unmapped) + " unmapped reads.");
     }
 
     /**
@@ -409,7 +412,7 @@ public abstract class AbstractAlignmentMerger {
         if (SAMUtils.cigarMapsNoBasesToRef(unaligned.getCigar())) {
             SAMUtils.makeReadUnmapped(unaligned);
         } else if (SAMUtils.recordMapsEntirelyBeyondEndOfReference(aligned)) {
-            log.warn("Record mapped off end of reference; making unmapped: " + aligned);
+            logger.warn("Record mapped off end of reference; making unmapped: " + aligned);
             SAMUtils.makeReadUnmapped(unaligned);
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/SamAlignmentMerger.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/mergealignment/SamAlignmentMerger.java
@@ -3,6 +3,8 @@ package org.broadinstitute.hellbender.utils.read.mergealignment;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.*;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +21,7 @@ import java.util.List;
  */
 public final class SamAlignmentMerger extends AbstractAlignmentMerger {
 
-    private final Log log = Log.getInstance(SamAlignmentMerger.class);
+    private final Logger log = LogManager.getLogger(SamAlignmentMerger.class);
     private final List<File> alignedSamFile;
     private final List<File> read1AlignedSamFile;
     private final List<File> read2AlignedSamFile;

--- a/src/main/java/org/broadinstitute/hellbender/utils/runtime/ProgressLogger.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/runtime/ProgressLogger.java
@@ -1,0 +1,66 @@
+package org.broadinstitute.hellbender.utils.runtime;
+
+import htsjdk.samtools.util.AbstractProgressLogger;
+import org.apache.logging.log4j.Logger;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+/**
+ * Facilitate consistent logging output when progressing through a stream of SAM records.
+ *
+ * Implements the SAMTools public htsjdk.samtools.util.AbstractProgressLogger interface to enable integration with SAMWriters.
+ *
+ */
+public class ProgressLogger extends AbstractProgressLogger {
+
+    private final Logger logger;
+
+    /**
+     * Construct a progress logger.
+     * @param logger the Logger object to write output to
+     * @param n the frequency with which to output (i.e. every N records)
+     * @param verb the verb to log, e.g. "Processed, Read, Written".
+     * @param noun the noun to use when logging, e.g. "Records, Variants, Loci"
+     */
+    public ProgressLogger(final Logger logger, final int n, final String verb, final String noun) {
+        super(noun, verb, n);
+        this.logger = logger;
+    }
+
+    /**
+     * Construct a progress logger.
+     * @param logger the Logger object to write outputs to
+     * @param n the frequency with which to output (i.e. every N records)
+     * @param verb the verb to log, e.g. "Processed, Read, Written".
+     */
+    public ProgressLogger(final Logger logger, final int n, final String verb) {
+        this(logger, n, verb, "records");
+    }
+
+    /**
+     * Construct a progress logger with the desired log and frequency and the verb "Processed".
+     * @param logger the Logger object to write outputs to
+     * @param n the frequency with which to output (i.e. every N records)
+     */
+    public ProgressLogger(final Logger logger, final int n) { this(logger, n, "Processed"); }
+
+    /**
+     * Construct a progress logger with the desired log, the verb "Processed" and a period of 1m records.
+     * @param logger the Logger object to write outputs to
+     */
+    public ProgressLogger(final Logger logger) { this(logger, 1000000); }
+
+    /**
+     * Log a message to whatever logger is being used
+     *
+     * @param message a message to be logged by the logger (recommended output level is INFO or the equivalent)
+     */
+    protected void log(String... message) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (String s : message) {
+            stringBuilder.append(s);
+        }
+        logger.info(stringBuilder.toString());
+    }
+}


### PR DESCRIPTION
This moves all logging to log4j (previously we had a mix of log4j and SAMTools logging). 

Questions:There are about 35 places where we were using the SAMTools ProgressLogger, which assumes SAMTools logging. I reproduced that class in hellbender, but implemented the SAMTools ProgressLoggerInterface in order to retain compatibility with SAMWriters, since we use those in a couple of places. The hellbender ProgressLogger class is in utils.runtime, not sure if there is a better place for it. Also I'm not sure how to handle the source code attribution of  it since it was lifted from SAMTools but slightly modified for hellbender ? Can I do that or do I need to rewrite it from scratch ?
