### PR TITLE
Add a method BaseTest.getAuthenticatedPipelineOptions() useful for bucket-based unit tests

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.hellbender.utils.test;
 
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.genomics.dataflow.utils.GCSOptions;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.variant.variantcontext.Genotype;
 import htsjdk.variant.vcf.VCFConstants;
@@ -95,6 +98,20 @@ public abstract class BaseTest {
             throw new UserException("For this test, please define environment variable \""+envVarName+"\"");
         }
         return value;
+    }
+
+    /**
+     * Gets a PipelineOptions object containing our API key as specified in the HELLBENDER_TEST_APIKEY
+     * environment variable. Useful for tests that need to access data in a GCS bucket via the
+     * methods in the {@link org.broadinstitute.hellbender.utils.dataflow.BucketUtils} class,
+     * but don't need to run an actual dataflow pipeline.
+     *
+     * @return a PipelineOptions object containing our API key
+     */
+    public PipelineOptions getAuthenticatedPipelineOptions() {
+        final GCSOptions popts = PipelineOptionsFactory.as(GCSOptions.class);
+        popts.setApiKey(getDataflowTestApiKey());
+        return popts;
     }
 
     @BeforeClass

--- a/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
@@ -1,10 +1,7 @@
 package org.broadinstitute.hellbender.utils.reference;
 
-import com.google.cloud.dataflow.sdk.Pipeline;
-import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
-import com.google.cloud.genomics.dataflow.utils.GCSOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import htsjdk.samtools.SAMSequenceDictionary;
-import org.broadinstitute.hellbender.engine.dataflow.GATKTestPipeline;
 import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
@@ -58,8 +55,7 @@ public class ReferenceUtilsUnitTest extends BaseTest {
     @Test(groups = {"bucket"})
     public void testLoadFastaDictionaryFromGCSBucket() throws IOException {
         final String bucketDictionary = getDataflowTestInputPath() + "org/broadinstitute/hellbender/utils/ReferenceUtilsTest.dict";
-        final GCSOptions popts = PipelineOptionsFactory.as(GCSOptions.class);
-        popts.setApiKey(getDataflowTestApiKey());
+        final PipelineOptions popts = getAuthenticatedPipelineOptions();
 
         try ( final InputStream referenceDictionaryStream = BucketUtils.openFile(bucketDictionary, popts) ) {
             final SAMSequenceDictionary dictionary = ReferenceUtils.loadFastaDictionary(referenceDictionaryStream);


### PR DESCRIPTION
Tests that need to access data in a GCS bucket (but not run an actual pipeline)
need a PipelineOptions object containing our API key. This new method makes
it for them.