### PR TITLE
Force google-http-client-assembly to 1.21.SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,15 @@ repositories {
     maven {
         url "https://repository.cloudera.com/artifactory/cloudera-repos/" // spark-dataflow
     }
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        force 'com.google.http-client:google-http-client:1.21.0-SNAPSHOT'
+    }
 }
 
 jacocoTestReport {


### PR DESCRIPTION
This should resolve #650.

This may require a change to the hellbender-protected build to include sonatype snapshots as an available maven repo if it doesn't already.  This is the same issue as #779.