### PR TITLE
Adding a second contig to Dataflow tests.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/dataflow/DataflowUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/dataflow/DataflowUtils.java
@@ -101,6 +101,23 @@ public final class DataflowUtils {
     }
 
     /**
+     * a transform that prints the contents to standard out. This is meant for local testing.
+     */
+    public static class PrintCollection<T> extends DoFn<T, Void> {
+        private final String name;
+        public PrintCollection(String name) {
+            this.name = name;
+        }
+
+        private static final long serialVersionUID = 1L;
+        @Override
+        public void processElement(ProcessContext c) throws Exception {
+            T i = c.element();
+            System.out.println(name + ": " + i);
+        }
+    }
+
+    /**
      * ingest local bam files from the file system and loads them into a PCollection<GATKRead>
      * @param pipeline a configured Pipeline
      * @param intervals intervals to select reads from

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsPreprocessingPipelineTestData.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsPreprocessingPipelineTestData.java
@@ -22,9 +22,7 @@ import java.util.UUID;
 
 /**
  * ReadsPreprocessingPipelineTestData contains coordinated test data that can be used in the many transforms that
- * are a part of the ReadsPreprocessingPipeline. Right now, the tests are limited to a single contig. We should add
- * tests for several contigs, however, this blocked on issue #688. The issue tracking adding tests for several contigs
- * is issue tracked at (#689).
+ * are a part of the ReadsPreprocessingPipeline.
  */
 public class ReadsPreprocessingPipelineTestData {
     private final List<KV<Integer, Integer>> readStartLength;
@@ -53,21 +51,27 @@ public class ReadsPreprocessingPipelineTestData {
 
         // TODO Make reads construction more general (issue #687).
         reads = Lists.newArrayList(
-                makeRead(readStartLength.get(0), 1, clazz),
-                makeRead(readStartLength.get(1), 2, clazz),
-                makeRead(readStartLength.get(2), 3, clazz),
-                makeRead(readStartLength.get(3), 4, clazz));
+                makeRead("1", readStartLength.get(0), 1, clazz),
+                makeRead("1", readStartLength.get(1), 2, clazz),
+                makeRead("1", readStartLength.get(2), 3, clazz),
+                makeRead("1", readStartLength.get(3), 4, clazz),
+                makeRead("2", readStartLength.get(2), 5, clazz)
+                );
 
         kvRefShardiReads =  Arrays.asList(
                 KV.of(new ReferenceShard(0, "1"), Lists.newArrayList(reads.get(1), reads.get(0))),
                 KV.of(new ReferenceShard(10, "1"), Lists.newArrayList(reads.get(2))),
-                KV.of(new ReferenceShard(29, "1"), Lists.newArrayList(reads.get(3))));
+                KV.of(new ReferenceShard(29, "1"), Lists.newArrayList(reads.get(3))),
+                KV.of(new ReferenceShard(10, "2"), Lists.newArrayList(reads.get(4)))
+                );
 
         readIntervals = Lists.newArrayList(
-                makeInterval(readStartLength.get(0)),
-                makeInterval(readStartLength.get(1)),
-                makeInterval(readStartLength.get(2)),
-                makeInterval(readStartLength.get(3)));
+                makeInterval("1", readStartLength.get(0)),
+                makeInterval("1", readStartLength.get(1)),
+                makeInterval("1", readStartLength.get(2)),
+                makeInterval("1", readStartLength.get(3)),
+                makeInterval("2", readStartLength.get(2))
+                );
 
         // The first two reads are mapped onto the same reference shard. The ReferenceBases returned should
         // be from the start of the first read [rStartLength.get(0).getKey()] to the end
@@ -81,59 +85,70 @@ public class ReadsPreprocessingPipelineTestData {
         kvRefBasesiReads = Arrays.asList(
                 KV.of(FakeReferenceSource.bases(spannedReadInterval), Lists.newArrayList(reads.get(1), reads.get(0))),
                 KV.of(FakeReferenceSource.bases(readIntervals.get(2)), Lists.newArrayList(reads.get(2))),
-                KV.of(FakeReferenceSource.bases(readIntervals.get(3)), Lists.newArrayList(reads.get(3))));
+                KV.of(FakeReferenceSource.bases(readIntervals.get(3)), Lists.newArrayList(reads.get(3))),
+                KV.of(FakeReferenceSource.bases(readIntervals.get(4)), Lists.newArrayList(reads.get(4)))
+        );
 
         kvReadsRefBases = Arrays.asList(
-                KV.of(reads.get(0), getBases(reads.get(0).getStart(), reads.get(0).getEnd())),
-                KV.of(reads.get(1), getBases(reads.get(1).getStart(), reads.get(1).getEnd())),
-                KV.of(reads.get(2), getBases(reads.get(2).getStart(), reads.get(2).getEnd())),
-                KV.of(reads.get(3), getBases(reads.get(3).getStart(), reads.get(3).getEnd()))
+                KV.of(reads.get(0), getBases("1", reads.get(0).getStart(), reads.get(0).getEnd())),
+                KV.of(reads.get(1), getBases("1", reads.get(1).getStart(), reads.get(1).getEnd())),
+                KV.of(reads.get(2), getBases("1", reads.get(2).getStart(), reads.get(2).getEnd())),
+                KV.of(reads.get(3), getBases("1", reads.get(3).getStart(), reads.get(3).getEnd())),
+                KV.of(reads.get(4), getBases("2", reads.get(4).getStart(), reads.get(4).getEnd()))
         );
 
         variants = Lists.newArrayList(
                 new SkeletonVariant(new SimpleInterval("1", 170, 180), true, false, new UUID(1001, 1001)),
                 new SkeletonVariant(new SimpleInterval("1", 210, 220), false, true, new UUID(1002, 1002)),
                 new SkeletonVariant(new SimpleInterval("1", 1000000, 1000000), true, false, new UUID(1003, 1003)),
-                new SkeletonVariant(new SimpleInterval("1", 2999998, 3000002), false, true, new UUID(1004, 1004))
+                new SkeletonVariant(new SimpleInterval("1", 2999998, 3000002), false, true, new UUID(1004, 1004)),
+                new SkeletonVariant(new SimpleInterval("2", 1000000, 1000000), false, true, new UUID(1005, 1005))
         );
 
         kvVariantShardRead = Arrays.asList(
                 KV.of(new VariantShard(0, "1"), reads.get(0)),
                 KV.of(new VariantShard(0, "1"), reads.get(1)),
                 KV.of(new VariantShard(10, "1"), reads.get(2)),
-                KV.of(new VariantShard(29, "1"), reads.get(3)),    // The last read spans
-                KV.of(new VariantShard(30, "1"), reads.get(3)));   // two shards.
+                KV.of(new VariantShard(29, "1"), reads.get(3)),     // The second to last read spans
+                KV.of(new VariantShard(30, "1"), reads.get(3)),     // two shards.
+                KV.of(new VariantShard(10, "2"), reads.get(4))
+        );
 
         kvVariantShardVariant = Arrays.asList(
                 KV.of(new VariantShard(0, "1"), variants.get(0)),
                 KV.of(new VariantShard(0, "1"), variants.get(1)),
                 KV.of(new VariantShard(10, "1"), variants.get(2)),
-                KV.of(new VariantShard(29, "1"), variants.get(3)),    // The last variant spans
-                KV.of(new VariantShard(30, "1"), variants.get(3)));   // two shards.
-
+                KV.of(new VariantShard(29, "1"), variants.get(3)),      // The second to last variant spans
+                KV.of(new VariantShard(30, "1"), variants.get(3)),       // two shards.
+                KV.of(new VariantShard(10, "2"), variants.get(4))
+        );
         kvReadVariant = Arrays.asList(
                 KV.of(reads.get(1), variants.get(0)),
                 KV.of(reads.get(1), variants.get(1)),
                 KV.of(reads.get(2), variants.get(2)),
                 KV.of(reads.get(3), variants.get(3)),    // The read and variant span two variant shards, that's
-                KV.of(reads.get(3), variants.get(3))     // why there are two of them (2,3).
+                KV.of(reads.get(3), variants.get(3)),     // why there are two of them (2,3).
+                KV.of(reads.get(4), variants.get(4))
         );
 
         Iterable<Variant> variant10 = Lists.newArrayList(kvReadVariant.get(1).getValue(), kvReadVariant.get(0).getValue());
         Iterable<Variant> variant2 = Lists.newArrayList(kvReadVariant.get(2).getValue());
         Iterable<Variant> variant3 = Lists.newArrayList(kvReadVariant.get(3).getValue());
+        Iterable<Variant> variant4 = Lists.newArrayList(kvReadVariant.get(5).getValue());
 
         kvReadiVariant = Arrays.asList(
                 KV.of(kvReadVariant.get(0).getKey(), variant10),
                 KV.of(kvReadVariant.get(2).getKey(), variant2),
-                KV.of(kvReadVariant.get(3).getKey(), variant3)
+                KV.of(kvReadVariant.get(3).getKey(), variant3),
+                KV.of(kvReadVariant.get(5).getKey(), variant4)
         );
 
         kvReadContextData = Arrays.asList(
                 KV.of(kvReadsRefBases.get(0).getKey(), new ReadContextData(kvReadsRefBases.get(0).getValue(), Lists.newArrayList())),
                 KV.of(kvReadsRefBases.get(1).getKey(), new ReadContextData(kvReadsRefBases.get(1).getValue(), kvReadiVariant.get(0).getValue())),
                 KV.of(kvReadsRefBases.get(2).getKey(), new ReadContextData(kvReadsRefBases.get(2).getValue(), kvReadiVariant.get(1).getValue())),
-                KV.of(kvReadsRefBases.get(3).getKey(), new ReadContextData(kvReadsRefBases.get(3).getValue(), kvReadiVariant.get(2).getValue()))
+                KV.of(kvReadsRefBases.get(3).getKey(), new ReadContextData(kvReadsRefBases.get(3).getValue(), kvReadiVariant.get(2).getValue())),
+                KV.of(kvReadsRefBases.get(4).getKey(), new ReadContextData(kvReadsRefBases.get(4).getValue(), kvReadiVariant.get(3).getValue()))
         );
     }
 
@@ -144,8 +159,8 @@ public class ReadsPreprocessingPipelineTestData {
      * @param clazz either Google model Read or SAMRecord
      * @return a new GAKTRead with either a Google model backed or SAMRecord backed read.
      */
-    public static GATKRead makeRead(KV<Integer, Integer> startLength, int i, Class<?> clazz) {
-        return makeRead(startLength.getKey(), startLength.getValue(), i, clazz);
+    public static GATKRead makeRead(String contig, KV<Integer, Integer> startLength, int i, Class<?> clazz) {
+        return makeRead(contig, startLength.getKey(), startLength.getValue(),i, clazz);
     }
 
     /**
@@ -156,22 +171,22 @@ public class ReadsPreprocessingPipelineTestData {
      * @param clazz either Google model Read or SAMRecord
      * @return a new GAKTRead with either a Google model backed or SAMRecord backed read.
      */
-    public static GATKRead makeRead(int start, int length, int i, Class<?> clazz) {
+    public static GATKRead makeRead(String contig, int start, int length, int i, Class<?> clazz) {
         if (clazz == Read.class) {
-            return ArtificialReadUtils.createGoogleBackedReadWithUUID(new UUID(0, i), Integer.toString(i), start, length);
+            return ArtificialReadUtils.createGoogleBackedReadWithUUID(new UUID(0, i), Integer.toString(i), contig, start, length);
         } else if (clazz == SAMRecord.class) {
-            return ArtificialReadUtils.createSamBackedReadWithUUID(new UUID(0, i), Integer.toString(i), start, length);
+            return ArtificialReadUtils.createSamBackedReadWithUUID(new UUID(0, i), Integer.toString(i), contig, start, length);
         } else {
             throw new GATKException("invalid GATKRead type");
         }
     }
 
-    private SimpleInterval makeInterval(KV<Integer, Integer> startLength) {
-        return new SimpleInterval("1", startLength.getKey(), startLength.getKey() + startLength.getValue() - 1);
+    private SimpleInterval makeInterval(String contig, KV<Integer, Integer> startLength) {
+        return new SimpleInterval(contig, startLength.getKey(), startLength.getKey() + startLength.getValue() - 1);
     }
 
-    private ReferenceBases getBases(int start, int end) {
-        return FakeReferenceSource.bases(new SimpleInterval("1", start, end));
+    private ReferenceBases getBases(String contig, int start, int end) {
+        return FakeReferenceSource.bases(new SimpleInterval(contig, start, end));
     }
 
     public final List<KV<Integer, Integer>> getReadStartLength() {

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/datasources/ReferenceShardUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/datasources/ReferenceShardUnitTest.java
@@ -20,9 +20,9 @@ public final class ReferenceShardUnitTest extends BaseTest {
     @DataProvider(name = "reads")
     public Object[][] reads() {
         return new Object[][]{
-                {ReadsPreprocessingPipelineTestData.makeRead(1, 300, 1, Read.class), new ReferenceShard(0,"1")},  //right in the middle of the shard
-                {ReadsPreprocessingPipelineTestData.makeRead(ReferenceShard.REFERENCE_SHARD_SIZE, 10, 2, Read.class), new ReferenceShard(1, "1")}, //at  the start of a shard
-                {ReadsPreprocessingPipelineTestData.makeRead(3 * ReferenceShard.REFERENCE_SHARD_SIZE - 1, 2, 3, Read.class),  new ReferenceShard(2, "1")}  //overlapping the end of a shard
+                {ReadsPreprocessingPipelineTestData.makeRead("1", 1, 300, 1, Read.class), new ReferenceShard(0,"1")},  //right in the middle of the shard
+                {ReadsPreprocessingPipelineTestData.makeRead("1", ReferenceShard.REFERENCE_SHARD_SIZE, 10, 2, Read.class), new ReferenceShard(1, "1")}, //at  the start of a shard
+                {ReadsPreprocessingPipelineTestData.makeRead("1", 3 * ReferenceShard.REFERENCE_SHARD_SIZE - 1, 2, 3, Read.class),  new ReferenceShard(2, "1")}  //overlapping the end of a shard
         };
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/datasources/VariantShardUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/datasources/VariantShardUnitTest.java
@@ -16,11 +16,11 @@ public final class VariantShardUnitTest extends BaseTest {
     @DataProvider(name = "variantShards")
     public Object[][] reads() {
         return new Object[][]{
-                {ReadsPreprocessingPipelineTestData.makeRead(1, 300, 1, Read.class),
+                {ReadsPreprocessingPipelineTestData.makeRead("1", 1, 300, 1, Read.class),
                         Arrays.asList(new VariantShard(0, "1"))},  //right in the middle of the shard
-                {ReadsPreprocessingPipelineTestData.makeRead(VariantShard.VARIANT_SHARDSIZE, 10, 2, Read.class),
+                {ReadsPreprocessingPipelineTestData.makeRead("1", VariantShard.VARIANT_SHARDSIZE, 10, 2, Read.class),
                         Arrays.asList(new VariantShard(1, "1"))}, //at  the start of a shard
-                {ReadsPreprocessingPipelineTestData.makeRead(3 * VariantShard.VARIANT_SHARDSIZE - 1, 2, 3, Read.class),
+                {ReadsPreprocessingPipelineTestData.makeRead("1", 3 * VariantShard.VARIANT_SHARDSIZE - 1, 2, 3, Read.class),
                         Arrays.asList(new VariantShard(2, "1"), new VariantShard(3, "1"))}  // overlapping the end of a shard
         };
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/KeyReadsByUUIDUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/KeyReadsByUUIDUnitTest.java
@@ -35,7 +35,8 @@ public final class KeyReadsByUUIDUnitTest extends BaseTest {
                     KV.of(reads.get(0).getUUID(), reads.get(0)),
                     KV.of(reads.get(1).getUUID(), reads.get(1)),
                     KV.of(reads.get(2).getUUID(), reads.get(2)),
-                    KV.of(reads.get(3).getUUID(), reads.get(3))
+                    KV.of(reads.get(3).getUUID(), reads.get(3)),
+                    KV.of(reads.get(4).getUUID(), reads.get(4))
             );
             data[i] = new Object[]{reads, expected};
         }

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/RemoveDuplicateReadVariantPairsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/RemoveDuplicateReadVariantPairsUnitTest.java
@@ -21,7 +21,6 @@ import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.variant.Variant;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
 import java.util.*;
 
 public final class RemoveDuplicateReadVariantPairsUnitTest extends BaseTest {
@@ -40,24 +39,32 @@ public final class RemoveDuplicateReadVariantPairsUnitTest extends BaseTest {
                     KV.of(dupes.get(1).getKey().getUUID(), dupes.get(1).getValue().getUUID()),
                     KV.of(dupes.get(2).getKey().getUUID(), dupes.get(2).getValue().getUUID()),
                     KV.of(dupes.get(3).getKey().getUUID(), dupes.get(3).getValue().getUUID()),
-                    KV.of(dupes.get(4).getKey().getUUID(), dupes.get(4).getValue().getUUID()));
+                    KV.of(dupes.get(4).getKey().getUUID(), dupes.get(4).getValue().getUUID()),
+                    KV.of(dupes.get(5).getKey().getUUID(), dupes.get(5).getValue().getUUID())
+            );
 
             Iterable<UUID> uuids0 = Arrays.asList(dupes.get(1).getValue().getUUID(), dupes.get(0).getValue().getUUID());
             Iterable<UUID> uuids2 = Arrays.asList(dupes.get(2).getValue().getUUID());
             Iterable<UUID> uuids3 = Arrays.asList(dupes.get(3).getValue().getUUID());
+            Iterable<UUID> uuids5 = Arrays.asList(dupes.get(5).getValue().getUUID());
             List<KV<UUID, Iterable<UUID>>> kvUUIDiUUID = Arrays.asList(
                     KV.of(dupes.get(0).getKey().getUUID(), uuids0),
                     KV.of(dupes.get(2).getKey().getUUID(), uuids2),
-                    KV.of(dupes.get(3).getKey().getUUID(), uuids3)
+                    KV.of(dupes.get(3).getKey().getUUID(), uuids3),
+                    KV.of(dupes.get(5).getKey().getUUID(), uuids5)
             );
 
             Iterable<Variant> variant01 = Arrays.asList(dupes.get(1).getValue(), dupes.get(0).getValue());
             Iterable<Variant> variant2 = Arrays.asList(dupes.get(2).getValue());
             Iterable<Variant> variant3 = Arrays.asList(dupes.get(3).getValue());
+            Iterable<Variant> variant5 = Arrays.asList(dupes.get(5).getValue());
+
             List<KV<UUID, Iterable<Variant>>> kvUUIDiVariant = Arrays.asList(
                     KV.of(dupes.get(0).getKey().getUUID(), variant01),
                     KV.of(dupes.get(2).getKey().getUUID(), variant2),
-                    KV.of(dupes.get(3).getKey().getUUID(), variant3));
+                    KV.of(dupes.get(3).getKey().getUUID(), variant3),
+                    KV.of(dupes.get(5).getKey().getUUID(), variant5)
+            );
 
             List<KV<GATKRead, Iterable<Variant>>> finalExpected = testData.getKvReadiVariant();
             data[i] = new Object[]{dupes, kvUUIDUUID, kvUUIDiUUID, kvUUIDiVariant, finalExpected};
@@ -92,7 +99,6 @@ public final class RemoveDuplicateReadVariantPairsUnitTest extends BaseTest {
         PCollection<KV<GATKRead, Iterable<Variant>>> finalResult = RemoveDuplicateReadVariantPairs.RemoveReadVariantDupesUtility.addBackReads(pKVs, matchedVariants);
         PCollection<KV<GATKRead, Iterable<Variant>>> pFinalExpected = p.apply(Create.of(finalExpected)).setCoder(KvCoder.of(new GATKReadCoder(), IterableCoder.of(new VariantCoder())));
         DataflowTestUtils.keyIterableValueMatcher(finalResult, pFinalExpected);
-
         p.run();
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/KeyVariantsByReadUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/KeyVariantsByReadUnitTest.java
@@ -53,7 +53,6 @@ public final class KeyVariantsByReadUnitTest extends BaseTest {
         PCollection<Variant> pVariant = DataflowTestUtils.pCollectionCreateAndVerify(p, variantList, new VariantCoder());
 
         PCollection<KV<GATKRead, Iterable<Variant>>> result = KeyVariantsByRead.key(pVariant, pReads);
-        //DataflowAssert.that(result).containsInAnyOrder(kvReadiVariant);
         PCollection<KV<GATKRead, Iterable<Variant>>> pFinalExpected = p.apply(Create.of(kvReadiVariant)).setCoder(KvCoder.of(new GATKReadCoder(), IterableCoder.of(new VariantCoder())));
         DataflowTestUtils.keyIterableValueMatcher(result, pFinalExpected);
 


### PR DESCRIPTION
Now, we many Dataflow tests have reads, variants, and reference bases on contig "2" as well as "1". I also added a useful utility DoFn: PrintCollection.