### PR TITLE
make working cloud tests mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ jdk:
 - oraclejdk8
 env:
   matrix:
-  - CLOUD=true
+  - CLOUD=mandatory
+  - CLOUD=todo
   - CLOUD=false
-  - DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=true
+  - DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=mandatory
   - DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=false
   global:
   #gradle needs this
@@ -33,8 +34,8 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=false
-    - env: DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=true
-    - env: CLOUD=true
+    - env: DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=mandatory
+    - env: CLOUD=todo
 cache:
   directories:
   - ~/.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -193,11 +193,14 @@ task testAll(type: Test){
 
 test {
     String CI = "$System.env.CI"
+    String CLOUD = "$System.env.CLOUD"
     useTestNG{
-        if ( "$System.env.CLOUD" =="true"){
+        if ( CLOUD =="mandatory"){
             includeGroups 'cloud', 'bucket'
+        } else if( CLOUD == "todo"){
+            includeGroups 'cloud_todo', 'bucket_todo'
         } else {
-            excludeGroups 'cloud', 'bucket'
+            excludeGroups 'cloud', 'bucket', 'cloud_todo', 'bucket_todo'
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/RefAPISourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/RefAPISourceUnitTest.java
@@ -33,7 +33,7 @@ public class RefAPISourceUnitTest extends BaseTest {
         return refAPISource.getReferenceBases(p.getOptions(), refAPIMetadata, interval);
     }
 
-    @Test(groups = "cloud")
+    @Test(groups = "cloud_todo")
     public void testDummy() {
         String referenceName = "EOSt9JOVhp3jkwE";
         SimpleInterval interval = new SimpleInterval("1", 50001, 10050000);

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/SmallBamWriterTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/SmallBamWriterTest.java
@@ -9,22 +9,21 @@ import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.util.GcsUtil;
 import com.google.cloud.dataflow.sdk.util.gcsfs.GcsPath;
 import com.google.cloud.dataflow.sdk.values.PCollection;
-import com.google.cloud.genomics.dataflow.utils.GCSOptions;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SamInputResource;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
-import org.broadinstitute.hellbender.engine.dataflow.DataflowCommandLineProgram;
-import org.broadinstitute.hellbender.utils.dataflow.SmallBamWriter;
 import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.dataflow.DataflowCommandLineProgram;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.ReadsDataflowSource;
 import org.broadinstitute.hellbender.tools.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
 import org.broadinstitute.hellbender.utils.dataflow.DataflowUtils;
+import org.broadinstitute.hellbender.utils.dataflow.SmallBamWriter;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.annotations.Test;
@@ -53,7 +52,7 @@ public class SmallBamWriterTest extends BaseTest {
         testReadAndWrite(LOCAL_INPUT, outputFile, false, false);
     }
 
-    @Test(groups = {"bucket"})
+    @Test(groups = {"bucket_todo"})
     public void checkGCSInput() throws Exception {
         File out = createTempFile("temp",".bam");
         String outputFile = out.getPath();
@@ -70,7 +69,7 @@ public class SmallBamWriterTest extends BaseTest {
     }
 
     // this leaves output files around, for now.
-    @Test(groups = {"cloud"})
+    @Test(groups = {"cloud_todo"})
     public void checkCloud() throws Exception {
         File out = createTempFile("temp",".bam");
         String tempName = out.getName();

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/FlagStatDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/FlagStatDataflowIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 public final class FlagStatDataflowIntegrationTest extends CommandLineProgramTest {
 
 
-    @Test( groups = {"bucket", "dataflow"})
+    @Test( groups = {"bucket_todo", "dataflow_todo"})
     public void flagStatDataflowLocalReadFromBucket() throws IOException {
         List<String> args = new ArrayList<>();
         args.add("--apiKey"); args.add(getDataflowTestApiKey());

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSRDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/ApplyBQSRDataflowIntegrationTest.java
@@ -110,7 +110,7 @@ public final class ApplyBQSRDataflowIntegrationTest extends CommandLineProgramTe
         spec.executeTest("testPrintReads-" + params.args, this);
     }
 
-    @Test(dataProvider = "ApplyBQSRTestGCS", groups = {"bucket"})
+    @Test(dataProvider = "ApplyBQSRTestGCS", groups = {"bucket_todo"})
     public void testPR_GCS(ABQSRTest params) throws IOException {
         String args =
                 " -I " + params.bam +
@@ -125,7 +125,7 @@ public final class ApplyBQSRDataflowIntegrationTest extends CommandLineProgramTe
         spec.executeTest("testPrintReads-" + params.args, this);
     }
 
-    @Test(dataProvider = "ApplyBQSRTestGCS", groups = {"cloud"})
+    @Test(dataProvider = "ApplyBQSRTestGCS", groups = {"cloud_todo"})
     public void testPR_Cloud(ABQSRTest params) throws IOException {
         String args =
                 " -I " + params.bam +

--- a/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/walkers/bqsr/BaseRecalibratorDataflowIntegrationTest.java
@@ -174,7 +174,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
     }
 
 
-    @Test(dataProvider = "BQSRTestBucket", groups = {"bucket"})
+    @Test(dataProvider = "BQSRTestBucket", groups = {"bucket_todo"})
     public void testBQSRBucket(BQSRTest params) throws IOException {
         IntegrationTestSpec spec = new IntegrationTestSpec(
                 params.getCommandLine(),


### PR DESCRIPTION
@jean-philippe-martin I think this might be a slightly better approach then merging the cloud tests into the main tests.  This just adds another build to the matrix so we have 1 for mandatory cloud tests and 1 for todo cloud tests.  That way we don't dramatically increase the build time by mashing the cloud tests into the main ones.