### PR TITLE
Fix BQSR Dataflow test that was failing due to lack of sequence dictionary validation

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorDataflowIntegrationTest.java
@@ -238,8 +238,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
         spec.executeTest("testBQSRFailWithoutDBSNP", this);
     }
 
-    // TODO: re-enable this once sequence dictionary validation is in
-    @Test(enabled = false)
+    @Test
     public void testBQSRFailWithIncompatibleReference() throws IOException {
         final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
 
@@ -250,7 +249,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
         IntegrationTestSpec spec = new IntegrationTestSpec(
                 params.getCommandLine(),
                 1,
-                UserException.MissingContigInSequenceDictionary.class);
+                UserException.IncompatibleSequenceDictionaries.class);
         spec.executeTest("testBQSRFailWithIncompatibleReference", this);
     }
 }


### PR DESCRIPTION
Now that sequence dictionary validation is in, we can re-enable this test,
which was previously failing with a java.lang.OutOfMemoryError due to lack
of upfront validation of the reads vs. reference sequence dictionaries.