### PR TITLE
Add support for CountedReadFilters in ReadWalkers.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/BaseRecalibratorWorker.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/BaseRecalibratorWorker.java
@@ -11,7 +11,7 @@ import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
-import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.engine.filters.WellformedReadFilter;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -162,14 +162,14 @@ public final class BaseRecalibratorWorker {
         return read.getBaseQualities()[offset] < minimumQToUse;
     }
 
-    public static ReadFilter readFilter( final SAMFileHeader header ) {
-        return new WellformedReadFilter(header)
-                    .and(ReadFilterLibrary.MAPPING_QUALITY_NOT_ZERO)
-                    .and(ReadFilterLibrary.MAPPING_QUALITY_AVAILABLE)
-                    .and(ReadFilterLibrary.MAPPED)
-                    .and(ReadFilterLibrary.PRIMARY_ALIGNMENT)
-                    .and(ReadFilterLibrary.NOT_DUPLICATE)
-                    .and(ReadFilterLibrary.PASSES_VENDOR_QUALITY_CHECK);
+    public static CountingReadFilter readFilter( final SAMFileHeader header ) {
+        return new CountingReadFilter("Wellformed", new WellformedReadFilter(header))
+                .and(new CountingReadFilter("Mapping_Quality_Not_Zero", ReadFilterLibrary.MAPPING_QUALITY_NOT_ZERO))
+                .and(new CountingReadFilter("Mapping_Quality_Available", ReadFilterLibrary.MAPPING_QUALITY_AVAILABLE))
+                .and(new CountingReadFilter("Mapped", ReadFilterLibrary.MAPPED))
+                .and(new CountingReadFilter("Primary_Alignment", ReadFilterLibrary.PRIMARY_ALIGNMENT))
+                .and(new CountingReadFilter("Not_Duplicate", ReadFilterLibrary.NOT_DUPLICATE))
+                .and(new CountingReadFilter("Passes_Vendor_Quality_Check", ReadFilterLibrary.PASSES_VENDOR_QUALITY_CHECK));
     }
 
     private static GATKRead consolidateCigar(GATKRead read) {

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilter.java
@@ -1,0 +1,187 @@
+package org.broadinstitute.hellbender.engine.filters;
+
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.Utils;
+
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+
+/**
+ * Wrapper/adapter for ReadFilter that counts the number of reads filtered, and provides a filter count summary.
+ *
+ * For filters with complex predicates that are composed of compound and/or operators, provides counts
+ * by level for each component predicate. All counts reflect short-circuited evaluation of and/or operators
+ * (ie., not all read filters in a compound predicate will necessarily be evaluated every time). Also note
+ * that the count for a compound predicate does not always equal the sum of the counts of it's component
+ * predicates, i.e. an "or" filter will report a filter count of 1 in the case where both component predicates
+ * are evaluated and both fail, but the the individual component filters will report a count of 1 at the next
+ * level.
+ *
+ */
+public class CountingReadFilter implements ReadFilter {
+
+    static private final long serialVersionUID = 1L;
+
+    // Underlying ReadFilter we delegate to if we're wrapping a simple ReadFilter.
+    private final ReadFilter delegateFilter;
+
+    // Name for this filter, used to report filter count summaries
+    protected final String name;
+
+    // Number of reads filtered by this filter
+    protected long filteredCount = 0;
+
+    public CountingReadFilter(final String filterName, final ReadFilter readFilter) {
+        Utils.nonNull(readFilter);
+        name = filterName;
+        delegateFilter = readFilter;
+    }
+
+    // Used only by the nested CountingBinopReadFilter subclass and its derivatives, which must
+    // override the test method with an implementation that does not depend on delegateFilter.
+    private CountingReadFilter(final String filterName) {
+        name = filterName;
+        delegateFilter = null;
+    }
+
+    // Return the number of reads filtered by this filter
+    public long getFilteredCount() {
+        return filteredCount;
+    }
+
+    public void resetFilteredCount() {
+        filteredCount = 0;
+    }
+
+    public String getName() {return name;}
+
+    // Returns a summary line with filter counts organized by level
+    public String getSummaryLine() {return getSummaryLineForLevel(0);}
+
+    protected String getSummaryLineForLevel(final int indentLevel) {
+        if (0 == filteredCount) {
+            return 0 == indentLevel ? "" : "No reads filtered by: " + getName();
+        }
+        else {
+            return getIndentString(indentLevel) + Long.toString(filteredCount) + " read(s) filtered by: " + getName() + " \n";
+        }
+    }
+
+    protected String getIndentString(final int indentLevel) {
+        final StringBuilder bldr = new StringBuilder();
+        IntStream.range(0, indentLevel).forEach(i -> bldr.append("  "));
+        return bldr.toString();
+    }
+
+    /**
+     * Specialization of {@link #and(Predicate)} so that CountingReadFilter and'ed with other CountingReadFilter produce a CountingReadFilter
+     */
+    //@Override
+    public CountingReadFilter and(final CountingReadFilter other) {
+        Utils.nonNull(other);
+        return new CountingAndReadFilter(this, other);
+    }
+
+    /**
+     * Specialization of {@link #or(Predicate)} so that CountingReadFilter ored with other CountingReadFilter produce a CountingReadFilter
+     */
+    //@Override
+    public CountingReadFilter or(final CountingReadFilter other) {
+        Utils.nonNull(other);
+        return new CountingOrReadFilter(this, other);
+    }
+
+    /**
+     * Specialization of negate so that the resulting object is still a CountingReadFilter
+     */
+    @Override
+    public CountingReadFilter negate() {
+        return new CountingReadFilter("(Not '" + getName() + "')",(t) -> !test(t));
+    }
+
+    @Override
+    public boolean test(final GATKRead read) {
+        final boolean accept = delegateFilter.test(read);
+        if (!accept) {
+            filteredCount++;
+        }
+        return accept;
+    }
+
+    /**
+     * Private class for Counting binary operator (and/or) filters; these keep track of how many reads are filtered at
+     * each level of filter nesting.
+     *
+     * Subclasses must override the test method.
+     */
+    private abstract class CountingBinopReadFilter extends CountingReadFilter {
+
+        static private final long serialVersionUID = 1L;
+
+        final CountingReadFilter lhs;
+        final CountingReadFilter rhs;
+
+        public CountingBinopReadFilter(final String name, final CountingReadFilter lhs, final CountingReadFilter rhs) {
+            super(name);
+            Utils.nonNull(lhs);
+            Utils.nonNull(rhs);
+            this.lhs = lhs;
+            this.rhs = rhs;
+        }
+
+        @Override
+        protected String getSummaryLineForLevel(final int indentLevel) {
+            final String indent = getIndentString(indentLevel);
+            if (0 == filteredCount) {
+                return "No reads filtered by: " + getName();
+            }
+            else {
+                return indent + Long.toString(filteredCount) + " read(s) filtered by: " + getName() + "\n"
+                        + (lhs.getFilteredCount() > 0 ? indent + lhs.getSummaryLineForLevel(indentLevel + 1) : "")
+                        + (rhs.getFilteredCount() > 0 ? indent + rhs.getSummaryLineForLevel(indentLevel + 1) : "");
+            }
+        }
+    }
+
+    /**
+     * Private class for Counting AND filters
+     */
+    private class CountingAndReadFilter extends CountingBinopReadFilter {
+
+        static private final long serialVersionUID = 1L;
+
+        private CountingAndReadFilter(final CountingReadFilter lhs, final CountingReadFilter rhs) {
+            super("(" + lhs.getName() + " AND " + rhs.getName() + ")", lhs, rhs);
+        }
+
+        @Override
+        public boolean test(final GATKRead read) {
+            final boolean accept = lhs.test(read) && rhs.test(read);
+            if (!accept) {
+                filteredCount++;
+            }
+            return accept;
+        }
+    }
+
+    /**
+     * Private class for Counting OR filters
+     */
+    private class CountingOrReadFilter extends CountingBinopReadFilter {
+
+        static private final long serialVersionUID = 1L;
+
+        private CountingOrReadFilter(final CountingReadFilter lhs, final CountingReadFilter rhs) {
+            super("(" + lhs.getName() + " OR " + rhs.getName() + ")", lhs, rhs);
+        }
+
+        @Override
+        public boolean test(final GATKRead read) {
+            final  boolean accept = lhs.test(read) || rhs.test(read);
+            if (!accept) {
+                filteredCount++;
+            }
+            return accept;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/filters/ReadFilter.java
@@ -2,10 +2,10 @@ package org.broadinstitute.hellbender.engine.filters;
 
 import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.Utils;
 
 import java.util.Objects;
 import java.util.function.Predicate;
-
 
 /**
  * Filters which operate on {@link GATKRead} should implement this interface by overriding {@link #test(GATKRead)}
@@ -27,15 +27,15 @@ public interface ReadFilter extends Predicate<GATKRead>, SerializableFunction<GA
      * Specialization of {@link #and(Predicate)} so that ReadFilters anded with other ReadFilters produce a ReadFilter
      */
     default ReadFilter and( ReadFilter other ) {
-            Objects.requireNonNull(other);
-            return (t) -> test(t) && other.test(t);
+        Utils.nonNull(other);
+        return (t) -> test(t) && other.test(t);
     }
 
     /**
      * Specialization of {@link #or(Predicate)} so that ReadFilters ored with other ReadFilters produce a ReadFilter
      */
     default ReadFilter or( ReadFilter other ) {
-        Objects.requireNonNull(other);
+        Utils.nonNull(other);
         return (t) -> test(t) || other.test(t);
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/exome/ExomeReadCounts.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/exome/ExomeReadCounts.java
@@ -16,7 +16,7 @@ import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.FeatureManager;
 import org.broadinstitute.hellbender.engine.ReadWalker;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
-import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
 import org.broadinstitute.hellbender.engine.filters.ReadFilterLibrary;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -281,11 +281,11 @@ public final class ExomeReadCounts extends ReadWalker {
     private int[][] counts;
 
     @Override
-    public ReadFilter makeReadFilter() {
+    public CountingReadFilter makeReadFilter() {
         return super.makeReadFilter()
-                .and(ReadFilterLibrary.MAPPED)
-                .and(ReadFilterLibrary.NOT_DUPLICATE)
-                .and(ReadFilterLibrary.NON_ZERO_REFERENCE_LENGTH_ALIGNMENT);
+                .and(new CountingReadFilter("Mapped", ReadFilterLibrary.MAPPED))
+                .and(new CountingReadFilter("Not_Duplicate", ReadFilterLibrary.NOT_DUPLICATE))
+                .and(new CountingReadFilter("Non_Zero_Reference_Length", ReadFilterLibrary.NON_ZERO_REFERENCE_LENGTH_ALIGNMENT));
     }
 
 

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibrator.java
@@ -12,7 +12,7 @@ import org.broadinstitute.hellbender.engine.FeatureContext;
 import org.broadinstitute.hellbender.engine.ReadWalker;
 import org.broadinstitute.hellbender.engine.ReferenceContext;
 import org.broadinstitute.hellbender.engine.ReferenceDataSource;
-import org.broadinstitute.hellbender.engine.filters.ReadFilter;
+import org.broadinstitute.hellbender.engine.filters.CountingReadFilter;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.recalibration.*;
@@ -213,14 +213,14 @@ public final class BaseRecalibrator extends ReadWalker {
     }
 
     @Override
-    public ReadFilter makeReadFilter() {
+    public CountingReadFilter makeReadFilter() {
         return super.makeReadFilter()
-                .and(MAPPING_QUALITY_NOT_ZERO)
-                .and(MAPPING_QUALITY_AVAILABLE)
-                .and(MAPPED)
-                .and(PRIMARY_ALIGNMENT)
-                .and(NOT_DUPLICATE)
-                .and(PASSES_VENDOR_QUALITY_CHECK);
+                .and(new CountingReadFilter("Mapping_Quality_Not_Zero", MAPPING_QUALITY_NOT_ZERO))
+                .and(new CountingReadFilter("Mapping_Quality_Available", MAPPING_QUALITY_AVAILABLE))
+                .and(new CountingReadFilter("Mapped", MAPPED))
+                .and(new CountingReadFilter("Primary_Alignment", PRIMARY_ALIGNMENT))
+                .and(new CountingReadFilter("Not_Duplicate", NOT_DUPLICATE))
+                .and(new CountingReadFilter("Passes_Vendor_Quality_Check", PASSES_VENDOR_QUALITY_CHECK));
     }
 
     private static GATKRead consolidateCigar(GATKRead read) {

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/CountingReadFilterUnitTest.java
@@ -1,0 +1,210 @@
+package org.broadinstitute.hellbender.engine.filters;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+public final class CountingReadFilterUnitTest {
+
+    // Mirrors ReadFilterUnitTest
+    static final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(1, 1, 10);
+    static final GATKRead goodRead = ArtificialReadUtils.createArtificialRead(header, "Zuul", 0, 2, 2);
+    static final GATKRead endBad = ArtificialReadUtils.createArtificialRead(header, "Peter", 0, 1, 100);
+    static final GATKRead startBad = ArtificialReadUtils.createArtificialRead(header, "Ray", 0, -1, 2);
+    static final GATKRead bothBad = ArtificialReadUtils.createArtificialRead(header, "Egon", 0, -1, 100);
+    static final ReadFilter startOk = r -> r.getStart() >= 1;
+    static final ReadFilter endOk = r -> r.getEnd() <= 10;
+
+    // Helper to verify post-filtering filter state
+    private void verifyFilterState(CountingReadFilter rf, boolean expected) {
+        long count = rf.getFilteredCount();
+        String rfSummary = rf.getSummaryLine();
+
+        if (expected) {
+            Assert.assertTrue(0 == count);
+            Assert.assertEquals(-1, rfSummary.indexOf("0 read(s) filtered"));
+        } else {
+            Assert.assertTrue(1 == count);
+            Assert.assertEquals(0, rfSummary.indexOf("1 read(s) filtered"));
+        }
+    }
+
+    @DataProvider(name = "readsStartEnd")
+    public Object[][] readsStartEnd() {
+        return new Object[][]{
+                {goodRead, true, true},
+                {startBad, false, true},
+                {endBad, true, false},
+                {bothBad, false, false}
+        };
+    }
+
+    @Test(dataProvider = "readsStartEnd")
+    public void testTest(GATKRead read, boolean start, boolean end) {
+
+        CountingReadFilter startOkCounting = new CountingReadFilter("StartOk", startOk);
+        Assert.assertEquals(startOkCounting.test(read), start);
+        verifyFilterState(startOkCounting, start);
+
+        CountingReadFilter endOkCounting = new CountingReadFilter("EndOk", endOk);
+        Assert.assertEquals(endOkCounting.test(read), end);
+        verifyFilterState(endOkCounting, end);
+    }
+
+    @Test(dataProvider = "readsStartEnd")
+    public void testNegate(GATKRead read, boolean start, boolean end) {
+        CountingReadFilter notStartOkCounting = new CountingReadFilter("StartOk", startOk).negate();
+        Assert.assertEquals(notStartOkCounting.test(read), !start);
+        verifyFilterState(notStartOkCounting, !start);
+
+        CountingReadFilter notEndOkCounting = new CountingReadFilter("EndOk", endOk).negate();
+        Assert.assertEquals(notEndOkCounting.test(read), !end);
+        verifyFilterState(notEndOkCounting, !end);
+    }
+
+    @DataProvider(name = "readsAnd")
+    public Object[][] readsAnd() {
+        return new Object[][]{
+                {goodRead, true},
+                {startBad, false},
+                {endBad, false},
+                {bothBad, false}
+        };
+    }
+
+    @Test(dataProvider = "readsAnd")
+    public void testAnd(GATKRead read, boolean expected) {
+
+        CountingReadFilter startAndEndOk = new CountingReadFilter("StartOk", startOk).and(new CountingReadFilter("EndOk", endOk));
+        Assert.assertEquals(startAndEndOk.test(read), expected);
+        verifyFilterState(startAndEndOk, expected);
+
+        CountingReadFilter endAndStartOk = new CountingReadFilter("EndOk", endOk).and(new CountingReadFilter("StartOk", startOk));
+        Assert.assertEquals(endAndStartOk.test(read), expected);
+        verifyFilterState(endAndStartOk, expected);
+    }
+
+    @DataProvider(name = "readsOr")
+    public Object[][] readsOr() {
+        return new Object[][]{
+                {goodRead, true},
+                {startBad, true},
+                {endBad, true},
+                {bothBad, false}
+        };
+    }
+
+    @Test(dataProvider = "readsOr")
+    public void testOr(GATKRead read, boolean expected) {
+
+        CountingReadFilter startOrEndOk = new CountingReadFilter("StartOk", startOk).or(new CountingReadFilter("EndOk", endOk));
+        Assert.assertEquals(startOrEndOk.test(read), expected);
+        verifyFilterState(startOrEndOk, expected);
+
+        CountingReadFilter endOrStartOk = new CountingReadFilter("EndOk", endOk).or(new CountingReadFilter("StartOk", startOk));
+        Assert.assertEquals(endOrStartOk.test(read), expected);
+        verifyFilterState(endOrStartOk, expected);
+    }
+
+    @DataProvider(name = "deeper")
+    public Object[][] deeper() {
+        return new Object[][]{
+                {goodRead, false},
+                {startBad, true},
+                {endBad, true},
+                {bothBad, false}
+        };
+    }
+
+    private CountingReadFilter readChecksOut() {
+        return new CountingReadFilter("StartOk", startOk)
+                .or(new CountingReadFilter("EndOk", endOk))
+                .and(new CountingReadFilter("notAMinionOfGozer", r -> !r.getName().equals("Zuul")));
+    }
+
+    @Test(dataProvider = "deeper")
+    public void testDeeperChaining(GATKRead read, boolean expected) {
+
+        CountingReadFilter readCheckOutCounting = readChecksOut();
+        Assert.assertEquals(readCheckOutCounting.test(read), expected);
+        verifyFilterState(readCheckOutCounting, expected);
+
+        readCheckOutCounting = readChecksOut().and(readChecksOut());
+        Assert.assertEquals(readCheckOutCounting.test(read), expected);
+        verifyFilterState(readCheckOutCounting, expected);
+
+        readCheckOutCounting = readChecksOut().and(new CountingReadFilter("false", r -> false));
+        Assert.assertEquals(readCheckOutCounting.test(read), false);
+        verifyFilterState(readCheckOutCounting, false);
+
+        readCheckOutCounting = readChecksOut().or(new CountingReadFilter("true", r -> true));
+        Assert.assertEquals(readCheckOutCounting.test(read), true);
+        verifyFilterState(readCheckOutCounting, true);
+    }
+
+    @DataProvider(name = "multipleRejection")
+    public Object[][] multipleRejection() {
+        return new Object[][] {
+            {
+                new GATKRead[] { goodRead, goodRead, goodRead }, 0
+            },
+            {
+                new GATKRead[] { goodRead, goodRead, bothBad }, 1
+            },
+            {
+                new GATKRead[] { startBad, bothBad, goodRead, startBad }, 3
+            },
+        };
+    }
+
+    @Test(dataProvider = "multipleRejection")
+    public void testRootFilterCounts(GATKRead[] reads, int expectedRejectionCount) {
+
+        CountingReadFilter startOkCounting = new CountingReadFilter("StartOk", startOk);
+        Arrays.asList(reads).stream().filter(startOkCounting).count();  // force the stream to be consumed
+        Assert.assertEquals(startOkCounting.getFilteredCount(), expectedRejectionCount);
+        startOkCounting.resetFilteredCount();
+        Assert.assertEquals(startOkCounting.getFilteredCount(), 0);
+    }
+
+    @DataProvider(name = "subFilterCounts")
+    public Object[][] subFilterCounts() {
+        return new Object[][] {
+                {
+                        new GATKRead[]{goodRead, startBad, bothBad, bothBad}, 1L, 2L, 1L
+                },
+                {
+                        new GATKRead[]{goodRead, goodRead, goodRead, bothBad }, 3L, 3L, 3L
+                },
+                {
+                        new GATKRead[]{goodRead, startBad, endBad, bothBad}, 2L, 3L, 2L
+                },
+        };
+    }
+
+    @Test(dataProvider = "subFilterCounts")
+    public void testSubFilterCounts(GATKRead[] reads, long totalRejections, long startEndRejections, long nameRejections) {
+
+        CountingReadFilter badStart = new CountingReadFilter("StartBad", r -> r.getStart() < 1);
+        CountingReadFilter badEnd = new CountingReadFilter("EndBad", r -> r.getEnd() > 10);
+        CountingReadFilter badStartAndEnd = badStart.and(badEnd);
+
+        CountingReadFilter isRay= new CountingReadFilter("isRay", r -> r.getName().equals("Ray"));
+        CountingReadFilter isEgon = new CountingReadFilter("isEgon", r -> r.getName().equals("Egon"));
+        CountingReadFilter isRayOrEgon = isRay.or(isEgon);
+
+        CountingReadFilter compoundFilter = badStartAndEnd.or(isRayOrEgon);
+
+        Arrays.asList(reads).stream().filter(compoundFilter).count(); // force the stream to be consumed
+
+        Assert.assertTrue(compoundFilter.getFilteredCount() == totalRejections);
+        Assert.assertTrue(badStartAndEnd.getFilteredCount() == startEndRejections);
+        Assert.assertTrue(isRayOrEgon.getFilteredCount() == nameRejections);
+    }
+}
+

--- a/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/filters/ReadFilterUnitTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 
 public final class ReadFilterUnitTest {
 
+    // Mirrors CountedReadFilterUnitTest
     static final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader(1, 1, 10);
     static final GATKRead goodRead = ArtificialReadUtils.createArtificialRead(header, "Zuul", 0, 2,2);
     static final GATKRead endBad = ArtificialReadUtils.createArtificialRead(header, "Peter", 0, 1,100);
@@ -56,7 +57,6 @@ public final class ReadFilterUnitTest {
         ReadFilter endAndStartOk = endOk.and(startOk);
         Assert.assertEquals(startAndEndOk.test(read), expected);
         Assert.assertEquals(endAndStartOk.test(read), expected);
-
     }
 
     @DataProvider(name = "readsOr")
@@ -72,10 +72,10 @@ public final class ReadFilterUnitTest {
 
     @Test(dataProvider = "readsOr")
     public void testOr(GATKRead read, boolean expected) {
-        ReadFilter startAndEndOk = startOk.or(endOk);
-        ReadFilter endAndStartOk = endOk.or(startOk);
-        Assert.assertEquals(startAndEndOk.test(read), expected);
-        Assert.assertEquals(endAndStartOk.test(read), expected);
+        ReadFilter startOrEndOk = startOk.or(endOk);
+        ReadFilter endOrStartOk = endOk.or(startOk);
+        Assert.assertEquals(startOrEndOk.test(read), expected);
+        Assert.assertEquals(endOrStartOk.test(read), expected);
     }
 
     @DataProvider(name = "deeper")


### PR DESCRIPTION
Questions: I'm not sure how to integrate the count summary and output from these in hellbender. GATK uses a collection of filters, so it can query each filter individually for a count. Hellbender uses a single filter lambda, which represents a sequence of and'd and or'd filters, so the filter itself needs to report all of the counts based on component filter conditions.

