### PR TITLE
Adding defensive copies in MarkDuplicates since we mutate the reads.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/PairedEnds.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/PairedEnds.java
@@ -81,4 +81,16 @@ public class PairedEnds implements OpticalDuplicateFinder.PhysicalLocation {
 
   @Override
   public void setLibraryId(final short libraryId) { this.libraryId = libraryId; }
+  /**
+   * returns a deep(ish) copy of the GATK reads in the PairedEnds.
+   * TODO: This is only deep for the Google Model read, GATKRead copy() isn't deep for
+   * TODO: for the SAMRecord backed read.
+   * @return a new deep copy
+   */
+  public PairedEnds copy() {
+    if (second == null) {
+      return new PairedEnds(first.copy());
+    }
+    return new PairedEnds(first.copy()).and(second.copy());
+  }
 }


### PR DESCRIPTION
I found all of the cases of .set* on reads and made copies before the mutation so the original wouldn't be changed. I also added comments to the .set*s so we know we've fixed these.