### PR TITLE
Add an initial stub end-to-end integration test for the ReadsPreProcessingPipeline

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -101,6 +101,18 @@ public abstract class BaseTest {
     }
 
     /**
+     * @return an arguments List containing the apiKey, project, and staging arguments
+     *         populated from environment variables as defined in {@link #getDataflowTestApiKey},
+     *         {@link #getDataflowTestProject}, and {@link #getDataflowTestStaging}, suitable
+     *         for use in a hellbender command line.
+     */
+    public List<String> getStandardDataflowArgumentsFromEnvironment() {
+        return Arrays.asList("--apiKey", getDataflowTestApiKey(),
+                             "--project", getDataflowTestProject(),
+                             "--staging", getDataflowTestStaging());
+    }
+
+    /**
      * Gets a PipelineOptions object containing our API key as specified in the HELLBENDER_TEST_APIKEY
      * environment variable. Useful for tests that need to access data in a GCS bucket via the
      * methods in the {@link org.broadinstitute.hellbender.utils.dataflow.BucketUtils} class,

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ReadsPreprocessingPipelineIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ReadsPreprocessingPipelineIntegrationTest.java
@@ -1,0 +1,45 @@
+package org.broadinstitute.hellbender.tools.dataflow.pipelines;
+
+
+import org.broadinstitute.hellbender.CommandLineProgramTest;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.tools.IntegrationTestSpec;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ReadsPreprocessingPipelineIntegrationTest extends CommandLineProgramTest {
+
+    @DataProvider(name = "EndToEndTestData")
+    public Object[][] getEndToEndTestData() {
+        final String testDir = publicTestDir + "org/broadinstitute/hellbender/engine/";
+
+        return new Object[][] {
+                // This test case checks that the input and output bams are equal (which should be the case with stub tool implementations)
+                { testDir + "reads_data_source_test1.bam", "EOSt9JOVhp3jkwE", testDir + "feature_data_source_test.vcf", new File(testDir + "reads_data_source_test1.bam") }
+        };
+    }
+
+    @Test(dataProvider = "EndToEndTestData", groups = {"cloud"})
+    public void testPipelineEndToEnd( final String inputBam, final String reference, final String knownSites, final File expectedOutput ) throws IOException {
+        final File output = createTempFile("testPipelineEndToEnd_output", ".bam");
+        List<String> argv = new ArrayList<>();
+
+        argv.addAll(Arrays.asList("-" + StandardArgumentDefinitions.INPUT_SHORT_NAME, inputBam,
+                                  "-" + StandardArgumentDefinitions.REFERENCE_SHORT_NAME, reference,
+                                  "-BQSRKnownVariants", knownSites,
+                                  "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, output.getAbsolutePath()));
+        argv.addAll(getStandardDataflowArgumentsFromEnvironment());
+
+        // Note: could use IntegrationTestSpec if we expand it a bit
+        runCommandLine(argv);
+
+        IntegrationTestSpec.assertEqualBamFiles(output, expectedOutput);
+    }
+}


### PR DESCRIPTION
Just checks that the input and output bams are equal (which is still the
case for a bam with no duplicates). Once BQSR is hooked up we'll have
to update the expected output for this test.

This is intended as a starting point for the more meaningful tests we
eventually want to have.