### PR TITLE
added logging to help with perf debugging.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/dev/BunnyLog.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/BunnyLog.java
@@ -1,0 +1,48 @@
+package org.broadinstitute.hellbender.dev;
+
+import java.util.Random;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * The "bunny" log format:
+ *
+ * =[**]= START <id> <name>
+ * =[**]= STEPEND <id> <step_name>
+ * =[**]= END <id>
+ *
+ * The functions here create an id for you and keep track of it, and format the various strings,
+ * sending it to a logger if you provided one.
+ */
+public final class BunnyLog {
+    // to mark the log entries in the "bunny" format
+    public static final String bunny = "=[**]=";
+    private Logger optLogger = null;
+    private final String id;
+
+    public BunnyLog() {
+        this.id = "" + new Random().nextLong();
+    }
+
+    public BunnyLog(Logger l) {
+        this();
+        optLogger = l;
+    }
+
+    public String start(String name) {
+        String ret = bunny + " START " + id + " " + name;
+        if (null!=optLogger) optLogger.info(ret);
+        return ret;
+    }
+
+    public String stepEnd(String stepName) {
+        String ret = bunny + " STEPEND " + id + " " + stepName;
+        if (null!=optLogger) optLogger.info(ret);
+        return ret;
+    }
+
+    public String end() {
+        String ret = bunny + " END " + id;
+        if (null!=optLogger) optLogger.info(ret);
+        return ret;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/dev/DoFnWLog.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/DoFnWLog.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.hellbender.dev;
+
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import org.apache.logging.log4j.LogManager;
+import org.broadinstitute.hellbender.dev.pipelines.bqsr.BaseRecalOutput;
+import org.broadinstitute.hellbender.tools.recalibration.RecalibrationTables;
+
+/**
+ * A DoFn that automatically logs its start and end.
+ * When subclassing, if you want to write your own start/finishBundle then
+ * make sure to call super.startBundle() and super.finishBundle().
+ */
+public abstract class DoFnWLog<T,U> extends DoFn<T,U> {
+    private static final long serialVersionUID = 1L;
+
+    protected String className;
+    protected String opName;
+    protected transient BunnyLog bunny;
+
+    public DoFnWLog(String name) {
+        this.opName = this.className = name;
+    }
+
+    public DoFnWLog(String className, String operationName) {
+        this.className = className;
+        this.opName = operationName;
+    }
+
+    @Override
+    public void startBundle(DoFn<T, U>.Context c) throws Exception {
+        bunny = new BunnyLog(LogManager.getLogger(className));
+        bunny.start(opName);
+    }
+    
+    @Override
+    public void finishBundle(DoFn<T, U>.Context c) throws Exception {
+        bunny.end();
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/dev/BunnyLogTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/dev/BunnyLogTest.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.hellbender.dev;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+import org.testng.Assert;
+
+public class BunnyLogTest {
+
+    @Test
+    public void testStart() throws Exception {
+        String start = new BunnyLog().start("eating carrots");
+        String[] p = start.split(" ");
+        Assert.assertEquals(p[0], BunnyLog.bunny);
+        Assert.assertEquals(p[1], "START");
+        Assert.assertEquals(p[3], "eating");
+    }
+
+    @Test
+    public void testStepEnd() throws Exception {
+        String stepEnd = new BunnyLog().stepEnd("digging");
+        String[] p = stepEnd.split(" ");
+        Assert.assertEquals(p[0], BunnyLog.bunny);
+        Assert.assertEquals(p[1], "STEPEND");
+        Assert.assertEquals(p[3], "digging");
+    }
+
+    @Test
+    public void testEnd() throws Exception {
+        BunnyLog log = new BunnyLog();
+        String start = log.start("eating carrots");
+        String id = start.split(" ")[2];
+        String end = log.end();
+        String[] p = end.split(" ");
+        Assert.assertEquals(p[0], BunnyLog.bunny);
+        Assert.assertEquals(p[1], "END");
+        Assert.assertEquals(p[2], id);
+    }
+}


### PR DESCRIPTION
This code adds log statements with "START" and "END" keywords so that we can then process the logs and see (i) how many times a specific operation was called, (ii) how long the operation took (per call, or in aggregate).

In addition it has the notion of intermediate "steps" so we can drill down individual operations.