### PR TITLE
Allow clients to request additional bases of reference context in AddContextDataToRead by passing in a function

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/RefAPIMetadata.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/RefAPIMetadata.java
@@ -1,5 +1,9 @@
 package org.broadinstitute.hellbender.engine.dataflow.datasources;
 
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
@@ -11,13 +15,28 @@ import java.util.Map;
 public class RefAPIMetadata implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * @param referenceName name of the reference
+     * @param referenceNameToIdTable table from reference name to id
+     */
     public RefAPIMetadata(String referenceName, Map<String, String> referenceNameToIdTable) {
+        this(referenceName, referenceNameToIdTable, RefWindowFunctions.IDENTITY_FUNCTION);
+    }
+
+    /**
+     * @param referenceName name of the reference
+     * @param referenceNameToIdTable table from reference name to id
+     * @param referenceWindowFunction custom reference window function used to map reads to desired reference bases
+     */
+    public RefAPIMetadata(String referenceName, Map<String, String> referenceNameToIdTable, SerializableFunction<GATKRead, SimpleInterval> referenceWindowFunction) {
         this.referenceName = referenceName;
         this.referenceNameToIdTable = Collections.unmodifiableMap(referenceNameToIdTable);
+        this.referenceWindowFunction = referenceWindowFunction;
     }
 
     private final String referenceName;
     private final Map<String, String> referenceNameToIdTable;
+    private final SerializableFunction<GATKRead, SimpleInterval> referenceWindowFunction;
 
     public String getReferenceName() {
         return referenceName;
@@ -25,5 +44,9 @@ public class RefAPIMetadata implements Serializable {
 
     public Map<String, String> getReferenceNameToIdTable() {
         return referenceNameToIdTable;
+    }
+
+    public SerializableFunction<GATKRead, SimpleInterval> getReferenceWindowFunction() {
+        return referenceWindowFunction;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/RefWindowFunctions.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/RefWindowFunctions.java
@@ -1,0 +1,47 @@
+package org.broadinstitute.hellbender.engine.dataflow.datasources;
+
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.engine.dataflow.transforms.composite.AddContextDataToRead;
+
+/**
+ * A library of reference window functions suitable for passing in to transforms such as {@link AddContextDataToRead}.
+ * These are functions from {@link GATKRead} to {@link SimpleInterval}, with the output interval representing
+ * the bases of reference context that should be retrieved for the input read.
+ */
+public class RefWindowFunctions {
+
+    /**
+     * A function for requesting only reference bases that directly overlap each read
+     */
+    public static final SerializableFunction<GATKRead, SimpleInterval> IDENTITY_FUNCTION = read -> new SimpleInterval(read);
+
+    /**
+     * A function for requesting a fixed number of extra bases of reference context on either side
+     * of each read. For example, a "new FixedWindowFunction(3, 5)" would request 3 extra reference bases
+     * before each read and 5 extra bases after each read, in addition to the reference bases spanning
+     * each read.
+     */
+    public static final class FixedWindowFunction implements SerializableFunction<GATKRead, SimpleInterval> {
+        private static final long serialVersionUID = 1L;
+
+        private final int leadingWindowBases;
+        private final int trailingWindowBases;
+
+        /**
+         * @param leadingWindowBases number of bases of additional reference context to request before each read's start position
+         * @param trailingWindowBases number of bases of additional reference context to request after each read's end position
+         */
+        public FixedWindowFunction( final int leadingWindowBases, final int trailingWindowBases ) {
+            this.leadingWindowBases = leadingWindowBases;
+            this.trailingWindowBases = trailingWindowBases;
+        }
+
+        @Override
+        public SimpleInterval apply( GATKRead read ) {
+            // TODO: truncate interval at contig end (requires a sequence dictionary)
+            return new SimpleInterval(read.getContig(), Math.max(read.getStart() - leadingWindowBases, 1), read.getEnd() + trailingWindowBases);
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/AddContextDataToRead.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/AddContextDataToRead.java
@@ -9,7 +9,7 @@ import com.google.common.collect.Lists;
 import org.broadinstitute.hellbender.dev.DoFnWLog;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.ReadContextData;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.RefAPIMetadata;
-import org.broadinstitute.hellbender.engine.dataflow.datasources.RefAPISource;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.VariantsDataflowSource;
 import org.broadinstitute.hellbender.engine.dataflow.transforms.KeyReadsByUUID;
 import org.broadinstitute.hellbender.exceptions.GATKException;
@@ -26,15 +26,18 @@ import java.util.UUID;
  * The variants are obtained from a local file (later a GCS Bucket). The reference bases come from the Google Genomics API.
  *
  * This transform is intended for direct use in pipelines.
+ *
+ * The reference bases paired with each read can be customized by passing in a reference window function
+ * inside the {@link RefAPIMetadata} argument to {@link #add}. See {@link RefWindowFunctions} for examples.
  */
 public class AddContextDataToRead {
+
     public static PCollection<KV<GATKRead, ReadContextData>> add(PCollection<GATKRead> pReads, RefAPIMetadata refAPIMetadata, VariantsDataflowSource variantsDataflowSource) {
         PCollection<Variant> pVariants = variantsDataflowSource.getAllVariants();
         PCollection<KV<GATKRead, Iterable<Variant>>> kvReadVariants = KeyVariantsByRead.key(pVariants, pReads);
         PCollection<KV<GATKRead, ReferenceBases>> kvReadRefBases =
                 RefBasesForReads.addBases(pReads, refAPIMetadata);
         return join(pReads, kvReadRefBases, kvReadVariants);
-
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ReadsPreprocessingPipeline.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ReadsPreprocessingPipeline.java
@@ -17,6 +17,7 @@ import org.broadinstitute.hellbender.cmdline.argumentcollections.OpticalDuplicat
 import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalIntervalArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.DataFlowProgramGroup;
 import org.broadinstitute.hellbender.dev.DoFnWLog;
+import org.broadinstitute.hellbender.dev.tools.walkers.bqsr.BaseRecalibratorDataflow;
 import org.broadinstitute.hellbender.engine.dataflow.*;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.*;
 import org.broadinstitute.hellbender.engine.dataflow.transforms.composite.AddContextDataToRead;
@@ -96,7 +97,8 @@ public class ReadsPreprocessingPipeline extends DataflowCommandLineProgram {
         final VariantsDataflowSource variantsDataflowSource = new VariantsDataflowSource(baseRecalibrationKnownVariants, pipeline);
 
         Map<String, String> referenceNameToIdTable = RefAPISource.buildReferenceNameToIdTable(pipeline.getOptions(), referenceName);
-        RefAPIMetadata refAPIMetadata = new RefAPIMetadata(referenceName, referenceNameToIdTable);
+        // Use the BQSR_REFERENCE_WINDOW_FUNCTION so that the reference bases required by BQSR for each read are fetched
+        RefAPIMetadata refAPIMetadata = new RefAPIMetadata(referenceName, referenceNameToIdTable, BaseRecalibratorDataflow.BQSR_REFERENCE_WINDOW_FUNCTION);
 
         final PCollection<KV<GATKRead, ReadContextData>> readsWithContext = AddContextDataToRead.add(markedReads, refAPIMetadata, variantsDataflowSource);
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/KeyReadsByRefShardUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/KeyReadsByRefShardUnitTest.java
@@ -5,6 +5,7 @@ import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.coders.IterableCoder;
 import com.google.cloud.dataflow.sdk.coders.KvCoder;
 import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import htsjdk.samtools.SAMRecord;
@@ -12,15 +13,16 @@ import org.broadinstitute.hellbender.engine.dataflow.DataflowTestUtils;
 import org.broadinstitute.hellbender.engine.dataflow.GATKTestPipeline;
 import org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData;
 import org.broadinstitute.hellbender.engine.dataflow.coders.GATKReadCoder;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceShard;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.DataflowUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 public final class KeyReadsByRefShardUnitTest extends BaseTest {
 
@@ -50,6 +52,65 @@ public final class KeyReadsByRefShardUnitTest extends BaseTest {
 
         PCollection<KV<ReferenceShard, Iterable<GATKRead>>> pFinalExpected = p.apply(Create.of(expectedResult).withCoder(KvCoder.of(ReferenceShard.CODER, IterableCoder.of(new GATKReadCoder()))));
         DataflowTestUtils.keyIterableValueMatcher(grouped, pFinalExpected);
+
+        p.run();
+    }
+
+    @DataProvider(name = "KeyReadsByRefShardWithCustomWindowFunctionTestData")
+    public Object[][] keyReadsByRefShardWithCustomWindowFunctionTestData() {
+        final List<GATKRead> samReads = ReadsPreprocessingPipelineTestData.makeReferenceShardBoundaryReads(2, 3, SAMRecord.class);
+        final List<GATKRead> googleReads = ReadsPreprocessingPipelineTestData.makeReferenceShardBoundaryReads(2, 3, Read.class);
+
+        return new Object[][] {
+                // Test case layout: reads, reference window function to apply, expected shard + reads pairs
+
+                // Identity function, SAM reads
+                { samReads, RefWindowFunctions.IDENTITY_FUNCTION, generateExpectedCustomWindowResult(samReads, 0, 0) },
+                // Identity function, google reads
+                { googleReads, RefWindowFunctions.IDENTITY_FUNCTION, generateExpectedCustomWindowResult(googleReads, 0, 0) },
+                // Expand reads by 1 base on each side, SAM reads
+                { samReads, new RefWindowFunctions.FixedWindowFunction(1, 1), generateExpectedCustomWindowResult(samReads, 1, 1) },
+                // Expand reads by 1 base on each side, google reads
+                { googleReads, new RefWindowFunctions.FixedWindowFunction(1, 1), generateExpectedCustomWindowResult(googleReads, 1, 1) },
+                // Expand reads by 3 bases on the left and 5 bases on the right, SAM reads
+                { samReads, new RefWindowFunctions.FixedWindowFunction(3, 5), generateExpectedCustomWindowResult(samReads, 3, 5) },
+                // Expand reads by 3 bases on the left and 5 bases on the right, google reads
+                { googleReads, new RefWindowFunctions.FixedWindowFunction(3, 5), generateExpectedCustomWindowResult(googleReads, 3, 5) },
+        };
+    }
+
+    private List<KV<ReferenceShard, Iterable<GATKRead>>> generateExpectedCustomWindowResult( final List<GATKRead> reads, final int windowLeadingBases, final int windowTrailingBases ) {
+        final Map<ReferenceShard, List<GATKRead>> shardMap = new HashMap<>();
+
+        for ( final GATKRead read : reads ) {
+            final SimpleInterval expandedReadInterval = new SimpleInterval(read.getContig(), Math.max(read.getStart() - windowLeadingBases, 1), read.getEnd() + windowTrailingBases);
+            final ReferenceShard readShard = ReferenceShard.getShardNumberFromInterval(expandedReadInterval);
+
+            if ( shardMap.containsKey(readShard) ) {
+                shardMap.get(readShard).add(read);
+            }
+            else {
+                shardMap.put(readShard, new ArrayList<>(Arrays.asList(read)));
+            }
+        }
+
+        List<KV<ReferenceShard, Iterable<GATKRead>>> expectedResult = new ArrayList<>();
+        for ( Map.Entry<ReferenceShard, List<GATKRead>> entry : shardMap.entrySet() ) {
+            expectedResult.add(KV.of(entry.getKey(), entry.getValue()));
+        }
+        return expectedResult;
+    }
+
+    @Test(dataProvider = "KeyReadsByRefShardWithCustomWindowFunctionTestData")
+    public void testKeyReadsByRefShardWithCustomWindowFunction(final List<GATKRead> reads, final SerializableFunction<GATKRead, SimpleInterval> referenceWindowFunction, final List<KV<ReferenceShard, Iterable<GATKRead>>> expectedResult ) {
+        Pipeline p = GATKTestPipeline.create();
+        DataflowUtils.registerGATKCoders(p);
+
+        PCollection<GATKRead> pReads = DataflowTestUtils.pCollectionCreateAndVerify(p, reads, new GATKReadCoder());
+        PCollection<KV<ReferenceShard, Iterable<GATKRead>>> shardedReads = pReads.apply(new KeyReadsByRefShard(referenceWindowFunction));
+
+        PCollection<KV<ReferenceShard, Iterable<GATKRead>>> pExpected = p.apply(Create.of(expectedResult).withCoder(KvCoder.of(ReferenceShard.CODER, IterableCoder.of(new GATKReadCoder()))));
+        DataflowTestUtils.keyIterableValueMatcher(shardedReads, pExpected);
 
         p.run();
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/PairReadsWithRefBasesUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/PairReadsWithRefBasesUnitTest.java
@@ -4,6 +4,7 @@ import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.coders.*;
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
 import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.api.services.genomics.model.Read;
@@ -11,14 +12,20 @@ import htsjdk.samtools.SAMRecord;
 import org.broadinstitute.hellbender.engine.dataflow.GATKTestPipeline;
 import org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData;
 import org.broadinstitute.hellbender.engine.dataflow.coders.GATKReadCoder;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.DataflowUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
-
 import org.broadinstitute.hellbender.utils.test.BaseTest;
+
+import static org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData.makeRead;
+
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -54,4 +61,54 @@ public final class PairReadsWithRefBasesUnitTest extends BaseTest {
         p.run();
     }
 
+    @DataProvider(name = "PairReadsWithRefBasesWithCustomWindowFunctionTestData")
+    public Object[][] pairReadsWithRefBasesWithCustomWindowFunctionTestData() {
+        // Using this made-up sequence as our reference for these tests.
+        final byte[] bases = "AGCCTTTCGAACTGAGCCCGTTCCTGGGGTTATACCCGGCTTTTGGCGCT".getBytes();
+        final ReferenceBases refBases = new ReferenceBases(bases, new SimpleInterval("1", 1, 50));
+
+        final List<Object[]> testCases = new ArrayList<>();
+        for ( final Class<?> readImplementation : Arrays.asList(SAMRecord.class, Read.class) ) {
+            // Test case layout: Ref bases + read, reference window function to apply, expected ref bases for read, expected ref interval for read
+
+            // Read at start of contig, identity function
+            testCases.add(new Object[]{ KV.of(refBases, Arrays.asList(makeRead("1", 1, 10, 0, readImplementation))), RefWindowFunctions.IDENTITY_FUNCTION, "AGCCTTTCGA".getBytes(), new SimpleInterval("1", 1, 10) });
+            // Read at start of contig, expand by 1 base on each side (goes off contig bounds)
+            testCases.add(new Object[]{ KV.of(refBases, Arrays.asList(makeRead("1", 1, 10, 0, readImplementation))), new RefWindowFunctions.FixedWindowFunction(1, 1), "AGCCTTTCGAA".getBytes(), new SimpleInterval("1", 1, 11) });
+            // Read at start of contig, expand by 3 bases on the left and 5 bases on the right (goes off contig bounds)
+            testCases.add(new Object[]{ KV.of(refBases, Arrays.asList(makeRead("1", 1, 10, 0, readImplementation))), new RefWindowFunctions.FixedWindowFunction(3, 5), "AGCCTTTCGAACTGA".getBytes(), new SimpleInterval("1", 1, 15) });
+            // Read in middle of contig, identity function
+            testCases.add(new Object[]{ KV.of(refBases, Arrays.asList(makeRead("1", 20, 11, 0, readImplementation))), RefWindowFunctions.IDENTITY_FUNCTION, "GTTCCTGGGGT".getBytes(), new SimpleInterval("1", 20, 30) });
+            // Read in middle of contig, expand by 1 base on each side
+            testCases.add(new Object[]{ KV.of(refBases, Arrays.asList(makeRead("1", 20, 11, 0, readImplementation))), new RefWindowFunctions.FixedWindowFunction(1, 1), "CGTTCCTGGGGTT".getBytes(), new SimpleInterval("1", 19, 31) });
+            // Read in middle of contig, expand by 3 bases on the left and 5 bases on the right
+            testCases.add(new Object[]{ KV.of(refBases, Arrays.asList(makeRead("1", 20, 11, 0, readImplementation))), new RefWindowFunctions.FixedWindowFunction(3, 5), "CCCGTTCCTGGGGTTATAC".getBytes(), new SimpleInterval("1", 17, 35) });
+            // Read in middle of contig, expand by 30 bases on the left and 10 bases on the right (goes off contig bounds)
+            testCases.add(new Object[]{ KV.of(refBases, Arrays.asList(makeRead("1", 20, 11, 0, readImplementation))), new RefWindowFunctions.FixedWindowFunction(30, 10), "AGCCTTTCGAACTGAGCCCGTTCCTGGGGTTATACCCGGC".getBytes(), new SimpleInterval("1", 1, 40) });
+        }
+        return testCases.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "PairReadsWithRefBasesWithCustomWindowFunctionTestData")
+    public void testPairReadsWithRefBasesWithCustomWindowFunction( final KV<ReferenceBases, Iterable<GATKRead>> input, final SerializableFunction<GATKRead, SimpleInterval> referenceWindowFunction, final byte[] expectedBases, final SimpleInterval expectedInterval ) {
+        Pipeline p = GATKTestPipeline.create();
+        DataflowUtils.registerGATKCoders(p);
+
+        PCollection<KV<ReferenceBases, Iterable<GATKRead>>> pInput = p.apply(Create.of(input)
+                .withCoder(KvCoder.of(SerializableCoder.of(ReferenceBases.class), IterableCoder.of(new GATKReadCoder()))));
+
+        PCollection<KV<GATKRead, ReferenceBases>> result = pInput.apply(new PairReadWithRefBases(referenceWindowFunction));
+
+        DataflowAssert.that(result).satisfies((Iterable<KV<GATKRead, ReferenceBases>> resultElements) -> {
+            for ( KV<GATKRead, ReferenceBases> kvPair : resultElements ) {
+                Assert.assertNotNull(kvPair.getKey(), "Null read in transform result");
+                Assert.assertNotNull(kvPair.getValue(), "Null ReferenceBases object paired with read");
+                Assert.assertEquals(kvPair.getValue().getBases(), expectedBases, "Wrong bases in ReferenceBases object paired with read");
+                Assert.assertEquals(kvPair.getValue().getInterval(), expectedInterval, "Wrong interval in ReferenceBases object paired with read");
+            }
+            return null;
+        });
+
+        p.run();
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/RefBasesFromAPIUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/RefBasesFromAPIUnitTest.java
@@ -6,7 +6,9 @@ import com.google.cloud.dataflow.sdk.coders.IterableCoder;
 import com.google.cloud.dataflow.sdk.coders.KvCoder;
 import com.google.cloud.dataflow.sdk.coders.SerializableCoder;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
 import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.common.collect.Lists;
@@ -18,6 +20,7 @@ import org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineT
 import org.broadinstitute.hellbender.engine.dataflow.coders.GATKReadCoder;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.RefAPIMetadata;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.RefAPISource;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceShard;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.DataflowUtils;
@@ -25,9 +28,11 @@ import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.FakeReferenceSource;
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +42,14 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 public final class RefBasesFromAPIUnitTest extends BaseTest {
+
+    private RefAPISource createMockRefAPISource( final List<SimpleInterval> intervals ) {
+        RefAPISource mockSource = mock(RefAPISource.class, withSettings().serializable());
+        for (SimpleInterval interval : intervals) {
+            when(mockSource.getReferenceBases(any(PipelineOptions.class), any(RefAPIMetadata.class), eq(interval))).thenReturn(FakeReferenceSource.bases(interval));
+        }
+        return mockSource;
+    }
 
     @DataProvider(name = "bases")
     public Object[][] bases(){
@@ -59,17 +72,8 @@ public final class RefBasesFromAPIUnitTest extends BaseTest {
         Pipeline p = GATKTestPipeline.create();
         DataflowUtils.registerGATKCoders(p);
 
-        // Set up the mock for RefAPISource;
-        RefAPISource mockSource = mock(RefAPISource.class, withSettings().serializable());
-        for (SimpleInterval interval : intervals) {
-            when(mockSource.getReferenceBases(any(PipelineOptions.class), any(RefAPIMetadata.class), eq(interval))).thenReturn(FakeReferenceSource.bases(interval));
-        }
-
-        String referenceName = "refName";
-        String refId = "0xbjfjd23f";
-        Map<String, String> referenceNameToIdTable = Maps.newHashMap();
-        referenceNameToIdTable.put(referenceName, refId);
-        RefAPIMetadata refAPIMetadata = new RefAPIMetadata(referenceName, referenceNameToIdTable);
+        final RefAPISource mockSource = createMockRefAPISource(intervals);
+        final RefAPIMetadata refAPIMetadata = ReadsPreprocessingPipelineTestData.createRefAPIMetadata();
 
         PCollection<KV<ReferenceShard, Iterable<GATKRead>>> pInput = p.apply("pInput.Create",Create.of(kvRefShardiReads).withCoder(KvCoder.of(ReferenceShard.CODER, IterableCoder.of(new GATKReadCoder()))));
 
@@ -80,24 +84,15 @@ public final class RefBasesFromAPIUnitTest extends BaseTest {
 
         p.run();
     }
+
     @Test(dataProvider = "bases")
     public void noReadsTest(List<KV<ReferenceShard, Iterable<GATKRead>>> kvRefShardiReads,
                              List<SimpleInterval> intervals, List<KV<ReferenceBases, Iterable<GATKRead>>> kvRefBasesiReads) {
         Pipeline p = GATKTestPipeline.create();
         DataflowUtils.registerGATKCoders(p);
 
-        // Set up the mock for RefAPISource;
-        RefAPISource mockSource = mock(RefAPISource.class, withSettings().serializable());
-        for (SimpleInterval interval : intervals) {
-            when(mockSource.getReferenceBases(any(PipelineOptions.class), any(RefAPIMetadata.class), eq(interval))).thenReturn(FakeReferenceSource.bases(interval));
-        }
-
-        String referenceName = "refName";
-        String refId = "0xbjfjd23f";
-        Map<String, String> referenceNameToIdTable = Maps.newHashMap();
-        referenceNameToIdTable.put(referenceName, refId);
-        RefAPIMetadata refAPIMetadata = new RefAPIMetadata(referenceName, referenceNameToIdTable);
-
+        final RefAPISource mockSource = createMockRefAPISource(intervals);
+        final RefAPIMetadata refAPIMetadata = ReadsPreprocessingPipelineTestData.createRefAPIMetadata();
 
         List<KV<ReferenceShard, Iterable<GATKRead>>> noReads = Arrays.asList(
                 KV.of(new ReferenceShard(0, "1"), Lists.newArrayList()));
@@ -107,6 +102,64 @@ public final class RefBasesFromAPIUnitTest extends BaseTest {
         RefAPISource.setRefAPISource(mockSource);
         // We expect an exception to be thrown if there is a problem. If no error is thrown, it's fine.
         RefBasesFromAPI.getBasesForShard(pInput, refAPIMetadata);
+
+        p.run();
+    }
+
+    @DataProvider(name = "RefBasesFromAPIWithCustomWindowFunctionTestData")
+    public Object[][] refBasesFromAPIWithCustomWindowFunctionTestData() {
+        final ReferenceShard shard = new ReferenceShard(0, "1");
+        final List<GATKRead> samReads = Arrays.asList(
+                ReadsPreprocessingPipelineTestData.makeRead("1", 500, 100, 0, SAMRecord.class),
+                ReadsPreprocessingPipelineTestData.makeRead("1", 1000, 100, 1, SAMRecord.class),
+                ReadsPreprocessingPipelineTestData.makeRead("1", 1050, 100, 2, SAMRecord.class)
+        );
+        final List<GATKRead> googleReads = Arrays.asList(
+                ReadsPreprocessingPipelineTestData.makeRead("1", 500, 100, 0, Read.class),
+                ReadsPreprocessingPipelineTestData.makeRead("1", 1000, 100, 1, Read.class),
+                ReadsPreprocessingPipelineTestData.makeRead("1", 1050, 100, 2, Read.class)
+        );
+
+        final List<Object[]> testCases = new ArrayList<>();
+        for ( final List<GATKRead> reads : Arrays.asList(samReads, googleReads) ) {
+            // Test case layout: input shard + reads, reference window function to apply, expected reference interval post-transform
+
+            // Identity function
+            testCases.add( new Object[]{ KV.of(shard, reads), RefWindowFunctions.IDENTITY_FUNCTION, new SimpleInterval("1", 500, 1149) });
+            // Expand reads by 1 base on each side
+            testCases.add( new Object[]{ KV.of(shard, reads), new RefWindowFunctions.FixedWindowFunction(1, 1), new SimpleInterval("1", 499, 1150) });
+            // Expand reads by 3 bases on the left and 5 bases on the right
+            testCases.add( new Object[]{ KV.of(shard, reads), new RefWindowFunctions.FixedWindowFunction(3, 5), new SimpleInterval("1", 497, 1154) });
+            // Expand reads by 30 bases on the left and 10 bases on the right
+            testCases.add( new Object[]{ KV.of(shard, reads), new RefWindowFunctions.FixedWindowFunction(30, 10), new SimpleInterval("1", 470, 1159) });
+            // Expand reads by 1000 bases on each side (goes off contig bounds)
+            testCases.add( new Object[]{ KV.of(shard, reads), new RefWindowFunctions.FixedWindowFunction(1000, 1000), new SimpleInterval("1", 1, 2149) });
+        }
+        return testCases.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "RefBasesFromAPIWithCustomWindowFunctionTestData")
+    public void testRefBasesFromAPIWithCustomWindowFunction( final KV<ReferenceShard, Iterable<GATKRead>> inputShard, final SerializableFunction<GATKRead, SimpleInterval> referenceWindowFunction, final SimpleInterval expectedReferenceInterval ) {
+        Pipeline p = GATKTestPipeline.create();
+        DataflowUtils.registerGATKCoders(p);
+
+        // Assuming everything works properly, we only need a mock response to the expected reference interval,
+        // since that is what should end up being queried in RefBasesFromAPI. If we later try to query an
+        // unexpected interval, we'll detect it via an Assert.
+        final RefAPISource mockSource = createMockRefAPISource(Arrays.asList(expectedReferenceInterval));
+        final RefAPIMetadata refAPIMetadata = ReadsPreprocessingPipelineTestData.createRefAPIMetadata(referenceWindowFunction);
+        RefAPISource.setRefAPISource(mockSource);
+
+        PCollection<KV<ReferenceShard, Iterable<GATKRead>>> pInput = p.apply("pInput.Create", Create.of(inputShard).withCoder(KvCoder.of(ReferenceShard.CODER, IterableCoder.of(new GATKReadCoder()))));
+        PCollection<KV<ReferenceBases, Iterable<GATKRead>>> actualResult = RefBasesFromAPI.getBasesForShard(pInput, refAPIMetadata);
+
+        DataflowAssert.that(actualResult).satisfies((Iterable<KV<ReferenceBases, Iterable<GATKRead>>> input) -> {
+            for ( KV<ReferenceBases, Iterable<GATKRead>> kvPair : input ) {
+                Assert.assertNotNull(kvPair.getKey(), "Null ReferenceBases in KV pair indicates that reference query in RefBaseFromAPI used an unexpected/incorrect interval (mock RefAPISource returned null)");
+                Assert.assertEquals(kvPair.getKey().getInterval(), expectedReferenceInterval, "Wrong interval for ReferenceBases object after applying RefBasesFromAPI");
+            }
+            return null;
+        });
 
         p.run();
     }

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/AddContextDataToReadUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/AddContextDataToReadUnitTest.java
@@ -5,7 +5,9 @@ import com.google.cloud.dataflow.sdk.coders.IterableCoder;
 import com.google.cloud.dataflow.sdk.coders.KvCoder;
 import com.google.cloud.dataflow.sdk.coders.SerializableCoder;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
 import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.common.collect.Maps;
@@ -25,13 +27,13 @@ import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.FakeReferenceSource;
 import org.broadinstitute.hellbender.utils.variant.Variant;
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import static org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData.makeRead;
 import static org.mockito.Mockito.*;
 
 public final class AddContextDataToReadUnitTest extends BaseTest {
@@ -94,15 +96,75 @@ public final class AddContextDataToReadUnitTest extends BaseTest {
             when(mockSource.getReferenceBases(any(PipelineOptions.class), any(RefAPIMetadata.class), eq(i))).thenReturn(FakeReferenceSource.bases(i));
         }
 
-        String referenceName = "refName";
-        String refId = "0xbjfjd23f";
-        Map<String, String> referenceNameToIdTable = Maps.newHashMap();
-        referenceNameToIdTable.put(referenceName, refId);
-        RefAPIMetadata refAPIMetadata = new RefAPIMetadata(referenceName, referenceNameToIdTable);
+        final RefAPIMetadata refAPIMetadata = ReadsPreprocessingPipelineTestData.createRefAPIMetadata();
         RefAPISource.setRefAPISource(mockSource);
         PCollection<KV<GATKRead, ReadContextData>> result = AddContextDataToRead.add(pReads, /*mockSource,*/ refAPIMetadata, mockVariantsSource);
         PCollection<KV<GATKRead, ReadContextData>> pkvReadContextData = p.apply(Create.of(kvReadContextData).withCoder(KvCoder.of(new GATKReadCoder(), new ReadContextDataCoder())));
         DataflowTestUtils.keyReadContextDataMatcher(result, pkvReadContextData);
         p.run();
+    }
+
+    @DataProvider(name = "AddContextDataWithCustomReferenceWindowFunctionTestData")
+    public Object[][] addContextDataWithCustomReferenceWindowFunctionTestData() {
+        // Using this made-up sequence as our reference for these tests.
+        final String referenceBasesString = "AGCCTTTCGAACTGAGCCCGTTCCTGGGGTTATACCCGGCTTTTGGCGCT";
+        final RefAPISource mockReferenceSource = mock(RefAPISource.class, withSettings().serializable());
+
+        // Set up mock reference source to handle expected queries in our test cases below
+        // (will return null for unexpected queries)
+        for ( final SimpleInterval queryInterval : Arrays.asList(new SimpleInterval("1", 1, 10), new SimpleInterval("1", 1, 11), new SimpleInterval("1", 1, 15), new SimpleInterval("1", 20, 30), new SimpleInterval("1", 19, 31), new SimpleInterval("1", 17, 35), new SimpleInterval("1", 1, 40)) ) {
+            when(mockReferenceSource.getReferenceBases(any(PipelineOptions.class), any(RefAPIMetadata.class), eq(queryInterval))).thenReturn(new ReferenceBases(referenceBasesString.substring(queryInterval.getStart() - 1, queryInterval.getEnd()).getBytes(), queryInterval));
+        }
+
+        final List<Object[]> testCases = new ArrayList<>();
+        for ( final Class<?> readImplementation : Arrays.asList(SAMRecord.class, Read.class) ) {
+            // Test case layout: read, mock reference source, reference window function to apply, expected ReferenceBases for read
+
+            // Read at start of contig, identity function
+            testCases.add(new Object[]{ makeRead("1", 1, 10, 0, readImplementation), mockReferenceSource, RefWindowFunctions.IDENTITY_FUNCTION, new ReferenceBases("AGCCTTTCGA".getBytes(), new SimpleInterval("1", 1, 10)) });
+            // Read at start of contig, expand by 1 base on each side (goes off contig bounds)
+            testCases.add(new Object[]{ makeRead("1", 1, 10, 0, readImplementation), mockReferenceSource, new RefWindowFunctions.FixedWindowFunction(1, 1), new ReferenceBases("AGCCTTTCGAA".getBytes(), new SimpleInterval("1", 1, 11)) });
+            // Read at start of contig, expand by 3 bases on the left and 5 bases on the right (goes off contig bounds)
+            testCases.add(new Object[]{ makeRead("1", 1, 10, 0, readImplementation), mockReferenceSource, new RefWindowFunctions.FixedWindowFunction(3, 5), new ReferenceBases("AGCCTTTCGAACTGA".getBytes(), new SimpleInterval("1", 1, 15)) });
+            // Read in middle of contig, identity function
+            testCases.add(new Object[]{ makeRead("1", 20, 11, 0, readImplementation), mockReferenceSource, RefWindowFunctions.IDENTITY_FUNCTION, new ReferenceBases("GTTCCTGGGGT".getBytes(), new SimpleInterval("1", 20, 30)) });
+            // Read in middle of contig, expand by 1 base on each side
+            testCases.add(new Object[]{ makeRead("1", 20, 11, 0, readImplementation), mockReferenceSource, new RefWindowFunctions.FixedWindowFunction(1, 1), new ReferenceBases("CGTTCCTGGGGTT".getBytes(), new SimpleInterval("1", 19, 31)) });
+            // Read in middle of contig, expand by 3 bases on the left and 5 bases on the right
+            testCases.add(new Object[]{ makeRead("1", 20, 11, 0, readImplementation), mockReferenceSource, new RefWindowFunctions.FixedWindowFunction(3, 5), new ReferenceBases("CCCGTTCCTGGGGTTATAC".getBytes(), new SimpleInterval("1", 17, 35)) });
+            // Read in middle of contig, expand by 30 bases on the left and 10 bases on the right (goes off contig bounds)
+            testCases.add(new Object[]{ makeRead("1", 20, 11, 0, readImplementation), mockReferenceSource, new RefWindowFunctions.FixedWindowFunction(30, 10), new ReferenceBases("AGCCTTTCGAACTGAGCCCGTTCCTGGGGTTATACCCGGC".getBytes(), new SimpleInterval("1", 1, 40)) });
+        }
+        return testCases.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "AddContextDataWithCustomReferenceWindowFunctionTestData")
+    public void testAddContextDataWithCustomReferenceWindowFunction( final GATKRead read, final RefAPISource mockRefSource, final SerializableFunction<GATKRead, SimpleInterval> referenceWindowFunction, final ReferenceBases expectedReferenceBases ) {
+        Pipeline p = GATKTestPipeline.create();
+        DataflowUtils.registerGATKCoders(p);
+
+        PCollection<GATKRead> pReads = DataflowTestUtils.pCollectionCreateAndVerify(p, Arrays.asList(read), new GATKReadCoder());
+
+        PCollection<Variant> pVariant = p.apply(Create.of(Collections.<Variant>emptyList()));
+        VariantsDataflowSource mockVariantsSource = mock(VariantsDataflowSource.class);
+        when(mockVariantsSource.getAllVariants()).thenReturn(pVariant);
+
+        final RefAPIMetadata refAPIMetadata = ReadsPreprocessingPipelineTestData.createRefAPIMetadata(referenceWindowFunction);
+        RefAPISource.setRefAPISource(mockRefSource);
+
+        PCollection<KV<GATKRead, ReadContextData>> result = AddContextDataToRead.add(pReads, refAPIMetadata, mockVariantsSource);
+
+        DataflowAssert.that(result).satisfies((Iterable<KV<GATKRead, ReadContextData>> resultElements) -> {
+            for ( KV<GATKRead, ReadContextData> kvPair : resultElements ) {
+                Assert.assertNotNull(kvPair.getKey(), "Null read in KV pair after AddContextDataToRead");
+                Assert.assertNotNull(kvPair.getValue(), "Null ReadContextData paired with read after AddContextDataToRead");
+                Assert.assertNotNull(kvPair.getValue().getOverlappingReferenceBases(), "Null ReferenceBases in KV pair indicates that reference query in RefBaseFromAPI used an unexpected/incorrect interval (mock RefAPISource returned null)");
+                Assert.assertEquals(kvPair.getValue().getOverlappingReferenceBases(), expectedReferenceBases, "Wrong ReferenceBases paired with read after AddContextDataToRead");
+            }
+            return null;
+        });
+
+        p.run();
+
     }
 }


### PR DESCRIPTION
-Can now request arbitrary windows of reference bases for each read in AddContextDataToRead

-Wrote a reference window function for BQSR that retrieves for each read exactly the reference
 bases required by the BQSR algorithm.

-Comprehensive unit tests