### PR TITLE
Pass reference into SAM Reader for CRAM support

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/GATKTool.java
@@ -3,6 +3,8 @@ package org.broadinstitute.hellbender.engine;
 import com.sun.xml.bind.v2.TODO;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
 import htsjdk.tribble.Feature;
 import htsjdk.variant.vcf.VCFHeader;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
@@ -84,7 +86,12 @@ public abstract class GATKTool extends CommandLineProgram {
      * May be overridden by traversals that require custom initialization of the reads data source.
      */
     void initializeReads() {
-        reads = ! readArguments.getReadFiles().isEmpty() ? new ReadsDataSource(readArguments.getReadFiles()) : null;
+        SamReaderFactory factory = null;
+        if (hasReference()){
+            // pass in reference if available, because CRAM files need it
+            factory = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT).referenceSequence(referenceArguments.getReferenceFile());
+        }
+        reads = ! readArguments.getReadFiles().isEmpty() ? new ReadsDataSource(readArguments.getReadFiles(), factory) : null;
     }
 
     /**


### PR DESCRIPTION
This allows CRAM files to be used in the existing structure. Fixes #606 