### PR TITLE
limiting gradle memory usage on circle ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,5 @@
 machine:
   java:
     version: oraclejdk8
+  environment:
+    GRADLE_OPTS: -Xmx512m -XX:MaxPermSize=512m


### PR DESCRIPTION
This should hopefully fix the out of memory errors on CircleCI, although it's hard to test since they happen kind of randomly.