### PR TITLE
cloud tests mandatory. Rename cloud_todo if broken.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,9 +195,10 @@ test {
     String CI = "$System.env.CI"
     useTestNG{
         if ( "$System.env.CLOUD" =="true"){
-            includeGroups 'cloud', 'bucket'
+            // run everything
         } else {
-            excludeGroups 'cloud', 'bucket'
+            // run everything except the "todo" tests
+            excludeGroups 'cloud_todo', 'bucket_todo'
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/RefAPISourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/RefAPISourceUnitTest.java
@@ -33,7 +33,7 @@ public class RefAPISourceUnitTest extends BaseTest {
         return refAPISource.getReferenceBases(p.getOptions(), refAPIMetadata, interval);
     }
 
-    @Test(groups = "cloud")
+    @Test(groups = "cloud_todo")
     public void testDummy() {
         String referenceName = "EOSt9JOVhp3jkwE";
         SimpleInterval interval = new SimpleInterval("1", 50001, 10050000);
@@ -59,7 +59,7 @@ public class RefAPISourceUnitTest extends BaseTest {
 
     }
 
-    @Test(groups = "cloud")
+    @Test(groups = "cloud_todo")
     public void testReferenceSourceQuery() {
         final ReferenceBases bases = queryReferenceAPI("EOSt9JOVhp3jkwE", new SimpleInterval("1", 50000, 50009));
 
@@ -69,17 +69,17 @@ public class RefAPISourceUnitTest extends BaseTest {
         Assert.assertEquals(new String(bases.getBases()), "TAAACAGGTT", "Wrong bases returned");
     }
 
-    @Test(groups = "cloud", expectedExceptions = UserException.class)
+    @Test(groups = "cloud_todo", expectedExceptions = UserException.class)
     public void testReferenceSourceQueryWithInvalidContig() {
         final ReferenceBases bases = queryReferenceAPI("EOSt9JOVhp3jkwE", new SimpleInterval("FOOCONTIG", 1, 2));
     }
 
-    @Test(groups = "cloud", expectedExceptions = UserException.class)
+    @Test(groups = "cloud_todo", expectedExceptions = UserException.class)
     public void testReferenceSourceQueryWithInvalidPosition() {
         final ReferenceBases bases = queryReferenceAPI("EOSt9JOVhp3jkwE", new SimpleInterval("1", 1000000000, 2000000000));
     }
 
-    @Test(groups = "cloud", expectedExceptions = IllegalArgumentException.class)
+    @Test(groups = "cloud_todo", expectedExceptions = IllegalArgumentException.class)
     public void testReferenceSourceQueryWithNullInterval() {
         final ReferenceBases bases = queryReferenceAPI("EOSt9JOVhp3jkwE", null);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/SmallBamWriterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/SmallBamWriterTest.java
@@ -53,7 +53,7 @@ public class SmallBamWriterTest extends BaseTest {
         testReadAndWrite(LOCAL_INPUT, outputFile, false, false);
     }
 
-    @Test(groups = {"bucket"})
+    @Test(groups = {"bucket_todo"})
     public void checkGCSInput() throws Exception {
         File out = createTempFile("temp",".bam");
         String outputFile = out.getPath();
@@ -61,7 +61,7 @@ public class SmallBamWriterTest extends BaseTest {
     }
 
     // this leaves output files around, for now.
-    @Test(groups = {"bucket"})
+    @Test(groups = {"bucket_todo"})
     public void checkGCSOutput() throws Exception {
         File out = createTempFile("temp",".bam");
         String tempName = out.getName();
@@ -70,7 +70,7 @@ public class SmallBamWriterTest extends BaseTest {
     }
 
     // this leaves output files around, for now.
-    @Test(groups = {"cloud"})
+    @Test(groups = {"cloud_todo"})
     public void checkCloud() throws Exception {
         File out = createTempFile("temp",".bam");
         String tempName = out.getName();

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/FlagStatDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/FlagStatDataflowIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 public final class FlagStatDataflowIntegrationTest extends CommandLineProgramTest {
 
 
-    @Test( groups = {"bucket", "dataflow"})
+    @Test( groups = {"bucket_todo", "dataflow"})
     public void flagStatDataflowLocalReadFromBucket() throws IOException {
         List<String> args = new ArrayList<>();
         args.add("--apiKey"); args.add(getDataflowTestApiKey());

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ReadsPreprocessingPipelineIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ReadsPreprocessingPipelineIntegrationTest.java
@@ -26,7 +26,7 @@ public class ReadsPreprocessingPipelineIntegrationTest extends CommandLineProgra
         };
     }
 
-    @Test(dataProvider = "EndToEndTestData", groups = {"cloud"})
+    @Test(dataProvider = "EndToEndTestData", groups = {"cloud_todo"})
     public void testPipelineEndToEnd( final String inputBam, final String reference, final String knownSites, final File expectedOutput ) throws IOException {
         final File output = createTempFile("testPipelineEndToEnd_output", ".bam");
         List<String> argv = new ArrayList<>();

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSRDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSRDataflowIntegrationTest.java
@@ -110,7 +110,7 @@ public final class ApplyBQSRDataflowIntegrationTest extends CommandLineProgramTe
         spec.executeTest("testPrintReads-" + params.args, this);
     }
 
-    @Test(dataProvider = "ApplyBQSRTestGCS", groups = {"bucket"})
+    @Test(dataProvider = "ApplyBQSRTestGCS", groups = {"bucket_todo"})
     public void testPR_GCS(ABQSRTest params) throws IOException {
         String args =
                 " -I " + params.bam +
@@ -125,7 +125,7 @@ public final class ApplyBQSRDataflowIntegrationTest extends CommandLineProgramTe
         spec.executeTest("testPrintReads-" + params.args, this);
     }
 
-    @Test(dataProvider = "ApplyBQSRTestGCS", groups = {"cloud"})
+    @Test(dataProvider = "ApplyBQSRTestGCS", groups = {"cloud_todo"})
     public void testPR_Cloud(ABQSRTest params) throws IOException {
         String args =
                 " -I " + params.bam +

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorDataflowIntegrationTest.java
@@ -174,7 +174,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
     }
 
 
-    @Test(dataProvider = "BQSRTestBucket", groups = {"bucket"})
+    @Test(dataProvider = "BQSRTestBucket", groups = {"bucket_todo"})
     public void testBQSRBucket(BQSRTest params) throws IOException {
         IntegrationTestSpec spec = new IntegrationTestSpec(
                 params.getCommandLine(),
@@ -182,7 +182,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
         spec.executeTest("testBQSR-" + params.args, this);
     }
 
-    @Test(dataProvider = "BQSRTestCloud", groups = {"cloud"})
+    @Test(dataProvider = "BQSRTestCloud", groups = {"cloud_todo"})
     public void testBQSRCloud(BQSRTest params) throws IOException {
         IntegrationTestSpec spec = new IntegrationTestSpec(
                 params.getCommandLine(),
@@ -191,7 +191,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
     }
 
 
-    @Test(description = "This is to test https://github.com/broadinstitute/hellbender/issues/322", groups = {"cloud"})
+    @Test(description = "This is to test https://github.com/broadinstitute/hellbender/issues/322", groups = {"cloud_todo"})
     public void testPlottingWorkflow() throws IOException {
         final String cloudArgs = "--apiKey " + getDataflowTestApiKey() + " ";
         final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";

--- a/src/test/java/org/broadinstitute/hellbender/utils/dataflow/BucketUtilsTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/dataflow/BucketUtilsTest.java
@@ -59,7 +59,7 @@ public final class BucketUtilsTest extends BaseTest {
         }
     }
 
-    @Test(groups={"bucket"})
+    @Test(groups={"bucket_todo"})
     public void testCopyAndDeleteGCS() throws IOException, GeneralSecurityException {
         final String src = publicTestDir + "empty.vcf";
         File dest = createTempFile("copy-empty", ".vcf");

--- a/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/reference/ReferenceUtilsUnitTest.java
@@ -52,7 +52,7 @@ public class ReferenceUtilsUnitTest extends BaseTest {
         }
     }
 
-    @Test(groups = {"bucket"})
+    @Test(groups = {"bucket_todo"})
     public void testLoadFastaDictionaryFromGCSBucket() throws IOException {
         final String bucketDictionary = getDataflowTestInputPath() + "org/broadinstitute/hellbender/utils/ReferenceUtilsTest.dict";
         final PipelineOptions popts = getAuthenticatedPipelineOptions();


### PR DESCRIPTION
"cloud" and "bucket" tests now run by default, in order to make progress for issue #751.

Moved all existing tests to "cloud_todo" and "bucket_todo". The plan is to then move back the tests that work (but in a separate PR, to keep this clean and simple).

This is a rebased and fixed version of #819.