### PR TITLE
When running on Spark (or writing to HDFS), use the Hadoop-BAM library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     //compile 'com.google.appengine.tools:appengine-gcs-client:0.4.4'
     compile 'org.jgrapht:jgrapht-core:0.9.1'
     compile 'org.testng:testng:6.9.6' //compile instead of testCompile because it is needed for test infrastructure that needs to be packaged
-    compile 'com.cloudera.dataflow.spark:spark-dataflow:0.4.0'
+    compile 'com.cloudera.dataflow.spark:spark-dataflow:0.4.0.1'
     compile('org.seqdoop:hadoop-bam:7.1.0') {
         exclude group: 'org.apache.hadoop'
         exclude module: 'htsjdk'
@@ -219,8 +219,6 @@ test {
 
     // ensure dataflowRunner is passed to the test VM if specified on the command line
     systemProperty "dataflowRunner", System.getProperty("dataflowRunner")
-    // increase max buffer size for Spark serialization
-    systemProperty "spark.kryoserializer.buffer.max", "256m"
 
     // set heap size for the test JVM(s)
     minHeapSize = "1G"

--- a/src/main/java/org/broadinstitute/hellbender/utils/dataflow/SmallBamWriter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/dataflow/SmallBamWriter.java
@@ -1,23 +1,42 @@
 package org.broadinstitute.hellbender.utils.dataflow;
 
 
+import com.cloudera.dataflow.hadoop.HadoopIO;
+import com.cloudera.dataflow.hadoop.WritableCoder;
+import com.cloudera.dataflow.spark.ShardNameTemplateAware;
+import com.cloudera.dataflow.spark.ShardNameTemplateHelper;
+import com.cloudera.dataflow.spark.SparkPipelineRunner;
 import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.coders.*;
 import com.google.cloud.dataflow.sdk.transforms.Create;
 import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.transforms.View;
+import com.google.cloud.dataflow.sdk.util.SerializableUtils;
+import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.PCollectionView;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileWriter;
 import htsjdk.samtools.SAMFileWriterFactory;
 import htsjdk.samtools.SAMRecord;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.seqdoop.hadoop_bam.KeyIgnoringBAMOutputFormat;
+import org.seqdoop.hadoop_bam.SAMRecordWritable;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.Base64;
 
 /**
  * Takes a few Reads and will write them to a BAM file.
@@ -38,16 +57,20 @@ public class SmallBamWriter implements Serializable {
      * @param destPath the GCS or local path to write to (must start with "gs://" if writing to GCS).
      */
     public static void writeToFile(Pipeline pipeline, PCollection<GATKRead> reads, final SAMFileHeader header, final String destPath) {
-        PCollectionView<Iterable<GATKRead>> iterableView =
-                reads.apply(View.<GATKRead>asIterable());
+        if (BucketUtils.isHadoopUrl(destPath) ||
+                pipeline.getRunner().getClass().equals(SparkPipelineRunner.class)) {
+            writeToHadoop(pipeline, reads, header, destPath);
+        } else {
+            PCollectionView<Iterable<GATKRead>> iterableView =
+                    reads.apply(View.<GATKRead>asIterable());
 
-        PCollection<String> dummy = pipeline.apply("output file name", Create.<String>of(destPath));
+            PCollection<String> dummy = pipeline.apply("output file name", Create.<String>of(destPath));
 
-        dummy.apply(ParDo.named("save to BAM file")
-                        .withSideInputs(iterableView)
-                        .of(new SaveToBAMFile(header, iterableView))
-        );
-
+            dummy.apply(ParDo.named("save to BAM file")
+                            .withSideInputs(iterableView)
+                            .of(new SaveToBAMFile(header, iterableView))
+            );
+        }
     }
 
     private static class SaveToBAMFile extends DoFn<String,Void> {
@@ -75,4 +98,76 @@ public class SmallBamWriter implements Serializable {
             }
         }
     }
+
+    private static void writeToHadoop(Pipeline pipeline, PCollection<GATKRead> reads, final SAMFileHeader header, final String destPath) {
+        if (destPath.equals("/dev/null")) {
+            return;
+        }
+
+        String headerString = Base64.getEncoder().encodeToString(SerializableUtils.serializeToByteArray(header));
+
+        @SuppressWarnings("unchecked")
+        Class<? extends FileOutputFormat<NullWritable, SAMRecordWritable>> outputFormatClass =
+                (Class<? extends FileOutputFormat<NullWritable, SAMRecordWritable>>) (Class<?>) TemplatedKeyIgnoringBAMOutputFormat.class;
+        @SuppressWarnings("unchecked")
+        HadoopIO.Write.Bound<NullWritable, SAMRecordWritable> write = HadoopIO.Write.to(destPath,
+                outputFormatClass, NullWritable.class, SAMRecordWritable.class)
+                .withConfigurationProperty(TemplatedKeyIgnoringBAMOutputFormat.SAM_HEADER_PROPERTY_NAME, headerString);
+
+        PCollection<KV<NullWritable, SAMRecordWritable>> samReads =
+                reads.apply(ParDo.of(new DoFn<GATKRead, KV<NullWritable, SAMRecordWritable>>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void processElement(ProcessContext c) throws Exception {
+                SAMRecord samRecord = c.element().convertToSAMRecord(header);
+                SAMRecordWritable samRecordWritable = new SAMRecordWritable();
+                samRecordWritable.set(samRecord);
+                c.output(KV.of(NullWritable.get(), samRecordWritable));
+            }
+        })).setCoder(KvCoder.of(WritableCoder.of(NullWritable.class), WritableCoder.of(SAMRecordWritable.class)));
+
+        // write as a single (unsharded) file
+        samReads.apply(write.withoutSharding());
+    }
+
+    public static class TemplatedKeyIgnoringBAMOutputFormat<K> extends KeyIgnoringBAMOutputFormat<K>
+        implements Configurable, ShardNameTemplateAware {
+
+        public static final String SAM_HEADER_PROPERTY_NAME = "sam.header";
+
+        private Configuration conf;
+
+        @Override
+        public void setConf(Configuration conf) {
+            this.conf = conf;
+            if (conf != null) {
+                String headerString = conf.get(SAM_HEADER_PROPERTY_NAME);
+                if (headerString == null) {
+                    throw new IllegalStateException("SAM file header has not been set");
+                }
+                byte[] headerBytes = Base64.getDecoder().decode(headerString);
+                setSAMHeader((SAMFileHeader) SerializableUtils.deserializeFromByteArray(headerBytes, "SAMFileHeader"));
+            }
+        }
+
+        @Override
+        public Configuration getConf() {
+            return getConf();
+        }
+
+        @Override
+        public void checkOutputSpecs(JobContext job) {
+            // overwrite old files if present (consistent with dataflow behavior)
+        }
+
+        @Override
+        public Path getDefaultWorkFile(TaskAttemptContext context,
+                String extension) throws IOException {
+            // Use ShardNameTemplateHelper to construct the output file name specified in HadoopIO.Write.to()
+            // above, along with any sharding and suffix information (if specified).
+            return ShardNameTemplateHelper.getDefaultWorkFile(this, context);
+        }
+    }
+
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ApplyBQSRDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ApplyBQSRDataflowIntegrationTest.java
@@ -135,10 +135,8 @@ public final class ApplyBQSRDataflowIntegrationTest extends CommandLineProgramTe
                 " --bqsr_recal_file " + getDataflowTestInputPath() + THIS_TEST_FOLDER + "HiSeq.20mb.1RG.table.gz " +
                 params.args +
                 " -O %s";
-        ArgumentsBuilder ab = new ArgumentsBuilder().add(args);
-        addDataflowRunnerArgs(ab);
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                ab.getString(),
+                args,
                 Arrays.asList(params.expectedFile));
         spec.executeTest("testPrintReads-" + params.args, this);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/BaseRecalibratorDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/BaseRecalibratorDataflowIntegrationTest.java
@@ -8,6 +8,7 @@ import org.broadinstitute.hellbender.tools.ApplyBQSR;
 import org.broadinstitute.hellbender.tools.IntegrationTestSpec;
 import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.read.SamAssertionUtils;
+import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -155,8 +156,10 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
     // "local", but we're still getting the reference from the cloud.
     @Test(dataProvider = "BQSRTest", groups = {"cloud"})
     public void testBQSRLocal(BQSRTest params) throws IOException {
+        ArgumentsBuilder ab = new ArgumentsBuilder().add(params.getCommandLine());
+        addDataflowRunnerArgs(ab);
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                params.getCommandLine(),
+                ab.getString(),
                 Arrays.asList(params.expectedFileName));
         spec.executeTest("testBQSR-" + params.args, this);
     }
@@ -164,8 +167,10 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
 
     @Test(dataProvider = "BQSRTestBucket", groups = {"bucket"})
     public void testBQSRBucket(BQSRTest params) throws IOException {
+        ArgumentsBuilder ab = new ArgumentsBuilder().add(params.getCommandLine());
+        addDataflowRunnerArgs(ab);
         IntegrationTestSpec spec = new IntegrationTestSpec(
-                params.getCommandLine(),
+                ab.getString(),
                 Arrays.asList(params.expectedFileName));
         spec.executeTest("testBQSR-" + params.args, this);
     }

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/MarkDuplicatesDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/MarkDuplicatesDataflowIntegrationTest.java
@@ -72,6 +72,8 @@ public class MarkDuplicatesDataflowIntegrationTest extends CommandLineProgramTes
         File metricsFile = createTempFile("markdups_metrics", ".txt");
         args.add(metricsFile.getAbsolutePath());
 
+        addDataflowRunnerArgs(args);
+
         runCommandLine(args.getArgsArray());
 
         Assert.assertTrue(outputFile.exists(), "Can't find expected MarkDuplicates output file at " + outputFile.getAbsolutePath());
@@ -127,6 +129,7 @@ public class MarkDuplicatesDataflowIntegrationTest extends CommandLineProgramTes
       args.add(metricsFile.getAbsolutePath());
       args.add("--READ_NAME_REGEX");
       args.add(null);
+      addDataflowRunnerArgs(args);
       runCommandLine(args.getArgsArray());
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ReadsPreprocessingPipelineIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/ReadsPreprocessingPipelineIntegrationTest.java
@@ -37,6 +37,7 @@ public class ReadsPreprocessingPipelineIntegrationTest extends CommandLineProgra
                                   "-BQSRKnownVariants", knownSites,
                                   "-" + StandardArgumentDefinitions.OUTPUT_SHORT_NAME, output.getAbsolutePath()));
         argv.addAll(getStandardDataflowArgumentsFromEnvironment());
+        addDataflowRunnerArgs(argv);
 
         // Note: could use IntegrationTestSpec if we expand it a bit
         runCommandLine(argv);


### PR DESCRIPTION
for writing BAM files. This reduces memory usage since the reads
don't need to all be stored in memory.

Also add some missing calls to addDataflowRunnerArgs in the integration
tests to ensure the correct dataflow runner is being picked up.

This is related to https://github.com/broadinstitute/hellbender/issues/771, for the Spark/Hadoop side.