### PR TITLE
More refactoring of Mark duplicates and pipeline hookup

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/coders/PairedEndsCoder.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/coders/PairedEndsCoder.java
@@ -1,0 +1,47 @@
+package org.broadinstitute.hellbender.engine.dataflow.coders;
+
+import com.google.cloud.dataflow.sdk.coders.Coder;
+import com.google.cloud.dataflow.sdk.coders.CoderException;
+import com.google.cloud.dataflow.sdk.coders.CustomCoder;
+import com.google.cloud.dataflow.sdk.coders.SerializableCoder;
+import org.broadinstitute.hellbender.tools.dataflow.transforms.markduplicates.PairedEnds;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Custom coder for the PairedEnds struct-like class.
+ */
+public class PairedEndsCoder extends CustomCoder<PairedEnds> {
+        private static final long serialVersionUID = 1L;
+
+    @Override
+    public void encode(PairedEnds value, OutputStream outStream, Context context) throws CoderException, IOException {
+        if ( value == null || value.first() == null ) {
+            throw new IOException("nothing to encode");
+        }
+
+        final boolean isCompletePair = value.second() != null ;
+        SerializableCoder.of(Boolean.class).encode(isCompletePair, outStream, context);
+        GATKReadCoder gatkReadCoder = new GATKReadCoder();
+
+        gatkReadCoder.encode(value.first(), outStream, context);
+        if ( isCompletePair ) {
+            gatkReadCoder.encode(value.second(), outStream, context);
+        }
+    }
+
+    @Override
+    public PairedEnds decode(InputStream inStream, Context context) throws CoderException, IOException {
+        final boolean isCompletePair = SerializableCoder.of(Boolean.class).decode(inStream, context);
+        GATKReadCoder gatkReadCoder = new GATKReadCoder();
+
+        PairedEnds pairedEnds = PairedEnds.of(gatkReadCoder.decode(inStream, context));
+        if ( isCompletePair ) {
+            pairedEnds.and(gatkReadCoder.decode(inStream, context));
+        }
+        return pairedEnds;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/MarkDuplicates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/MarkDuplicates.java
@@ -1,0 +1,58 @@
+package org.broadinstitute.hellbender.tools.dataflow.transforms.markduplicates;
+
+import com.google.cloud.dataflow.sdk.transforms.*;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.PCollectionList;
+import com.google.cloud.dataflow.sdk.values.PCollectionView;
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+/**
+ * The main transform for MarkDuplicates. Takes reads, returns reads with some reads marked as duplicates.
+ */
+public class MarkDuplicates extends PTransform<PCollection<GATKRead>, PCollection<GATKRead>> {
+    private static final long serialVersionUID = 1l;
+    
+    //private vs non-primary alignments
+    private enum ReadsPartition {
+        PRIMARY, NOT_PRIMARY
+    }
+
+    /**
+     * The header for all reads processed.
+     */
+    private final PCollectionView<SAMFileHeader> header;
+
+    public MarkDuplicates(final PCollectionView<SAMFileHeader> header) {
+        this.header = header;
+    }
+
+    @Override
+    public PCollection<GATKRead> apply(final PCollection<GATKRead> preads) {
+        final PCollectionList<GATKRead> readsPartitioned = partitionReadsByPrimaryNonPrimaryAlignment(preads);
+
+        final PCollection<GATKRead> fragments = readsPartitioned.get(ReadsPartition.PRIMARY.ordinal());
+        final PCollection<GATKRead> fragmentsTransformed = MarkDuplicatesUtils.transformFragments(header, fragments);
+
+        final PCollection<GATKRead> pairs = readsPartitioned.get(ReadsPartition.PRIMARY.ordinal());
+        final PCollection<GATKRead> pairsTransformed = MarkDuplicatesUtils.transformReads(header, pairs);
+
+        //no work on those
+        final PCollection<GATKRead> not_primary = readsPartitioned.get(ReadsPartition.NOT_PRIMARY.ordinal());
+
+        return PCollectionList.of(fragmentsTransformed).and(pairsTransformed).and(not_primary).apply(Flatten.<GATKRead>pCollections());
+    }
+
+    private static PCollectionList<GATKRead> partitionReadsByPrimaryNonPrimaryAlignment(PCollection<GATKRead> preads) {
+        return preads.apply(Partition.of(2, new Partition.PartitionFn<GATKRead>() {
+            private static final long serialVersionUID = 1l;
+
+            @Override
+            public int partitionFor(final GATKRead read, final int n) {
+                return read.isSecondaryAlignment() || read.isSupplementaryAlignment() || read.isUnmapped() ? ReadsPartition.NOT_PRIMARY.ordinal() : ReadsPartition.PRIMARY.ordinal();
+            }
+        }));
+    }
+
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/MarkDuplicatesDataflow.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/MarkDuplicatesDataflow.java
@@ -1,14 +1,9 @@
-package org.broadinstitute.hellbender.tools.dataflow;
+package org.broadinstitute.hellbender.tools.dataflow.transforms.markduplicates;
 
 import com.google.cloud.dataflow.sdk.Pipeline;
-import com.google.cloud.dataflow.sdk.coders.*;
 import com.google.cloud.dataflow.sdk.transforms.*;
-import com.google.cloud.dataflow.sdk.transforms.Partition.PartitionFn;
-import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
-import com.google.cloud.dataflow.sdk.values.PCollectionList;
 import com.google.cloud.dataflow.sdk.values.PCollectionView;
-import com.google.common.collect.*;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import org.broadinstitute.hellbender.cmdline.Argument;
@@ -19,26 +14,13 @@ import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumen
 import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalIntervalArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.DataFlowProgramGroup;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.ReadsDataflowSource;
-import org.broadinstitute.hellbender.tools.dataflow.transforms.MarkDuplicates;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.dataflow.SmallBamWriter;
 import org.broadinstitute.hellbender.engine.dataflow.DataflowCommandLineProgram;
-import org.broadinstitute.hellbender.engine.dataflow.coders.GATKReadCoder;
-import org.broadinstitute.hellbender.tools.dataflow.transforms.MarkDuplicatesReadsKey;
-import org.broadinstitute.hellbender.utils.GenomeLocSortedSet;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
-import org.broadinstitute.hellbender.utils.read.ReadUtils;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Serializable;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 
 @CommandLineProgramProperties(

--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/PairedEnds.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/PairedEnds.java
@@ -1,0 +1,48 @@
+package org.broadinstitute.hellbender.tools.dataflow.transforms.markduplicates;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadUtils;
+
+/**
+ * Struct-like class to store information about the paired reads for mark duplicates.
+ */
+public final class PairedEnds {
+    private GATKRead first, second;
+
+    PairedEnds(final GATKRead first) {
+        this.first = first;
+    }
+
+    public static PairedEnds of(final GATKRead first) {
+        return new PairedEnds(first);
+    }
+
+    public PairedEnds and(final GATKRead second) {
+        if (second != null &&
+                ReadUtils.getStrandedUnclippedStart(first) > ReadUtils.getStrandedUnclippedStart(second)) {
+
+            this.second = this.first;
+            this.first = second;
+        } else {
+            this.second = second;
+        }
+        return this;
+    }
+
+    public String key(final SAMFileHeader header) {
+        return ReadsKey.keyForPairedEnds(header, first, second);
+    }
+
+    public GATKRead first() {
+        return first;
+    }
+
+    public GATKRead second() {
+        return second;
+    }
+
+    public int score() {
+        return MarkDuplicatesUtils.score(first) + MarkDuplicatesUtils.score(second);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/ReadsKey.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/ReadsKey.java
@@ -1,4 +1,4 @@
-package org.broadinstitute.hellbender.tools.dataflow.transforms;
+package org.broadinstitute.hellbender.tools.dataflow.transforms.markduplicates;
 
 import htsjdk.samtools.SAMFileHeader;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
@@ -7,7 +7,7 @@ import org.broadinstitute.hellbender.utils.read.ReadUtils;
 /**
  * Encodes a unique key for read, read pairs and fragments. Used to identify duplicates for MarkDuplicates.
  */
-public final class MarkDuplicatesReadsKey {
+final class ReadsKey {
 
     /**
      * Makes a unique key for the fragment.

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/ReadsKeyTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/ReadsKeyTest.java
@@ -1,15 +1,14 @@
-package org.broadinstitute.hellbender.tools.dataflow;
+package org.broadinstitute.hellbender.tools.dataflow.transforms.markduplicates;
 
 
 import htsjdk.samtools.SAMFileHeader;
-import org.broadinstitute.hellbender.tools.dataflow.transforms.MarkDuplicatesReadsKey;
 import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public final class MarkDuplicatesReadsKeyTest {
+public final class ReadsKeyTest {
     @DataProvider(name = "sams")
     public Object[][] sams(){
         final SAMFileHeader header = ArtificialReadUtils.createArtificialSamHeader();
@@ -31,6 +30,6 @@ public final class MarkDuplicatesReadsKeyTest {
 
     @Test(dataProvider = "sams", groups= {"dataflow"})
     public void countBasesTest(final SAMFileHeader header, final GATKRead read, final String expectedKey){
-        final String key = MarkDuplicatesReadsKey.keyForFragment(header, read);
+        final String key = ReadsKey.keyForFragment(header, read);
         Assert.assertEquals(expectedKey, key);
     }}


### PR DESCRIPTION
I moved Mark duplicates into it's own package (instead of a single file). There is more refactoring that could be done. I might stop here for now and sync with @jean-philippe-martin on his planned changes.