### PR TITLE
Add large files for testing, tracked using git-lfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Requirements
 
 * Gradle 2.2.1
 
-* R 3.1.3 
+* R 3.1.3
+
+* Git 2.5
+
+* The [git-lfs plugin](https://git-lfs.github.com/). Run `git lfs init` after installing.
 
 
 Installation
@@ -40,7 +44,8 @@ General guidelines for Hellbender developers
 
 * **Do not put private or restricted data into the repo.**
 
-* **Try to keep datafiles under 100kb in size.**
+* **Try to keep datafiles under 100kb in size.** Larger test files should go into `src/test/resources/large`, and must be
+  managed using `git lfs` by running `git lfs track <file>` on each new large file before commit.
 
 * Hellbender is  BSD licensed.  The license is in the top level LICENSE.TXT file.  Do not add any additional license text or accept files with a license included in them.
 
@@ -74,7 +79,7 @@ Tests
 ----------------
 We use [Travis-CI](https://travis-ci.org/broadinstitute/hellbender) as our continuous integration provider.
 
-* Before merging any branch make sure that all required tests pass on travis.  Currently tests in the `cloud` and `bucket` groups as well as the tests running on spark are not required to pass before merging.
+* Before merging any branch make sure that all required tests pass on travis.
 * Every travis build will upload the test results to our hellbender google bucket.  A link to the uploaded report will appear at the very bottom of the travis log.  Look for the line that says `See the test report at`.
 If TestNG itself crashes there will be no report generated.
 

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -44,6 +44,24 @@ public abstract class BaseTest {
     public static final String publicTestDir = new File(gatkDirectory, publicTestDirRelative).getAbsolutePath() + "/";
     public static final String publicTestDirRoot = publicTestDir.replace(publicTestDirRelative, "");
 
+    /**
+     * LARGE FILES FOR TESTING (MANAGED BY GIT LFS)
+     */
+    public static final String largeFileTestDir = new File(publicTestDir, "large").getAbsolutePath() + "/";
+
+    // All of chromosomes 20 and 21 from the b37 reference
+    public static final String b37_reference_20_21 = largeFileTestDir + "human_g1k_v37.20.21.fasta";
+
+    // ~600,000 reads from chromosomes 20 and 21 of an NA12878 WGS bam aligned to b37, plus ~50,000 unmapped reads
+    public static final String NA12878_20_21_WGS_bam = largeFileTestDir + "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam";
+
+    // Variants from a DBSNP 138 VCF overlapping the reads in NA12878_20_21_WGS_bam
+    public static final String dbsnp_138_b37_20_21_vcf = largeFileTestDir + "dbsnp_138.b37.20.21.vcf";
+
+    /**
+     * END OF LARGE FILES FOR TESTING
+     */
+
     public static final String hg19_chr1_1M_Reference = publicTestDir + "Homo_sapiens_assembly19_chr1_1M.fasta";
     public static final String hg19_chr1_1M_dbSNP = publicTestDir + "Homo_sapiens_assembly19.dbsnp135.chr1_1M.exome_intervals.vcf";
 

--- a/src/test/resources/large/.gitattributes
+++ b/src/test/resources/large/.gitattributes
@@ -1,0 +1,8 @@
+
+CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam filter=lfs diff=lfs merge=lfs -text
+CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam.bai filter=lfs diff=lfs merge=lfs -text
+dbsnp_138.b37.20.21.vcf filter=lfs diff=lfs merge=lfs -text
+dbsnp_138.b37.20.21.vcf.idx filter=lfs diff=lfs merge=lfs -text
+human_g1k_v37.20.21.dict filter=lfs diff=lfs merge=lfs -text
+human_g1k_v37.20.21.fasta filter=lfs diff=lfs merge=lfs -text
+human_g1k_v37.20.21.fasta.fai filter=lfs diff=lfs merge=lfs -text

--- a/src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam
+++ b/src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b1304800e60c0ac0358df137bdad48b7857a36465b04fef3fbbb09380f04746
+size 79856849

--- a/src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam.bai
+++ b/src/test/resources/large/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06d71f4306957dea0f46adf78fce2969e80c37ecb070c2d51088b8db88ef9ab1
+size 11520

--- a/src/test/resources/large/dbsnp_138.b37.20.21.vcf
+++ b/src/test/resources/large/dbsnp_138.b37.20.21.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0c7060c55e35cc879da11b0ac9f3f6772fe95dc8b927fafb80f0139e6c4c065
+size 1575950

--- a/src/test/resources/large/dbsnp_138.b37.20.21.vcf.idx
+++ b/src/test/resources/large/dbsnp_138.b37.20.21.vcf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b62a51ebafae25cc735b16a90c4233a13372e66aa75c2410c4819c4140d5f94
+size 83916

--- a/src/test/resources/large/human_g1k_v37.20.21.dict
+++ b/src/test/resources/large/human_g1k_v37.20.21.dict
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:233c4c703ac071c37ff052c12cd5ad2016a0e84021e9ca3d01764b7165821aa7
+size 317

--- a/src/test/resources/large/human_g1k_v37.20.21.fasta
+++ b/src/test/resources/large/human_g1k_v37.20.21.fasta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bafe4b1274a4ee6f9b5d9348a6a5f31d49781595bcda25cc452ad6fd6ad3cb34
+size 113008112

--- a/src/test/resources/large/human_g1k_v37.20.21.fasta.fai
+++ b/src/test/resources/large/human_g1k_v37.20.21.fasta.fai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e5daa85c50bc06de53d26794dc02ed3bddcad083badae7a601e524982eeb58d
+size 48


### PR DESCRIPTION
-Added a "large files" directory to src/test/resoureces containing files managed
 by "git lfs" rather than checked directly into the hellbender repository.
 Updated setup instructions in README appropriately to reflect new requirement
 for git lfs.

-Added a bam with ~600,000 reads from chromosomes 20 and 21, as well as ~50000
 unmapped reads.

-Added a snippet of the b37 reference with all of chromosomes 20 and 21.

-Added a DBSNP vcf containing variants overlapping the reads in the bam above.