### PR TITLE
Increase Kyro buffer size for large objects in Spark.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ before_install:
 - R --version
 after_success:
 - gradle jacocoTestReport coveralls
+after_failure:
+- dmesg | tail -100

--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,8 @@ test {
 
     // ensure dataflowRunner is passed to the test VM if specified on the command line
     systemProperty "dataflowRunner", System.getProperty("dataflowRunner")
+    // increase max buffer size for Spark serialization
+    systemProperty "spark.kryoserializer.buffer.max", "256m"
 
     // set heap size for the test JVM(s)
     minHeapSize = "1G"


### PR DESCRIPTION
This fixes the unit tests running on Spark.