### PR TITLE
Uploading the test results from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,3 +53,8 @@ after_success:
 - gradle jacocoTestReport coveralls
 after_failure:
 - dmesg | tail -100
+after_script:
+- $GCLOUD/gcloud components -q update gsutil
+- REPORT_PATH=$TRAVIS_BRANCH_$TRAVIS_JOB_NUMBER
+- $GCLOUD/gsutil -m cp -z html -z js -z xml -z css -r build/reports/tests gs://hellbender/test/build_reports/$REPORT_PATH/
+- echo "See the test report at https://storage.googleapis.com/hellbender/test/build_reports/$REPORT_PATH/tests/index.html"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ General guidelines for Hellbender developers
 
 * If you push to master or mess the commit history, you owe us 1 growler or tasty snacks at happy hour. If you break the master build, you owe 3 growlers (or lots of tasty snacks). Beer may be replaced by wine (in the color and vintage of buyer's choosing) in proportions of 1 growler = 1 bottle. 
 
+Tests
+----------------
+We use [Travis-CI](https://travis-ci.org/broadinstitute/hellbender) as our continuous integration provider.
+
+* Before merging any branch make sure that all required tests pass on travis.  Currently tests in the `cloud` and `bucket` groups as well as the tests running on spark are not required to pass before merging.
+* Every travis build will upload the test results to our hellbender google bucket.  A link to the uploaded report will appear at the very bottom of the travis log.  Look for the line that says `See the test report at`.
+If TestNG itself crashes there will be no report generated.
+
 R Dependency
 ----------------
 Certain Hellbender tools may optionally generate plots if R is installed.  We recommend **R v3.1.3** if you want to produce plots.  If you are uninterested in plotting, R is still required by several of the unit tests.  Plotting is currently untested and should be viewed as a convinience rather than a primary output.  


### PR DESCRIPTION
Every travis build will upload it's test results to gs://hellbender/test/build_reports/<somepath>

The end of the build log shows the publicly accessible url for the test results.