### PR TITLE
Replace File.createTempFile with BaseTest's

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/dev/pipelines/bqsr/BaseRecalOutputSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/pipelines/bqsr/BaseRecalOutputSource.java
@@ -5,21 +5,13 @@ import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.values.PCollection;
-import com.google.cloud.dataflow.sdk.values.POutput;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.tools.recalibration.QuantizationInfo;
-import org.broadinstitute.hellbender.tools.recalibration.RecalibrationReport;
-import org.broadinstitute.hellbender.tools.recalibration.RecalibrationTables;
-import org.broadinstitute.hellbender.tools.recalibration.covariates.StandardCovariateList;
 import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Serializable;
-import java.nio.channels.Channels;
 
 /**
  * Functions to oad a BaseRecalOutput.
@@ -42,7 +34,7 @@ public final class BaseRecalOutputSource implements Serializable {
                     @Override
                     public void processElement(ProcessContext c) {
                         final String fname = c.element();
-                        File dest = BaseTest.createTempFile("temp-BaseRecal-", ".gz");
+                        File dest = IOUtils.createTempFile("temp-BaseRecal-", ".gz");
                         try {
                             BucketUtils.copyFile(fname, c.getPipelineOptions(), dest.getPath());
                         } catch (IOException x) {

--- a/src/main/java/org/broadinstitute/hellbender/dev/pipelines/bqsr/BaseRecalibratorDataflowUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/pipelines/bqsr/BaseRecalibratorDataflowUtils.java
@@ -28,6 +28,7 @@ import org.broadinstitute.hellbender.tools.recalibration.RecalibrationTables;
 import org.broadinstitute.hellbender.tools.walkers.bqsr.RecalibrationEngine;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
@@ -131,7 +132,7 @@ public final class BaseRecalibratorDataflowUtils implements Serializable {
                     // Saving and loading back the report actually changes it. So we have to do it.
                     // TODO: Figure out what it changes, and just do that instead of doing the whole rigamarole.
                     try {
-                        File temp = BaseTest.createTempFile("temp-recalibrationtable-", ".tmp");
+                        File temp = IOUtils.createTempFile("temp-recalibrationtable-", ".tmp");
                         toolArgs.RAC.RECAL_TABLE = new PrintStream(temp);
                         RecalUtils.outputRecalibrationReport(toolArgs.RAC, baseRecalibratorWorker.getQuantizationInfo(rt), rt, baseRecalibratorWorker.getRequestedCovariates(), false);
                         BaseRecalOutput ret = new BaseRecalOutput(temp);

--- a/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/BaseRecalibratorDataflow.java
+++ b/src/main/java/org/broadinstitute/hellbender/dev/tools/walkers/bqsr/BaseRecalibratorDataflow.java
@@ -22,7 +22,11 @@ import org.broadinstitute.hellbender.cmdline.programgroups.ReadProgramGroup;
 import org.broadinstitute.hellbender.dev.BunnyLog;
 import org.broadinstitute.hellbender.dev.pipelines.bqsr.BaseRecalibratorDataflowUtils;
 import org.broadinstitute.hellbender.dev.pipelines.bqsr.DataflowReadFilter;
-import org.broadinstitute.hellbender.engine.*;
+import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.engine.FeatureInput;
+import org.broadinstitute.hellbender.engine.FeatureManager;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.ReferenceDataSource;
 import org.broadinstitute.hellbender.engine.dataflow.DataflowCommandLineProgram;
 import org.broadinstitute.hellbender.engine.dataflow.ReadsSource;
 import org.broadinstitute.hellbender.engine.dataflow.coders.GATKReadCoder;
@@ -35,8 +39,8 @@ import org.broadinstitute.hellbender.utils.SequenceDictionaryUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
 import org.broadinstitute.hellbender.utils.dataflow.DataflowUtils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.utils.test.BaseTest;
 
 import java.io.File;
 import java.io.IOException;
@@ -173,7 +177,7 @@ public class BaseRecalibratorDataflow extends DataflowCommandLineProgram {
         if (remote) {
             return GcsPath.fromUri(stagingLocation).resolve(TEMP_RECALTABLES + ".sj").toString();
         } else {
-            File outputTables = BaseTest.createTempFile(TEMP_RECALTABLES, ".sj");
+            File outputTables = IOUtils.createTempFile(TEMP_RECALTABLES, ".sj");
             return outputTables.getPath();
         }
     }

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/bqsr/AnalyzeCovariates.java
@@ -10,10 +10,10 @@ import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.recalibration.RecalUtils;
 import org.broadinstitute.hellbender.tools.recalibration.RecalibrationReport;
 import org.broadinstitute.hellbender.utils.Utils;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -477,13 +477,7 @@ public final class AnalyzeCovariates extends CommandLineProgram {
         if (csvFile != null)  {
             return csvFile;
         } else {
-            try {
-              final File result = File.createTempFile("AnalyzeCovariates", ".csv");
-              result.deleteOnExit();
-              return result;
-            } catch (IOException e) {
-                throw new UserException("Could not create temporary Csv file",e);
-            }
+            return IOUtils.createTempFile("AnalyzeCovariates", ".csv");
         }
     }
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -1,17 +1,15 @@
 package org.broadinstitute.hellbender.utils.test;
 
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.tribble.Tribble;
-import htsjdk.tribble.util.TabixUtils;
 import htsjdk.variant.variantcontext.Genotype;
 import htsjdk.variant.vcf.VCFConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.GenomeLoc;
 import org.broadinstitute.hellbender.utils.GenomeLocParser;
 import org.broadinstitute.hellbender.utils.fasta.CachingIndexedFastaSequenceFile;
+import org.broadinstitute.hellbender.utils.io.IOUtils;
 import org.testng.Assert;
 import org.testng.Reporter;
 import org.testng.annotations.BeforeClass;
@@ -206,25 +204,14 @@ public abstract class BaseTest {
 
     /**
      * Creates a temp file that will be deleted on exit after tests are complete.
+     *
+     * This will also mark the corresponding Tribble/Tabix/BAM indices matching the temp file for deletion.
      * @param name Prefix of the file.
      * @param extension Extension to concat to the end of the file.
      * @return A file in the temporary directory starting with name, ending with extension, which will be deleted after the program exits.
      */
     public static File createTempFile(final String name, final String extension) {
-        try {
-            final File file = File.createTempFile(name, extension);
-            file.deleteOnExit();
-
-            // Mark corresponding indices for deletion on exit as well just in case an index is created for the temp file:
-            new File(file.getAbsolutePath() + Tribble.STANDARD_INDEX_EXTENSION).deleteOnExit();
-            new File(file.getAbsolutePath() + TabixUtils.STANDARD_INDEX_EXTENSION).deleteOnExit();
-            new File(file.getAbsolutePath() + ".bai").deleteOnExit();
-            new File(file.getAbsolutePath().replaceAll(extension + "$", ".bai")).deleteOnExit();
-
-            return file;
-        } catch (IOException ex) {
-            throw new GATKException("Cannot create temp file: " + ex.getMessage(), ex);
-        }
+        return IOUtils.createTempFile(name, extension);
     }
 
     /**

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -349,8 +349,7 @@ public final class CommandLineParserTest {
 
     @Test
     public void testArgumentsFile() throws Exception {
-        final File argumentsFile = File.createTempFile("clp.", ".arguments");
-        argumentsFile.deleteOnExit();
+        final File argumentsFile = BaseTest.createTempFile("clp.", ".arguments");
         try (final PrintWriter writer = new PrintWriter(argumentsFile)) {
             writer.println("-T 18");
             writer.println("--TRUTHINESS");
@@ -390,8 +389,7 @@ public final class CommandLineParserTest {
      */
     @Test( expectedExceptions = UserException.CommandLineException.class)
     public void testArgumentsFileWithDisallowedOverride() throws Exception {
-        final File argumentsFile = File.createTempFile("clp.", ".arguments");
-        argumentsFile.deleteOnExit();
+        final File argumentsFile = BaseTest.createTempFile("clp.", ".arguments");
         try (final PrintWriter writer = new PrintWriter(argumentsFile)) {
             writer.println("--T 18");
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/PrintReadsIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.read.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -21,8 +22,7 @@ public final class PrintReadsIntegrationTest extends CommandLineProgramTest{
     @Test(dataProvider="testingData")
     public void testFileToFile(String fileIn, String extOut) throws Exception {
         String samFile= fileIn;
-        final File outFile = File.createTempFile(samFile + ".", extOut);
-        outFile.deleteOnExit();
+        final File outFile = BaseTest.createTempFile(samFile + ".", extOut);
         File ORIG_BAM = new File(TEST_DATA_DIR, samFile);
         final String[] args = new String[]{
                 "--input" , ORIG_BAM.getAbsolutePath(),

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectAlignmentSummaryMetricsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectAlignmentSummaryMetricsTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.picard.analysis;
 
 import htsjdk.samtools.metrics.MetricsFile;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -26,8 +27,7 @@ public final class CollectAlignmentSummaryMetricsTest extends CommandLineProgram
     public void test() throws IOException {
         final File input = new File(TEST_DATA_DIR, "summary_alignment_stats_test.sam");
         final File reference = new File(TEST_DATA_DIR, "summary_alignment_stats_test.fasta");
-        final File outfile   = File.createTempFile("alignmentMetrics", ".txt");
-        outfile.deleteOnExit();
+        final File outfile = BaseTest.createTempFile("alignmentMetrics", ".txt");
         final String[] args = new String[] {
                 "--INPUT", input.getAbsolutePath(),
                 "--OUTPUT", outfile.getAbsolutePath(),
@@ -85,8 +85,7 @@ public final class CollectAlignmentSummaryMetricsTest extends CommandLineProgram
     public void testBisulfite() throws IOException {
         final File input = new File(TEST_DATA_DIR, "summary_alignment_bisulfite_test.sam");
         final File reference = new File(TEST_DATA_DIR, "summary_alignment_stats_test.fasta");
-        final File outfile   = File.createTempFile("alignmentMetrics", ".txt");
-        outfile.deleteOnExit();
+        final File outfile = BaseTest.createTempFile("alignmentMetrics", ".txt");
         final String[] args = new String[] {
                 "--INPUT", input.getAbsolutePath(),
                 "--OUTPUT", outfile.getAbsolutePath(),
@@ -147,8 +146,7 @@ public final class CollectAlignmentSummaryMetricsTest extends CommandLineProgram
     @Test
     public void testNoReference() throws IOException {
         final File input = new File(TEST_DATA_DIR, "summary_alignment_stats_test.sam");
-        final File outfile   = File.createTempFile("alignmentMetrics", ".txt");
-        outfile.deleteOnExit();
+        final File outfile = BaseTest.createTempFile("alignmentMetrics", ".txt");
         final String[] args = new String[] {
                 "--INPUT", input.getAbsolutePath(),
                 "--OUTPUT", outfile.getAbsolutePath()
@@ -204,8 +202,7 @@ public final class CollectAlignmentSummaryMetricsTest extends CommandLineProgram
     @Test
     public void testZeroLengthReads() throws IOException {
         final File input = new File(TEST_DATA_DIR, "summary_alignment_stats_test2.sam");
-        final File outfile   = File.createTempFile("alignmentMetrics", ".txt");
-        outfile.deleteOnExit();
+        final File outfile = BaseTest.createTempFile("alignmentMetrics", ".txt");
         final String[] args = new String[] {
                 "--INPUT", input.getAbsolutePath(),
                 "--OUTPUT", outfile.getAbsolutePath()
@@ -222,8 +219,7 @@ public final class CollectAlignmentSummaryMetricsTest extends CommandLineProgram
     @Test
     public void testMultipleLevelsOfMetrics() throws IOException {
         final File input = new File(TEST_DATA_DIR, "summary_alignment_stats_test_multiple.sam");
-        final File outfile   = File.createTempFile("alignmentMetrics", ".txt");
-        outfile.deleteOnExit();
+        final File outfile = BaseTest.createTempFile("alignmentMetrics", ".txt");
         final String[] args = new String[] {
                 "--INPUT", input.getAbsolutePath(),
                 "--OUTPUT", outfile.getAbsolutePath(),

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetricsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/CollectInsertSizeMetricsTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.picard.analysis;
 
 import htsjdk.samtools.metrics.MetricsFile;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -22,10 +23,8 @@ public final class CollectInsertSizeMetricsTest extends CommandLineProgramTest {
     @Test
     public void test() throws IOException {
         final File input = new File(TEST_DATA_DIR, "insert_size_metrics_test.sam");
-        final File outfile   = File.createTempFile("test", ".insert_size_metrics");
-        final File pdf   = File.createTempFile("test", ".pdf");
-        outfile.deleteOnExit();
-        pdf.deleteOnExit();
+        final File outfile   = BaseTest.createTempFile("test", ".insert_size_metrics");
+        final File pdf   = BaseTest.createTempFile("test", ".pdf");
         final String[] args = new String[] {
                 "--INPUT", input.getAbsolutePath(),
                 "--OUTPUT", outfile.getAbsolutePath(),

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRnaSeqMetricsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRnaSeqMetricsTest.java
@@ -11,14 +11,14 @@ import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.StringUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.gene.RefFlatReader.RefFlatColumns;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.PrintStream;
-
-import org.broadinstitute.hellbender.utils.gene.RefFlatReader.RefFlatColumns;
 
 public final class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
     public String getTestedClassName() {
@@ -45,7 +45,7 @@ public final class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
 
         builder.addFrag("ignoredFrag", builder.getHeader().getSequenceIndex(ignoredSequence), 1, false);
 
-        final File samFile = File.createTempFile("tmp.collectRnaSeqMetrics.", ".sam");
+        final File samFile = BaseTest.createTempFile("tmp.collectRnaSeqMetrics.", ".sam");
         try (final SAMFileWriter samWriter = new SAMFileWriterFactory().makeSAMWriter(builder.getHeader(), false, samFile)) {
             for (final SAMRecord rec : builder.getRecords()) samWriter.addAlignment(rec);
         }
@@ -54,12 +54,11 @@ public final class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
         final Interval rRnaInterval = new Interval(sequence, 300, 520, true, "rRNA");
         final IntervalList rRnaIntervalList = new IntervalList(builder.getHeader());
         rRnaIntervalList.add(rRnaInterval);
-        final File rRnaIntervalsFile = File.createTempFile("tmp.rRna.", ".interval_list");
-        rRnaIntervalsFile.deleteOnExit();
+        final File rRnaIntervalsFile = BaseTest.createTempFile("tmp.rRna.", ".interval_list");
         rRnaIntervalList.write(rRnaIntervalsFile);
 
         // Generate the metrics.
-        final File metricsFile = File.createTempFile("tmp.", ".rna_metrics");
+        final File metricsFile = BaseTest.createTempFile("tmp.", ".rna_metrics");
 
         final String[] args = new String[] {
                 "--INPUT", samFile.getAbsolutePath(),
@@ -116,7 +115,7 @@ public final class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
 
         builder.addFrag("ignoredFrag", builder.getHeader().getSequenceIndex(ignoredSequence), 1, false);
 
-        final File samFile = File.createTempFile("tmp.collectRnaSeqMetrics.", ".sam");
+        final File samFile = BaseTest.createTempFile("tmp.collectRnaSeqMetrics.", ".sam");
         try (final SAMFileWriter samWriter = new SAMFileWriterFactory().makeSAMWriter(builder.getHeader(), false, samFile)) {
             for (final SAMRecord rec : builder.getRecords()) samWriter.addAlignment(rec);
         }
@@ -125,12 +124,11 @@ public final class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
         final Interval rRnaInterval = new Interval(sequence, 300, 520, true, "rRNA");
         final IntervalList rRnaIntervalList = new IntervalList(builder.getHeader());
         rRnaIntervalList.add(rRnaInterval);
-        final File rRnaIntervalsFile = File.createTempFile("tmp.rRna.", ".interval_list");
-        rRnaIntervalsFile.deleteOnExit();
+        final File rRnaIntervalsFile = BaseTest.createTempFile("tmp.rRna.", ".interval_list");
         rRnaIntervalList.write(rRnaIntervalsFile);
 
         // Generate the metrics.
-        final File metricsFile = File.createTempFile("tmp.", ".rna_metrics");
+        final File metricsFile = BaseTest.createTempFile("tmp.", ".rna_metrics");
 
         final String[] args = new String[] {
                 "--INPUT", samFile.getAbsolutePath(),
@@ -206,8 +204,7 @@ public final class CollectRnaSeqMetricsTest extends CommandLineProgramTest {
         refFlatFields[RefFlatColumns.EXON_STARTS.ordinal()] = "49,249";
         refFlatFields[RefFlatColumns.EXON_ENDS.ordinal()] = "200,500";
 
-        final File refFlatFile = File.createTempFile("tmp.", ".refFlat");
-        refFlatFile.deleteOnExit();
+        final File refFlatFile = BaseTest.createTempFile("tmp.", ".refFlat");
         try (final PrintStream refFlatStream = new PrintStream(refFlatFile)) {
             refFlatStream.println(StringUtil.join("\t", refFlatFields));
         }

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRrbsMetricsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/analysis/directed/CollectRrbsMetricsTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.picard.analysis.directed;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.IOUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -24,7 +25,7 @@ public final class CollectRrbsMetricsTest extends CommandLineProgramTest {
 
 	@BeforeTest
 	private void setUp() throws Exception {
-		rootTestDir = File.createTempFile("crmt.", ".tmp");
+		rootTestDir = BaseTest.createTempFile("crmt.", ".tmp");
 		Assert.assertTrue(rootTestDir.delete());
 		Assert.assertTrue(rootTestDir.mkdir());
 	}

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/interval/BedToIntervalListTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/interval/BedToIntervalListTest.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMException;
 import htsjdk.samtools.util.IOUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -19,8 +20,7 @@ public final class BedToIntervalListTest extends CommandLineProgramTest {
     private final File TEST_DATA_DIR = new File(getTestDataDir(), "picard/interval/BedToIntervalListTest");
 
     private void doTest(final String inputBed, final String header) throws IOException {
-        final File outputFile  = File.createTempFile("bed_to_interval_list_test.", ".interval_list");
-        outputFile.deleteOnExit();
+        final File outputFile = BaseTest.createTempFile("bed_to_interval_list_test.", ".interval_list");
         final BedToIntervalList program = new BedToIntervalList();
         final File inputBedFile = new File(TEST_DATA_DIR, inputBed);
         program.INPUT = inputBedFile;

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/AddCommentsToBamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/AddCommentsToBamIntegrationTest.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.SAMTextHeaderCodec;
 import htsjdk.samtools.SamReaderFactory;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -28,7 +29,7 @@ public final class AddCommentsToBamIntegrationTest extends CommandLineProgramTes
 
     @Test
     public void testAddCommentsToBam() throws Exception {
-        final File outputFile = File.createTempFile("addCommentsToBamTest.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File outputFile = BaseTest.createTempFile("addCommentsToBamTest.", BamFileIoUtils.BAM_FILE_EXTENSION);
         runIt(BAM_FILE, outputFile, commentList);
 
         final SAMFileHeader newHeader = SamReaderFactory.makeDefault().getFileHeader(outputFile);
@@ -45,14 +46,14 @@ public final class AddCommentsToBamIntegrationTest extends CommandLineProgramTes
 
     @Test(expectedExceptions = UserException.class)
     public void testUsingSam() throws Exception {
-        final File outputFile = File.createTempFile("addCommentsToBamTest.samFile", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File outputFile = BaseTest.createTempFile("addCommentsToBamTest.samFile", BamFileIoUtils.BAM_FILE_EXTENSION);
         runIt(SAM_FILE, outputFile, commentList);
         throw new IllegalStateException("We shouldn't be here!");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testUsingNewlines() throws Exception {
-        final File outputFile = File.createTempFile("addCommentsToBamTest.newLine", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File outputFile = BaseTest.createTempFile("addCommentsToBamTest.newLine", BamFileIoUtils.BAM_FILE_EXTENSION);
         runIt(SAM_FILE, outputFile, new String[]{"this is\n a crazy\n test"});
         throw new IllegalStateException("We shouldn't be here!");
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CleanSamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CleanSamIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.*;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.read.testers.CleanSamTester;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -22,8 +23,7 @@ public final class CleanSamIntegrationTest extends CommandLineProgramTest {
     @Test(dataProvider = "testCleanSamDataProvider")
     public void testCleanSam(final String samFile, final String expectedCigar) throws IOException {
         final File inputFile = new File(TEST_DATA_DIR, samFile);
-        final File cleanedFile = File.createTempFile(samFile + ".", ".sam");
-        cleanedFile.deleteOnExit();
+        final File cleanedFile = BaseTest.createTempFile(samFile + ".", ".sam");
         final String[] args = new String[]{
                 "--INPUT", inputFile.getAbsolutePath(),
                 "--OUTPUT", cleanedFile.getAbsolutePath()

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/CreateSequenceDictionaryIntegrationTest.java
@@ -22,9 +22,8 @@ public final class CreateSequenceDictionaryIntegrationTest extends CommandLinePr
 
     @Test
     public void testBasic() throws Exception {
-        final File outputDict = File.createTempFile("CreateSequenceDictionaryTest.", ".dict");
+        final File outputDict = BaseTest.createTempFile("CreateSequenceDictionaryTest.", ".dict");
         outputDict.delete();
-        outputDict.deleteOnExit();
         final String[] argv = {
                 "--REFERENCE", BASIC_FASTA.getAbsolutePath(),
                 "--OUTPUT", outputDict.getAbsolutePath()
@@ -37,9 +36,8 @@ public final class CreateSequenceDictionaryIntegrationTest extends CommandLinePr
      */
     @Test(expectedExceptions = {UserException.MalformedFile.class})
     public void testNonUniqueSequenceName() throws Exception {
-        final File outputDict = File.createTempFile("CreateSequenceDictionaryTest.", ".dict");
+        final File outputDict = BaseTest.createTempFile("CreateSequenceDictionaryTest.", ".dict");
         outputDict.delete();
-        outputDict.deleteOnExit();
         final String[] argv = {
                 "--REFERENCE", DUPLICATE_FASTA.getAbsolutePath(),
                 "--OUTPUT", outputDict.getAbsolutePath(),
@@ -52,7 +50,6 @@ public final class CreateSequenceDictionaryIntegrationTest extends CommandLinePr
     @Test(expectedExceptions = {UserException.CommandLineException.class})
     public void testNoReferenceSpecified() throws Exception {
         final File output = BaseTest.createTempFile("TestOutput", ".out");
-        output.deleteOnExit();
         final String[] argv = {
                 "CreateSequenceDictionary",
                 "--OUTPUT", output.getAbsolutePath()

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/FastqToSamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/FastqToSamIntegrationTest.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.util.FastqQualityFormat;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -176,14 +177,12 @@ public final class FastqToSamIntegrationTest extends CommandLineProgramTest {
     }
 
     private static File newTempSamFile(final String filename) throws IOException {
-        final File file = File.createTempFile(filename,".sam");
-        file.deleteOnExit();
+        final File file = BaseTest.createTempFile(filename, ".sam");
         return file;
     }
 
     private static File newTempFile(final String filename) throws IOException {
-        final File file = File.createTempFile(filename,".tmp");
-        file.deleteOnExit();
+        final File file = BaseTest.createTempFile(filename, ".tmp");
         return file;
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/GatherBamFilesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/GatherBamFilesIntegrationTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 import htsjdk.samtools.BamFileIoUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.read.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -29,7 +30,7 @@ public final class GatherBamFilesIntegrationTest extends CommandLineProgramTest 
 
     @Test
     public void testTheGathering() throws Exception {
-        final File outputFile = File.createTempFile("gatherBamFilesTest.samFile.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File outputFile = BaseTest.createTempFile("gatherBamFilesTest.samFile.", BamFileIoUtils.BAM_FILE_EXTENSION);
         final List<String> args = new ArrayList<>();
         for (final File splitBam : SPLIT_BAMS) {
             args.add("--INPUT");

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/MergeBamAlignmentIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/MergeBamAlignmentIntegrationTest.java
@@ -7,6 +7,7 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.read.SamAssertionUtils;
 import org.broadinstitute.hellbender.utils.read.mergealignment.BestMapqPrimaryAlignmentSelectionStrategy;
 import org.broadinstitute.hellbender.utils.read.mergealignment.SamAlignmentMerger;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -60,7 +61,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
 
     @Test
     public void testMergerWithSupplemental() throws Exception {
-        final File outputWithSupplemental = File.createTempFile("mergeWithSupplementalTest", ".sam");
+        final File outputWithSupplemental = BaseTest.createTempFile("mergeWithSupplementalTest", ".sam");
         System.out.println(outputWithSupplemental.getAbsolutePath());
         // outputWithSupplemental.deleteOnExit();
 
@@ -134,8 +135,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
 
     @Test
     public void testMerger() throws Exception {
-        final File output = File.createTempFile("mergeTest", ".sam");
-        output.deleteOnExit();
+        final File output = BaseTest.createTempFile("mergeTest", ".sam");
 
         doMergeAlignment(unmappedBam, Collections.singletonList(alignedBam),
                 null, null, null, null,
@@ -226,8 +226,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
 
     @Test
     public void testMergerFromMultipleFiles() throws Exception {
-        final File output = File.createTempFile("mergeTest", ".sam");
-        output.deleteOnExit();
+        final File output = BaseTest.createTempFile("mergeTest", ".sam");
 
         doMergeAlignment(unmappedBam, Arrays.asList(oneHalfAlignedBam, otherHalfAlignedBam),
                 null, null, null, null,
@@ -282,8 +281,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
     public void testSortingOnSamAlignmentMerger(final File unmapped, final File aligned, final boolean sorted, final String testName)
             throws IOException {
 
-        final File target = File.createTempFile("target", "bam");
-        target.deleteOnExit();
+        final File target = BaseTest.createTempFile("target", "bam");
         final SamAlignmentMerger merger = new SamAlignmentMerger(unmapped,  target, fasta, null, true, false,
                 false, Arrays.asList(aligned), 1, null, null, null, null, null, null,
                 Arrays.asList(SamPairUtil.PairOrientation.FR), SAMFileHeader.SortOrder.coordinate,
@@ -316,8 +314,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
      */
     @Test(dataProvider="separateTrimmed")
     public void testMergingFromSeparatedReadTrimmedAlignments(final File unmapped, final List<File> r1Align, final List<File> r2Align, final int r1Trim, final int r2Trim, final String testName) throws Exception {
-        final File output = File.createTempFile("mergeMultipleAlignmentsTest", ".sam");
-        output.deleteOnExit();
+        final File output = BaseTest.createTempFile("mergeMultipleAlignmentsTest", ".sam");
 
         doMergeAlignment(unmapped, null, r1Align, r2Align, r1Trim, r2Trim,
                 false, true, false, 1,
@@ -380,8 +377,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
     @Test(expectedExceptions = {IllegalStateException.class, GATKException.class})
     public void testOldQuerynameSortFails() throws IOException {
 
-        final File merged = File.createTempFile("merged", BamFileIoUtils.BAM_FILE_EXTENSION);
-        merged.deleteOnExit();
+        final File merged = BaseTest.createTempFile("merged", BamFileIoUtils.BAM_FILE_EXTENSION);
 
         doMergeAlignment(badorderUnmappedBam, Collections.singletonList(badorderAlignedBam),
                 null, null, null, null,
@@ -396,8 +392,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
 
     @Test
     public void testMultiHit() throws IOException {
-        final File merged = File.createTempFile("merged", ".sam");
-        merged.deleteOnExit();
+        final File merged = BaseTest.createTempFile("merged", ".sam");
 
         doMergeAlignment(multiHitUnmappedBam, Collections.singletonList(multiHitAlignedBam),
                 null, null, null, null,
@@ -533,8 +528,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
             firstUnmappedRec = unmappedSamFileIterator.next();
             secondUnmappedRec = unmappedSamFileIterator.next();
         }
-        final File alignedSam = File.createTempFile("aligned.", ".sam");
-        alignedSam.deleteOnExit();
+        final File alignedSam = BaseTest.createTempFile("aligned.", ".sam");
         final SAMFileHeader alignedHeader = new SAMFileHeader();
         alignedHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
         alignedHeader.setSequenceDictionary(SamReaderFactory.makeDefault().getFileHeader(sequenceDict).getSequenceDictionary());
@@ -557,8 +551,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
         }
 
         // Merge aligned file with original unmapped file.
-        final File mergedSam = File.createTempFile("merged.", ".sam");
-        mergedSam.deleteOnExit();
+        final File mergedSam = BaseTest.createTempFile("merged.", ".sam");
 
         doMergeAlignment(multiHitFilterUnmappedBam, Collections.singletonList(alignedSam),
                 null, null, null, null,
@@ -802,8 +795,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
         // Create the aligned file by copying bases, quals, readname from the unmapped read, and conforming to each HitSpec.
         try (final SAMRecordIterator unmappedSamFileIterator = SamReaderFactory.makeDefault().open(multiHitFilterFragmentUnmappedBam).iterator()) {
             final SAMRecord unmappedRec = unmappedSamFileIterator.next();
-            final File alignedSam = File.createTempFile("aligned.", ".sam");
-            alignedSam.deleteOnExit();
+            final File alignedSam = BaseTest.createTempFile("aligned.", ".sam");
             final SAMFileHeader alignedHeader = new SAMFileHeader();
             alignedHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
             alignedHeader.setSequenceDictionary(SamReaderFactory.makeDefault().getFileHeader(sequenceDict).getSequenceDictionary());
@@ -817,8 +809,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
                 }
             }
             // Merge aligned file with original unmapped file.
-            final File mergedSam = File.createTempFile("merged.", ".sam");
-            mergedSam.deleteOnExit();
+            final File mergedSam = BaseTest.createTempFile("merged.", ".sam");
 
             doMergeAlignment(multiHitFilterFragmentUnmappedBam, Collections.singletonList(alignedSam),
                     null, null, null, null,
@@ -894,11 +885,9 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
      */
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testEarliestFragmentStrategyPaired() throws Exception {
-        final File output = File.createTempFile("mergeTest", ".sam");
-        output.deleteOnExit();
+        final File output = BaseTest.createTempFile("mergeTest", ".sam");
 
-        final File unmappedSam = File.createTempFile("unmapped.", ".sam");
-        unmappedSam.deleteOnExit();
+        final File unmappedSam = BaseTest.createTempFile("unmapped.", ".sam");
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         final SAMFileHeader header = new SAMFileHeader();
         header.setSortOrder(SAMFileHeader.SortOrder.queryname);
@@ -926,8 +915,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
             unmappedWriter.addAlignment(secondOfPair);
         }
 
-        final File alignedSam = File.createTempFile("aligned.", ".sam");
-        alignedSam.deleteOnExit();
+        final File alignedSam = BaseTest.createTempFile("aligned.", ".sam");
 
         // Populate the header with SAMSequenceRecords
         header.getSequenceDictionary().addSequence(new SAMSequenceRecord("chr1", 1000000));
@@ -985,8 +973,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
     @Test(dataProvider = "testEarliestFragmentStrategyDataProvider")
     public void testEarliestFragmentStrategy(final String testName, final MultipleAlignmentSpec[] specs) throws IOException {
 
-        final File output = File.createTempFile(testName, ".sam");
-        output.deleteOnExit();
+        final File output = BaseTest.createTempFile(testName, ".sam");
         final File[] sams = createSamFilesToBeMerged(specs);
 
         doMergeAlignment(sams[0], Collections.singletonList(sams[1]),
@@ -1062,52 +1049,46 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
      * @return a 2-element array in which the first element is the unmapped SAM, and the second the mapped SAM.
      */
     private File[] createSamFilesToBeMerged(final MultipleAlignmentSpec[] specs) {
-        try {
-            final File unmappedSam = File.createTempFile("unmapped.", ".sam");
-            unmappedSam.deleteOnExit();
-            final SAMFileWriterFactory factory = new SAMFileWriterFactory();
-            final SAMFileHeader header = new SAMFileHeader();
-            header.setSortOrder(SAMFileHeader.SortOrder.queryname);
-            final SAMRecord unmappedRecord = new SAMRecord(header);
+        final File unmappedSam = BaseTest.createTempFile("unmapped.", ".sam");
+        final SAMFileWriterFactory factory = new SAMFileWriterFactory();
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSortOrder(SAMFileHeader.SortOrder.queryname);
+        final SAMRecord unmappedRecord = new SAMRecord(header);
 
-            unmappedRecord.setReadName("theRead");
-            unmappedRecord.setReadString("ACGTACGTACGTACGT");
-            unmappedRecord.setBaseQualityString("5555555555555555");
-            unmappedRecord.setReadUnmappedFlag(true);
+        unmappedRecord.setReadName("theRead");
+        unmappedRecord.setReadString("ACGTACGTACGTACGT");
+        unmappedRecord.setBaseQualityString("5555555555555555");
+        unmappedRecord.setReadUnmappedFlag(true);
 
-            try (final SAMFileWriter unmappedWriter = factory.makeSAMWriter(header, false, unmappedSam)) {
-                unmappedWriter.addAlignment(unmappedRecord);
-            }
-
-            final File alignedSam = File.createTempFile("aligned.", ".sam");
-            alignedSam.deleteOnExit();
-
-            final String sequence = "chr1";
-            // Populate the header with SAMSequenceRecords
-            header.getSequenceDictionary().addSequence(new SAMSequenceRecord(sequence, 1000000));
-
-            try (final SAMFileWriter alignedWriter = factory.makeSAMWriter(header, false, alignedSam)){
-                for (final MultipleAlignmentSpec spec : specs) {
-                    final SAMRecord alignedRecord = new SAMRecord(header);
-                    alignedRecord.setReadName(unmappedRecord.getReadName());
-                    alignedRecord.setReadBases(unmappedRecord.getReadBases());
-                    alignedRecord.setBaseQualities(unmappedRecord.getBaseQualities());
-                    alignedRecord.setReferenceName(sequence);
-                    alignedRecord.setAlignmentStart(1);
-                    alignedRecord.setReadNegativeStrandFlag(spec.reverseStrand);
-                    alignedRecord.setCigarString(spec.cigar);
-                    alignedRecord.setMappingQuality(spec.mapQ);
-                    if (spec.oneOfTheBest) {
-                        alignedRecord.setAttribute(ONE_OF_THE_BEST_TAG, 1);
-                    }
-                    alignedWriter.addAlignment(alignedRecord);
-                }
-            }
-
-            return new File[]{unmappedSam, alignedSam};
-        } catch (IOException e) {
-            throw new GATKException(e.getMessage(), e);
+        try (final SAMFileWriter unmappedWriter = factory.makeSAMWriter(header, false, unmappedSam)) {
+            unmappedWriter.addAlignment(unmappedRecord);
         }
+
+        final File alignedSam = BaseTest.createTempFile("aligned.", ".sam");
+
+        final String sequence = "chr1";
+        // Populate the header with SAMSequenceRecords
+        header.getSequenceDictionary().addSequence(new SAMSequenceRecord(sequence, 1000000));
+
+        try (final SAMFileWriter alignedWriter = factory.makeSAMWriter(header, false, alignedSam)){
+            for (final MultipleAlignmentSpec spec : specs) {
+                final SAMRecord alignedRecord = new SAMRecord(header);
+                alignedRecord.setReadName(unmappedRecord.getReadName());
+                alignedRecord.setReadBases(unmappedRecord.getReadBases());
+                alignedRecord.setBaseQualities(unmappedRecord.getBaseQualities());
+                alignedRecord.setReferenceName(sequence);
+                alignedRecord.setAlignmentStart(1);
+                alignedRecord.setReadNegativeStrandFlag(spec.reverseStrand);
+                alignedRecord.setCigarString(spec.cigar);
+                alignedRecord.setMappingQuality(spec.mapQ);
+                if (spec.oneOfTheBest) {
+                    alignedRecord.setAttribute(ONE_OF_THE_BEST_TAG, 1);
+                }
+                alignedWriter.addAlignment(alignedRecord);
+            }
+        }
+
+        return new File[]{unmappedSam, alignedSam};
     }
 
     class MultipleAlignmentSpec {
@@ -1129,8 +1110,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
      */
     @Test
     public void testShortFragmentClipping() throws Exception {
-        final File output = File.createTempFile("testShortFragmentClipping", ".sam");
-        output.deleteOnExit();
+        final File output = BaseTest.createTempFile("testShortFragmentClipping", ".sam");
         doMergeAlignment(clipTestUnmappedBam,
                 Collections.singletonList(clipTestAlignedBam),
                 null, null, null, null,
@@ -1173,8 +1153,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
     private void testBestFragmentMapqStrategy(final String testName, final int[] firstMapQs, final int[] secondMapQs,
                                               final boolean includeSecondary, final int expectedFirstMapq,
                                               final int expectedSecondMapq) throws Exception {
-        final File unmappedSam = File.createTempFile("unmapped.", ".sam");
-        unmappedSam.deleteOnExit();
+        final File unmappedSam = BaseTest.createTempFile("unmapped.", ".sam");
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         final SAMFileHeader header = new SAMFileHeader();
         header.setSortOrder(SAMFileHeader.SortOrder.queryname);
@@ -1205,8 +1184,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
             unmappedWriter.addAlignment(secondUnmappedRead);
         }
 
-        final File alignedSam = File.createTempFile("aligned.", ".sam");
-        alignedSam.deleteOnExit();
+        final File alignedSam = BaseTest.createTempFile("aligned.", ".sam");
 
         final String sequence = "chr1";
         // Populate the header with SAMSequenceRecords
@@ -1217,8 +1195,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
             addAlignmentsForBestFragmentMapqStrategy(alignedWriter, secondUnmappedRead, sequence, secondMapQs);
         }
 
-        final File output = File.createTempFile("testBestFragmentMapqStrategy." + testName, ".sam");
-        output.deleteOnExit();
+        final File output = BaseTest.createTempFile("testBestFragmentMapqStrategy." + testName, ".sam");
         doMergeAlignment(unmappedSam, Collections.singletonList(alignedSam),
                 null, null, null, null,
                 false, true, false, 1,
@@ -1390,8 +1367,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
                                         final MostDistantStrategyAlignmentSpec[] firstEndSpecs,
                                         final MostDistantStrategyAlignmentSpec[] secondEndSpecs) throws Exception {
 
-        final File unmappedSam = File.createTempFile("unmapped.", ".sam");
-        unmappedSam.deleteOnExit();
+        final File unmappedSam = BaseTest.createTempFile("unmapped.", ".sam");
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         final SAMFileHeader header = new SAMFileHeader();
         header.setSortOrder(SAMFileHeader.SortOrder.queryname);
@@ -1422,8 +1398,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
             unmappedWriter.addAlignment(secondUnmappedRead);
         }
 
-        final File alignedSam = File.createTempFile("aligned.", ".sam");
-        alignedSam.deleteOnExit();
+        final File alignedSam = BaseTest.createTempFile("aligned.", ".sam");
 
         header.setSequenceDictionary(SamReaderFactory.makeDefault().getFileHeader(sequenceDict).getSequenceDictionary());
 
@@ -1453,8 +1428,7 @@ public final class MergeBamAlignmentIntegrationTest extends CommandLineProgramTe
                 }
             }
         }
-        final File output = File.createTempFile("testMostDistantStrategy." + testName, ".sam");
-        output.deleteOnExit();
+        final File output = BaseTest.createTempFile("testMostDistantStrategy." + testName, ".sam");
         doMergeAlignment(unmappedSam, Collections.singletonList(alignedSam),
                 null, null, null, null,
                 false, true, false, 1,

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/MergeSamFilesIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/MergeSamFilesIntegrationTest.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.util.CloserUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.read.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -26,8 +27,7 @@ public final class MergeSamFilesIntegrationTest extends CommandLineProgramTest {
         final File unsortedInputTestDataDir = new File(TEST_DATA_DIR, "unsorted_input");
         final File sam1 = new File(unsortedInputTestDataDir, "1.sam");
         final File sam2 = new File(unsortedInputTestDataDir, "2.sam");
-        final File mergedOutput = File.createTempFile("unsortedInputSortedOutputTest.", BamFileIoUtils.BAM_FILE_EXTENSION);
-        mergedOutput.deleteOnExit();
+        final File mergedOutput = BaseTest.createTempFile("unsortedInputSortedOutputTest.", BamFileIoUtils.BAM_FILE_EXTENSION);
 
         final String[] args = new String[]{
                 "--INPUT", sam1.getAbsolutePath(),

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/RevertSamIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/RevertSamIntegrationTest.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.util.CloserUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,7 +32,7 @@ public final class RevertSamIntegrationTest extends CommandLineProgramTest {
                                    final boolean restoreOriginalQualities, final String sample, final String library,
                                    final List<String> attributesToClear) throws Exception {
 
-        final File output = File.createTempFile("reverted", ".sam");
+        final File output = BaseTest.createTempFile("reverted", ".sam");
         final RevertSam reverter = new RevertSam();
         final List<String> args = new ArrayList<>();
         args.add("--INPUT");
@@ -125,7 +126,7 @@ public final class RevertSamIntegrationTest extends CommandLineProgramTest {
     @Test(dataProvider="negativeTestData", expectedExceptions = {UserException.class, GATKException.class})
     public void basicNegativeTest(final String sample, final String library) throws Exception {
 
-        final File output = File.createTempFile("bad", ".sam");
+        final File output = BaseTest.createTempFile("bad", ".sam");
         final RevertSam reverter = new RevertSam();
         final List<String> args = new ArrayList<>();
         args.add("--INPUT");

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/SamFormatConverterIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/SamFormatConverterIntegrationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.hellbender.tools.picard.sam;
 
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.utils.read.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -53,7 +54,7 @@ public final class SamFormatConverterIntegrationTest extends CommandLineProgramT
         final List<String> samFileConverterArgs = new ArrayList<>();
         samFileConverterArgs.add("--INPUT");
         samFileConverterArgs.add(inputFile.getAbsolutePath());
-        final File converterOutput = File.createTempFile("SamFileConverterTest." + inputFile.getName(), extension);
+        final File converterOutput = BaseTest.createTempFile("SamFileConverterTest." + inputFile.getName(), extension);
         samFileConverterArgs.add("--OUTPUT");
         samFileConverterArgs.add(converterOutput.getAbsolutePath());
         runCommandLine(samFileConverterArgs);

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/SamToFastqIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/sam/SamToFastqIntegrationTest.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.fastq.FastqRecord;
 import htsjdk.samtools.util.IOUtil;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -51,10 +52,8 @@ public final class SamToFastqIntegrationTest extends CommandLineProgramTest {
     public void testClipping(final String clippingAction, final String bases1_1, final String quals1_1, final String bases1_2, final String quals1_2,
                              final String bases2_1, final String quals2_1, final String bases2_2, final String quals2_2, final String testName) throws IOException {
         final File samFile = new File(TEST_DATA_DIR, CLIPPING_TEST_DATA) ;
-        final File f1 = File.createTempFile("clippingtest1", "fastq");
-        final File f2 = File.createTempFile("clippingtest2", "fastq");
-        f1.deleteOnExit();
-        f2.deleteOnExit();
+        final File f1 = BaseTest.createTempFile("clippingtest1", "fastq");
+        final File f2 = BaseTest.createTempFile("clippingtest2", "fastq");
 
         if (clippingAction != null) {
             convertFile(new String[]{
@@ -163,10 +162,8 @@ public final class SamToFastqIntegrationTest extends CommandLineProgramTest {
     @Test (dataProvider = "badFiles", expectedExceptions= SAMFormatException.class)
     public void testBadFile(final String samFilename) throws IOException {
         final File samFile = new File(TEST_DATA_DIR,samFilename);
-        final File pair1 = File.createTempFile("tt-pair1.", ".fastq");
-        final File pair2 = File.createTempFile("tt-pair2.", ".fastq");
-        pair1.deleteOnExit();
-        pair2.deleteOnExit();
+        final File pair1 = BaseTest.createTempFile("tt-pair1.", ".fastq");
+        final File pair2 = BaseTest.createTempFile("tt-pair2.", ".fastq");
         convertFile(new String[]{
                 "--INPUT", samFile.getAbsolutePath(),
                 "--FASTQ", pair1.getAbsolutePath(),
@@ -288,8 +285,6 @@ public final class SamToFastqIntegrationTest extends CommandLineProgramTest {
         final File samFile = new File(TEST_DATA_DIR, samFilename);
         final File pair1File = newTempFastqFile("pair1");
         final File pair2File = newTempFastqFile("pair2");
-        pair1File.deleteOnExit();
-        pair2File.deleteOnExit();
 
         convertFile(new String[]{
                 "--INPUT", samFile.getAbsolutePath(),
@@ -392,8 +387,7 @@ public final class SamToFastqIntegrationTest extends CommandLineProgramTest {
 
     private File newTempFastqFile(final String filename) throws IOException {
         if(filename == null) return null;
-        final File file = File.createTempFile(filename,".fastq");
-        file.deleteOnExit();
+        final File file = BaseTest.createTempFile(filename, ".fastq");
         return file;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/vcf/AbstractVcfMergingClpTester.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/vcf/AbstractVcfMergingClpTester.java
@@ -6,6 +6,7 @@ import htsjdk.variant.variantcontext.VariantContextComparator;
 import htsjdk.variant.vcf.VCFFileReader;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -65,9 +66,8 @@ public abstract class AbstractVcfMergingClpTester extends CommandLineProgramTest
 	public void testMergeIndelsSnps() throws IOException {
 		final File indelInputFile = new File(TEST_DATA_PATH, "CEUTrio-indels.vcf");
 		final File snpInputFile = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf");
-		final File output = File.createTempFile("merge-indels-snps-test-output.", ".vcf");
+        final File output = BaseTest.createTempFile("merge-indels-snps-test-output.", ".vcf");
         final List<String> indexing = Arrays.asList("--CREATE_INDEX", "false");
-        output.deleteOnExit();
 
 		final Queue<String> indelContigPositions = loadContigPositions(indelInputFile);
 		final Queue<String> snpContigPositions = loadContigPositions(snpInputFile);
@@ -123,8 +123,7 @@ public abstract class AbstractVcfMergingClpTester extends CommandLineProgramTest
 		positionQueues.add(5, loadContigPositions(five));
 
         final List<String> indexing = Arrays.asList("--CREATE_INDEX", "false");
-        final File output = File.createTempFile("random-scatter-test-output.", ".vcf");
-		output.deleteOnExit();
+        final File output = BaseTest.createTempFile("random-scatter-test-output.", ".vcf");
 
         runClp(inputs, output, indexing);
         validateResultsForMultipleInputs(output, positionQueues);

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/vcf/SortVcfTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/vcf/SortVcfTest.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextComparator;
 import htsjdk.variant.vcf.VCFFileReader;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -21,9 +22,8 @@ public final class SortVcfTest extends AbstractVcfMergingClpTester {
     @Test
     public void testPresortedFile() throws IOException {
         final File snpInputFile = new File(TEST_DATA_PATH, "CEUTrio-snps.vcf");
-        final File output = File.createTempFile("sort-presorted-test-output.", ".vcf");
+        final File output = BaseTest.createTempFile("sort-presorted-test-output.", ".vcf");
         final List<String> indexing = Arrays.asList("--CREATE_INDEX", "false");
-        output.deleteOnExit();
 
         final int numberOfVariantContexts = loadContigPositions(snpInputFile).size();
 
@@ -34,9 +34,8 @@ public final class SortVcfTest extends AbstractVcfMergingClpTester {
     @Test
     public void testSingleScrambledFile() throws IOException {
         final File snpInputFile = new File(TEST_DATA_PATH, "CEUTrio-snps-scrambled.1.vcf");
-        final File output = File.createTempFile("sort-single-scrambled-test-output.", ".vcf");
+        final File output = BaseTest.createTempFile("sort-single-scrambled-test-output.", ".vcf");
         final List<String> indexing = Arrays.asList("--CREATE_INDEX", "false");
-        output.deleteOnExit();
 
         final int numberOfVariantContexts = loadContigPositions(snpInputFile).size();
 
@@ -48,9 +47,8 @@ public final class SortVcfTest extends AbstractVcfMergingClpTester {
     public void testTwoScrambledSnpFiles() throws IOException {
         final File inputFile1 = new File(TEST_DATA_PATH, "CEUTrio-snps-scrambled.1.vcf");
         final File inputFile2 = new File(TEST_DATA_PATH, "CEUTrio-snps-scrambled.2.vcf");
-        final File output = File.createTempFile("sort-multiple-scrambled-test-output.", ".vcf");
+        final File output = BaseTest.createTempFile("sort-multiple-scrambled-test-output.", ".vcf");
         final List<String> indexing = Arrays.asList("--CREATE_INDEX", "false");
-        output.deleteOnExit();
 
         final int numberOfVariantContexts = loadContigPositions(inputFile1).size() + loadContigPositions(inputFile2).size();
 
@@ -62,9 +60,8 @@ public final class SortVcfTest extends AbstractVcfMergingClpTester {
     public void testScrambledSnpsAndOrderedIndels() throws IOException {
         final File indelInputFile = new File(TEST_DATA_PATH, "CEUTrio-indels.vcf");
         final File snpInputFile = new File(TEST_DATA_PATH, "CEUTrio-snps-scrambled.1.vcf");
-        final File output = File.createTempFile("sort-scrambled-indels-snps-test-output.", ".vcf");
+        final File output = BaseTest.createTempFile("sort-scrambled-indels-snps-test-output.", ".vcf");
         final List<String> indexing = Arrays.asList("--CREATE_INDEX", "false");
-        output.deleteOnExit();
 
         final int numberOfVariantContexts = loadContigPositions(indelInputFile).size() + loadContigPositions(snpInputFile).size();
 
@@ -76,9 +73,8 @@ public final class SortVcfTest extends AbstractVcfMergingClpTester {
     public void testScrambledSnpsAndScrambledIndels() throws IOException {
         final File indelInputFile = new File(TEST_DATA_PATH, "CEUTrio-indels-scrambled.1.vcf");
         final File snpInputFile = new File(TEST_DATA_PATH, "CEUTrio-snps-scrambled.1.vcf");
-        final File output = File.createTempFile("merge-indels-snps-test-output.", ".vcf");
-        final List<String> indexing = Arrays.asList("--CREATE_INDEX", "false");
-        output.deleteOnExit();
+        final File output = BaseTest.createTempFile("merge-indels-snps-test-output.", ".vcf");
+        final List<String> indexing = Arrays.asList("--CREATE_INDEX", "false");;
 
         final int numberOfVariantContexts = loadContigPositions(indelInputFile).size() + loadContigPositions(snpInputFile).size();
 

--- a/src/test/java/org/broadinstitute/hellbender/tools/picard/vcf/filter/FilterVcfTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/picard/vcf/filter/FilterVcfTest.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.util.ListMap;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFFileReader;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -88,8 +89,7 @@ public final class FilterVcfTest extends CommandLineProgramTest {
 
     /** Utility method that takes a a VCF and a set of parameters and filters the VCF. */
     File testFiltering(final File vcf, final double minAb, final int minDp, final int minGq, final double maxFs) throws Exception {
-        final File out = File.createTempFile("filterVcfTest.", ".vcf.gz");
-        out.deleteOnExit();
+        final File out = BaseTest.createTempFile("filterVcfTest.", ".vcf.gz");
 
         final String[] args = new String[]{
                 "--CREATE_INDEX", "true",

--- a/src/test/java/org/broadinstitute/hellbender/utils/text/parsers/TabbedTextFileWithHeaderParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/text/parsers/TabbedTextFileWithHeaderParserTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.hellbender.utils.text.parsers;
 
 import htsjdk.samtools.util.StringUtil;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -18,8 +19,7 @@ public final class TabbedTextFileWithHeaderParserTest {
                 new String[] {"foo", "bar", "splat"},
         };
 
-        final File tmp = File.createTempFile("tabbedTextTest.", ".txt");
-        tmp.deleteOnExit();
+        final File tmp = BaseTest.createTempFile("tabbedTextTest.", ".txt");
         try (final BufferedWriter out = new BufferedWriter(new FileWriter(tmp))) {
 
             for (final String[] fields : data) {
@@ -51,8 +51,7 @@ public final class TabbedTextFileWithHeaderParserTest {
 
         final String[] headers = {"STRING", "STRING2", "NUMBER"};
 
-        final File tmp = File.createTempFile("tabbedTextTest.", ".txt");
-        tmp.deleteOnExit();
+        final File tmp = BaseTest.createTempFile("tabbedTextTest.", ".txt");
 
         try (final BufferedWriter out = new BufferedWriter(new FileWriter(tmp))) {
 


### PR DESCRIPTION
Replacing instances of `File.createTempFile` with `BaseTest.createTempFile` since it automatically cleans up it's tmp files and is therefore safer to use.

Deleting now extraneous instances of `deleteOnExit`

I left a usage of `File.createTempFile in IOUtils.writeTempResource because it's some thing used only by the `RscriptExcecutor` and I'm afraid it might continue running Rscripts after the java VM shutsdown and will break if we clean up the temp files while it's running. 
 
I Left another usage in `IOUtils.createTempDir`.  It's unclear to me if changing the semantics of this method will have any ill effects.  We should investigate further.  I think we should probably move this method to `BaseTest` as well at some point just for symmetry's sake.

Fixes #667