### PR TITLE
Initial Spark dataflow commit, basic skeleton with some tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,18 +126,22 @@ dependencies {
     }
     compile('org.apache.hadoop:hadoop-client:2.2.0') // should be a 'provided' dependency
 
+    compile('org.apache.spark:spark-core_2.10:1.4.1') {
+        // JUL is used by Google Dataflow as the backend logger, so exclude jul-to-slf4j to avoid a loop
+        exclude module: 'jul-to-slf4j'
+        exclude module: 'javax.servlet'
+        exclude module: 'servlet-api'
+        exclude module: 'kryo'
+    }
+
+    compile 'com.esotericsoftware.kryo:kryo:2.24.0' // We need the latest 2.x version for de.javakaffee:kryo-serializers
+    compile 'de.javakaffee:kryo-serializers:0.26'
+
     //needed for DataflowAssert
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'junit:junit:4.12'
     testCompile 'org.apache.hadoop:hadoop-minicluster:2.7.1'
     testCompile "org.mockito:mockito-core:1.10.19"
-    testCompile('org.apache.spark:spark-core_2.10:1.4.1') {
-        // JUL is used by Google Dataflow as the backend logger, so exclude jul-to-slf4j to avoid a loop
-        exclude module: 'jul-to-slf4j'
-        exclude module: 'javax.servlet'
-        exclude module: 'servlet-api'
-    }
-
 }
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/programgroups/SparkProgramGroup.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/programgroups/SparkProgramGroup.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.hellbender.cmdline.programgroups;
+
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramGroup;
+
+public final class SparkProgramGroup implements CommandLineProgramGroup {
+
+    @Override
+    public String getName() {
+        return "Spark tests";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Programs to test out Apache Spark";
+    }
+}
+

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/RefAPISource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/RefAPISource.java
@@ -7,6 +7,7 @@ import com.google.api.services.genomics.model.Reference;
 import com.google.api.services.genomics.model.SearchReferencesRequest;
 import com.google.api.services.genomics.model.SearchReferencesResponse;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.genomics.dataflow.utils.GCSOptions;
 import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.utils.GenomicsFactory;
@@ -62,11 +63,20 @@ public class RefAPISource implements ReferenceSource, Serializable {
 
     private Map<String, Reference> referenceMap;
     private Map<String, String> referenceNameToIdTable;
+    private String apiKey;
 
     public RefAPISource(final PipelineOptions pipelineOptions, final String referenceURL) {
         String referenceName = getReferenceSetID(referenceURL);
         this.referenceMap = getReferenceNameToReferenceTable(pipelineOptions, referenceName);
         this.referenceNameToIdTable = getReferenceNameToIdTableFromMap(referenceMap);
+
+        // For Spark, we keep around the apiKey from the PipelineOptions since we don't have
+        // a "context" with PipelineOptions available on each worker.
+        // If we go with Spark, we'll end up refactoring this to store all of the secrets
+        // directly in this class and get rid of PipelineOptions as an argument to
+        // getReferenceBases.
+        Utils.nonNull(pipelineOptions);
+        this.apiKey = pipelineOptions.as(GCSOptions.class).getApiKey();
     }
 
     @VisibleForTesting
@@ -107,11 +117,17 @@ public class RefAPISource implements ReferenceSource, Serializable {
        * @return the reference bases specified by interval and apiData (using the Google Genomics API).
        */
       public ReferenceBases getReferenceBases(final PipelineOptions pipelineOptions, final SimpleInterval interval, int pageSize) {
-          Utils.nonNull(pipelineOptions);
           Utils.nonNull(interval);
 
           if (genomicsService == null) {
-              genomicsService = createGenomicsService(pipelineOptions);
+              if (pipelineOptions == null) {
+                  // Fall back on the saved apiKey for Spark.
+                  GCSOptions options = PipelineOptionsFactory.as(GCSOptions.class);
+                  options.setApiKey(apiKey);
+                  genomicsService = createGenomicsService(options);
+              } else {
+                  genomicsService = createGenomicsService(pipelineOptions);
+              }
           }
           if (!referenceNameToIdTable.containsKey(interval.getContig())) {
               throw new UserException("Contig " + interval.getContig() + " not in our set of reference names for this reference source");
@@ -290,6 +306,8 @@ public class RefAPISource implements ReferenceSource, Serializable {
         }
     }
 
+    // TODO: Move these to a CustomCoder. That will allow us to do something else (possibly better) for Spark.
+    // TODO: See Issue #849.
     // implement methods for Java serialization, since Reference does not implement Serializable
     private void writeObject(ObjectOutputStream stream) throws IOException {
         JsonFactory jsonFactory = com.google.api.client.googleapis.util.Utils.getDefaultJsonFactory();
@@ -299,6 +317,7 @@ public class RefAPISource implements ReferenceSource, Serializable {
             stream.writeUTF(jsonFactory.toString(e.getValue()));
         }
         stream.writeObject(referenceNameToIdTable);
+        stream.writeObject(apiKey);
     }
     
     private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
@@ -310,7 +329,9 @@ public class RefAPISource implements ReferenceSource, Serializable {
         }
         @SuppressWarnings("unchecked")
         final Map<String, String> refTable = (Map<String, String>) stream.readObject();
+        final String apiKey = (String) stream.readObject();
         this.referenceMap = refs;
         this.referenceNameToIdTable = refTable;
+        this.apiKey = apiKey;
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/ReferenceDataflowSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/ReferenceDataflowSource.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.Utils;
 import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
@@ -32,6 +33,7 @@ public class ReferenceDataflowSource implements ReferenceSource, Serializable {
      */
     public ReferenceDataflowSource(final PipelineOptions pipelineOptions, final String referenceURL,
                                    final SerializableFunction<GATKRead, SimpleInterval> referenceWindowFunction) {
+        Utils.nonNull(referenceWindowFunction);
         if (isFasta(referenceURL)) {
             if (BucketUtils.isHadoopUrl(referenceURL)) {
                 referenceSource = new ReferenceHadoopSource(referenceURL);

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/ReferenceShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/ReferenceShard.java
@@ -18,7 +18,7 @@ public final class ReferenceShard implements Serializable {
     private final int shardNumber; // shardNumber is zero-based.
     private final String contig;
 
-    public static final int REFERENCE_SHARD_SIZE = 1000000; // This value is subject to change (by humans).
+    public static final int REFERENCE_SHARD_SIZE = 10000; // This value is subject to change (by humans).
 
     public ReferenceShard(int shardNumber, String contig) {
         this.shardNumber = shardNumber;

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/VariantShard.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/datasources/VariantShard.java
@@ -18,7 +18,7 @@ import java.util.List;
 public final class VariantShard {
     private final int shardNumber;
     private final String contig;
-    public static final int VARIANT_SHARDSIZE = 100000; // This value is subject to change (by humans)
+    public static final int VARIANT_SHARDSIZE = 1000; // This value is subject to change (by humans)
 
     public VariantShard(int shardNumber, String contig) {
         this.shardNumber = shardNumber;

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSpark.java
@@ -1,0 +1,102 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReadContextData;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceDataflowSource;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
+import org.broadinstitute.hellbender.utils.variant.Variant;
+import scala.Tuple2;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * AddContextDataToRead pairs reference bases and overlapping variants with each GATKRead in the RDD input.
+ * The variants are obtained from a local file (later a GCS Bucket). The reference bases come from the Google Genomics API.
+ *
+ * This transform is intended for direct use in pipelines.
+ *
+ * The reference bases paired with each read can be customized by passing in a reference window function
+ * inside the {@link ReferenceDataflowSource} argument to {@link #add}. See
+ * {@link org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions} for examples.
+ */
+public class AddContextDataToReadSpark {
+    public static JavaPairRDD<GATKRead, ReadContextData> add(
+            final JavaRDD<GATKRead> reads, final ReferenceDataflowSource referenceDataflowSource,
+            final JavaRDD<Variant> variants) {
+        // Join Reads and Variants, Reads and ReferenceBases
+        JavaPairRDD<GATKRead, Iterable<Variant>> readiVariants = JoinReadsWithVariants.join(reads, variants);
+        JavaPairRDD<GATKRead, ReferenceBases> readRefBases = JoinReadsWithRefBases.addBases(referenceDataflowSource, reads);
+
+        // For testing we want to know that the reads from the KVs coming back from JoinReadsWithVariants.Join
+        // and JoinReadsWithRefBases.Pair are the same reads from "reads".
+        boolean assertsEnabled = false;
+        assert assertsEnabled = true; // Intentional side-effect!!!
+        // Now assertsEnabled is set to the correct value
+        if (assertsEnabled) {
+            assertSameReads(reads, readRefBases, readiVariants);
+        }
+
+        JavaPairRDD<GATKRead, Tuple2<Iterable<Iterable<Variant>>, Iterable<ReferenceBases>>> cogroup = readiVariants.cogroup(readRefBases);
+        return cogroup.mapToPair(in -> {
+            ReadContextData readContextData = null;
+            try {
+                List<Variant> lVariants = makeListFromIterableIterable(in._2()._1());
+
+                ReferenceBases refBases = Iterables.getOnlyElement(in._2()._2());
+                readContextData = new ReadContextData(refBases, lVariants);
+            } catch(NoSuchElementException e) {
+                throw new GATKException.ShouldNeverReachHereException(e);
+            }
+            return new Tuple2<>(in._1(), readContextData);
+        });
+    }
+
+    private static <T> List<T> makeListFromIterableIterable(Iterable<Iterable<T>> iterables) {
+        List<Iterable<T>> listIterableT = Lists.newArrayList(iterables);
+        List<T> listT = Lists.newArrayList();
+        if (!listIterableT.isEmpty()) {
+            final Iterable<T> iterableT = Iterables.getOnlyElement(iterables);
+            // It's possible for the iterableT to contain only a null T, we don't
+            // want to include that.
+            final T next = iterableT.iterator().next();
+            if (next != null) {
+                listT = Lists.newArrayList(iterableT);
+            }
+        }
+        return listT;
+
+    }
+
+    private static void assertSameReads(final JavaRDD<GATKRead> reads,
+                                        final JavaPairRDD<GATKRead, ReferenceBases> readRefBases,
+                                        final JavaPairRDD<GATKRead, Iterable<Variant>> readiVariants) {
+
+        // We want to verify that the reads are teh same for each collection and that there are no duplicates
+        // in any collection.
+
+        // Collect all reads (with potential duplicates) in allReads. We expect there to be 3x the unique reads.
+        // Verify that there are 3x the distinct reads and the reads count for each collection match
+        // the distinct reads count.
+        // We should also check that the reference bases and variants are correctly paired with the reads. See
+        // issue (#873).
+        JavaRDD<GATKRead> refBasesReads = readRefBases.keys();
+        JavaRDD<GATKRead> variantsReads = readiVariants.keys();
+        JavaRDD<GATKRead> allReads = reads.union(refBasesReads).union(variantsReads);
+        long allReadsCount = allReads.count();
+        long distinctReads = allReads.distinct().count();
+
+        assert 3*distinctReads == allReadsCount;
+        assert distinctReads == reads.count();
+        assert distinctReads == refBasesReads.count();
+        assert distinctReads == variantsReads.count();
+    }
+
+}
+

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.google.api.services.genomics.model.Read;
+import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
+import org.apache.spark.serializer.KryoRegistrator;
+
+import java.util.Collections;
+
+/**
+ * GATKRegistrator registers Serializers for our project. We need a JsonSerializer for the Google Genomics classes
+ * and UnmodifiableCollectionsSerializer from a bug in the version of Kryo we're on.
+ */
+public class GATKRegistrator implements KryoRegistrator {
+    @SuppressWarnings("unchecked")
+    @Override
+    public void registerClasses(Kryo kryo) {
+
+        // JsonSerializer is needed for the Google Genomics classes like Read and Reference.
+        kryo.register(Read.class, new JsonSerializer<Read>());
+        // htsjdk.variant.variantcontext.CommonInfo has a Map<String, Object> that defaults to
+        // a Collections.unmodifiableMap. This can't be handled by the version of kryo used in Spark, it's fixed
+        // in newer versions (3.0.x), but we can't use those because of incompatibility with Spark. We just include the
+        // fix here.
+        // We are tracking this issue with (#874)
+        kryo.register(Collections.unmodifiableMap(Collections.EMPTY_MAP).getClass(), new UnmodifiableCollectionsSerializer());
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBases.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBases.java
@@ -1,0 +1,83 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
+import com.google.common.collect.Lists;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceDataflowSource;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceShard;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
+import scala.Tuple2;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * RefBasesForReads queries the Google Genomics API for reference bases overlapping all of the reads.
+ *
+ * step 1: key reads by reference shards
+ *
+ * |--------- shard 0 ----------|---------- shard 1 ----------|--------- shard 2 ----------|--------- shard 3 ----------|
+ *           |------ read a -----|                             |-- read b --|   |---- read c ----|
+ *
+ * step 2: group reads by the shard they start in
+ *
+ *  |--------- shard 0 ----------|
+ *            |------ read a -----|
+ *
+ *
+ *  |--------- shard 2 ----------|
+ *   |-- read b --|   |---- read c ----|
+ *
+ *  step 3: query the Google Genomics API for all bases needed for each shard
+ *
+
+ * |--- ref bases 1 ---|        |--------- ref bases 2 -----------|
+ * |------ read a -----|        |-- read b --|   |---- read c ----|
+ *
+ *  step 4: pair the ref bases needed for each read with the read
+ *
+ * |------ read a -----|        |-- read b --|   |---- read c ----|
+ * |-- ref bases 1a ---|        |ref bases 2b|   |- ref bases 2c -|
+ *
+ * or in code,
+ *  KV<read a, ref bases 1a>
+ *  KV<read b, ref bases 2b>
+ *  KV<read c, ref bases 2c>
+ *
+ * The reference bases paired with each read can be customized by passing in a reference window function
+ * inside the {@link ReferenceDataflowSource} argument to {@link #addBases}. See {@link org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions} for examples.
+ */
+public class JoinReadsWithRefBases {
+    public static JavaPairRDD<GATKRead, ReferenceBases> addBases(final ReferenceDataflowSource referenceDataflowSource,
+                                                                 final JavaRDD<GATKRead> reads) {
+        SerializableFunction<GATKRead, SimpleInterval> windowFunction = referenceDataflowSource.getReferenceWindowFunction();
+
+        JavaPairRDD<ReferenceShard, GATKRead> shardRead = reads.mapToPair(gatkRead -> {
+            ReferenceShard shard = ReferenceShard.getShardNumberFromInterval(windowFunction.apply(gatkRead));
+            return new Tuple2<>(shard, gatkRead);
+        });
+
+        JavaPairRDD<ReferenceShard, Iterable<GATKRead>> shardiRead = shardRead.groupByKey();
+
+        return shardiRead.flatMapToPair(in -> {
+            List<Tuple2<GATKRead, ReferenceBases>> out = Lists.newArrayList();
+            Iterable<GATKRead> iReads = in._2();
+
+            // Apply the reference window function to each read to produce a set of intervals representing
+            // the desired reference bases for each read.
+            final List<SimpleInterval> readWindows = StreamSupport.stream(iReads.spliterator(), false).map(read -> windowFunction.apply(read)).collect(Collectors.toList());
+
+            SimpleInterval interval = SimpleInterval.getSpanningInterval(readWindows);
+            ReferenceBases bases = referenceDataflowSource.getReferenceBases(null, interval);
+            for (GATKRead r : iReads) {
+                final ReferenceBases subset = bases.getSubset(windowFunction.apply(r));
+                out.add(new Tuple2<>(r, subset));
+            }
+            return out;
+        });
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariants.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariants.java
@@ -1,0 +1,119 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.common.collect.Lists;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.VariantShard;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.variant.Variant;
+import scala.Tuple2;
+
+import java.util.List;
+
+/**
+ * PairReadsAndVariants takes two RDDs (GATKRead and Variant) and returns an RDD with a
+ * (GATKRead,Iterable<Variant>) for every read and all the variants that overlap. We do this by first
+ * Making Tuple2s of GATKRead,Variant, which means that a read or variant may be present
+ * multiple times in the output. Also, there may be duplicate (GATKRead,Variant) pairs in the output.
+ * Currently, all reads must be mapped. We then dedup (distinct) then group by key.
+ *
+ * The function works by creating a single RDD of Tuple2 where GATKRead is the key and Variant is the value.
+ * We do this join by sharding both collections by "variant shard" and checking for overlap on each "shard."
+ *
+ * step 1: key reads and variants by shard
+ * |---- shard 0 -----|---- shard 1 -----|---- shard 2 -----|---- shard 3 -----|---- shard 4 -----|
+ *     |---------- read a ---------|               |----- read b ------|
+ *   |- variant 1 -|    |- variant 2 -|               |- variant 3 -|
+ *
+ * step 2: shard read and variant by variant shard
+ *                      |---- shard 0 -----|
+ *                          |---------- read a ---------|
+ *                        |- variant 1 -|
+ *
+ *
+ *                      |---- shard 1 -----|
+ *       |---------- read a ---------|
+ *                        |- variant 2 -|
+ *
+ *
+ *                      |---- shard 2 -----|
+ *                                |----- read b ------|
+ *                                   |- variant 3 -|
+ *
+ *                      |---- shard 3 -----|
+ *             |----- read b ------|
+ *                |- variant 3 -|
+ *
+ * step 3: pair reads and variants
+ * Tuple2<read a, variant 1> // from shard 0
+ * Tuple2<read a, variant 2> // from shard 1
+ * Tuple2<read b, variant 3> // from shard 2
+ * Tuple2<read b, variant 3> // from shard 3
+ *
+ * step 4: distinct and group by key
+ * Tuple2<read a, <variant 1, variant2>>
+ * Tuple2<read b, <variant 3>>
+ */
+public class JoinReadsWithVariants {
+    public static JavaPairRDD<GATKRead, Iterable<Variant>> join(
+            final JavaRDD<GATKRead> reads, final JavaRDD<Variant> variants) {
+
+        JavaPairRDD<VariantShard, GATKRead> readsWShards = pairReadsWithVariantShards(reads);
+
+        JavaPairRDD<VariantShard, Variant> variantsWShards = pairVariantsWithVariantShards(variants);
+
+        JavaPairRDD<GATKRead, Variant> allPairs = pairReadsWithVariants(readsWShards, variantsWShards);
+
+        return allPairs.distinct().groupByKey();
+    }
+
+    private static JavaPairRDD<VariantShard, GATKRead> pairReadsWithVariantShards(final JavaRDD<GATKRead> reads) {
+        return reads.flatMapToPair(gatkRead -> {
+            List<VariantShard> shards = VariantShard.getVariantShardsFromInterval(gatkRead);
+            List<Tuple2<VariantShard, GATKRead>> out = Lists.newArrayList();
+            for (VariantShard shard : shards) {
+                out.add(new Tuple2<>(shard, gatkRead));
+            }
+            return out;
+        });
+    }
+
+    private static JavaPairRDD<VariantShard, Variant> pairVariantsWithVariantShards(final JavaRDD<Variant> variants) {
+        return  variants.flatMapToPair(variant -> {
+            List<VariantShard> shards = VariantShard.getVariantShardsFromInterval(variant);
+            List<Tuple2<VariantShard, Variant>> out = Lists.newArrayList();
+            for (VariantShard shard : shards) {
+                out.add(new Tuple2<>(shard, variant));
+            }
+            return out;
+        });
+    }
+    private static JavaPairRDD<GATKRead, Variant> pairReadsWithVariants(final JavaPairRDD<VariantShard, GATKRead> readsWShards,
+                                                                        final  JavaPairRDD<VariantShard, Variant> variantsWShards) {
+        JavaPairRDD<VariantShard, Tuple2<Iterable<GATKRead>, Iterable<Variant>>> cogroup = readsWShards.cogroup(variantsWShards);
+
+        return cogroup.flatMapToPair(cogroupValue -> {
+            Iterable<GATKRead> iReads = cogroupValue._2()._1();
+            Iterable<Variant> iVariants = cogroupValue._2()._2();
+
+            List<Tuple2<GATKRead, Variant>> out = Lists.newArrayList();
+            // For every read, find every overlapping variant.
+            for (GATKRead r : iReads) {
+                boolean foundVariants = false;
+                SimpleInterval interval = new SimpleInterval(r);
+                for (Variant v : iVariants) {
+                    if (interval.overlaps(v)) {
+                        foundVariants = true;
+                        out.add(new Tuple2<>(r, v));
+                    }
+                }
+                // If no variants are found, we still want to output the read.
+                if (!foundVariants) {
+                    out.add(new Tuple2<>(r, null));
+                }
+            }
+            return out;
+        });
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/JsonSerializer.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/JsonSerializer.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.json.JsonFactory;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+
+import java.io.IOException;
+
+/**
+ * This is a simple JsonSerializer for use with Kryo. We need this because the Google
+ * Genomics classes don't work "out of the box" with Kryo.
+ * @param <T> The type of Json-like class.
+ */
+public class JsonSerializer<T> extends Serializer<T> {
+    private static final JsonFactory JSON_FACTORY = Utils.getDefaultJsonFactory();
+
+    @Override
+    public void write(Kryo kryo, Output output, T object) {
+        try {
+            output.writeString(JSON_FACTORY.toString(object));
+        } catch (IOException e) {
+            throw new GATKException("Json writing error:" + e);
+        }
+    }
+
+    @Override
+    public T read(Kryo kryo, Input input, Class<T> type) {
+        String s = input.readString();
+        try {
+            return JSON_FACTORY.fromString(s, type);
+        } catch (IOException e) {
+            throw new GATKException("Json reading error" + e);
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
@@ -1,0 +1,57 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgram;
+
+import java.io.Serializable;
+
+
+public abstract class SparkCommandLineProgram extends CommandLineProgram implements Serializable {
+    private static final long serialVersionUID = 1l;
+
+    @Argument(doc = "API Key for google cloud authentication",
+            shortName = "apiKey", fullName = "apiKey", optional=true)
+    protected String apiKey = null;
+
+
+    @Argument(fullName = "sparkMaster", doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.", optional = true)
+    protected String sparkMaster = "local[2]";
+
+    @Override
+    protected Object doWork() {
+        final JavaSparkContext ctx = buildContext();
+        runPipeline(ctx);
+        afterPipeline(ctx);
+
+        return null;
+    }
+
+    private JavaSparkContext buildContext() {
+        SparkConf sparkConf = new SparkConf().setAppName(getProgramName())
+                .setMaster(sparkMaster)
+                .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+                .set("spark.kryo.registrator", "org.broadinstitute.hellbender.engine.spark.GATKRegistrator")
+                .set("spark.kryoserializer.buffer.max", "512m");
+
+        return new JavaSparkContext(sparkConf);
+    }
+
+    // ---------------------------------------------------
+    // Functions meant for overriding
+
+    protected abstract void runPipeline(final JavaSparkContext ctx);
+
+    /**
+     * Override this to run code after the pipeline returns.
+     */
+    protected void afterPipeline(final JavaSparkContext ctx) {
+        ctx.stop();
+    }
+
+    protected abstract String getProgramName();
+    // ---------------------------------------------------
+    // Helpers
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSink.java
@@ -1,0 +1,140 @@
+package org.broadinstitute.hellbender.engine.spark.datasources;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import org.apache.commons.collections4.iterators.IteratorIterable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
+import org.seqdoop.hadoop_bam.KeyIgnoringBAMOutputFormat;
+import org.seqdoop.hadoop_bam.SAMRecordWritable;
+import scala.Tuple2;
+
+import java.io.IOException;
+
+/**
+ * ReadsSparkSink writes GATKReads to a file. This code lifts from the HadoopGenomics/Hadoop-BAM
+ * read writing code as well as from bigdatagenomics/adam.
+ */
+public class ReadsSparkSink {
+    // TODO: Make ReadsSparkSink able to also write sharded BAMs (#854).
+
+    // We need an output format for saveAsNewAPIHadoopFile.
+    public static class SparkBAMOutputFormat extends KeyIgnoringBAMOutputFormat<NullWritable> {
+        public static SAMFileHeader bamHeader = null;
+
+        public static void setHeader(final SAMFileHeader header) {
+            bamHeader = header;
+        }
+
+        @Override
+        public RecordWriter<NullWritable, SAMRecordWritable> getRecordWriter(TaskAttemptContext ctx) throws IOException {
+            setSAMHeader(bamHeader);
+            return super.getRecordWriter(ctx);
+        }
+    }
+
+    /**
+     * writeReads writes rddReads to outputFile with header as the file header.
+     * @param ctx the JavaSparkContext to write.
+     * @param outputFile path to the output bam.
+     * @param rddReads reads to write.
+     * @param header the header to put at the top of the files
+     * @param singleFile should the output be a single file or sharded, i.e., outputfile/part-r-00000, outputfile/part-r-00001...
+     */
+    public static void writeReads(
+            final JavaSparkContext ctx, final String outputFile, final JavaRDD<GATKRead> rddReads,
+            final SAMFileHeader header, boolean singleFile) throws IOException {
+        if (singleFile) {
+            writeReadsSingle(ctx, outputFile, rddReads, header);
+        } else {
+            writeReadsSharded(ctx, outputFile, rddReads, header);
+
+        }
+
+    }
+
+    private static void writeReadsSharded(
+            final JavaSparkContext ctx, final String outputFile, final JavaRDD<GATKRead> rddReads,
+                                         final SAMFileHeader header) {
+        // Set the header on the main thread.
+        SparkBAMOutputFormat.setHeader(header);
+        // MyOutputFormat is a static class, so we need to copy the header to each worker then call
+        final Broadcast<SAMFileHeader> broadcast = ctx.broadcast(header);
+        JavaRDD<GATKRead> gatkReadJavaRDD = rddReads.mapPartitions(gatkReadIterator -> {
+            SparkBAMOutputFormat.setHeader(broadcast.getValue());
+            return new IteratorIterable<>(gatkReadIterator);
+        });
+
+        // The expected format for writing is JavaPairRDD where the key is ignored and the value is a
+        // SAMRecordWritable. We use GATKRead as the key, so we can sort the reads before writing them to a file.
+        JavaPairRDD<GATKRead, SAMRecordWritable> rddSamRecordWriteable = gatkReadJavaRDD.mapToPair(gatkRead -> {
+            SAMRecord samRecord = gatkRead.convertToSAMRecord(broadcast.getValue());
+            SAMRecordWritable samRecordWritable = new SAMRecordWritable();
+            samRecordWritable.set(samRecord);
+            return new Tuple2<>(gatkRead, samRecordWritable);
+        });
+
+        rddSamRecordWriteable.saveAsNewAPIHadoopFile(outputFile, GATKRead.class, SAMRecordWritable.class, SparkBAMOutputFormat.class);
+    }
+
+    private static void writeReadsSingle(
+            final JavaSparkContext ctx, final String outputFile, final JavaRDD<GATKRead> rddReads,
+            final SAMFileHeader header) throws IOException {
+        // Set the header on the main thread.
+        SparkBAMOutputFormat.setHeader(header);
+
+        // The expected format for writing is JavaPairRDD where the key is ignored and the value is a
+        // SAMRecordWritable. We use GATKRead as the key, so we can sort the reads before writing them to a file.
+        JavaPairRDD<GATKRead, SAMRecordWritable> rddSamRecordWriteable = rddReads.mapToPair(gatkRead -> {
+            SAMRecord samRecord = gatkRead.convertToSAMRecord(header);
+            SAMRecordWritable samRecordWritable = new SAMRecordWritable();
+            samRecordWritable.set(samRecord);
+            return new Tuple2<>(gatkRead, samRecordWritable);
+        });
+
+        // coalesce is needed for writing to a single bam.
+        final JavaPairRDD<GATKRead, SAMRecordWritable> out =
+                rddSamRecordWriteable.sortByKey(new ReadCoordinateComparator(header)).coalesce(1);
+
+        // MyOutputFormat is a static class, so we need to copy the header to each worker then call
+        // MyOutputFormat.setHeader.
+        final Broadcast<SAMFileHeader> broadcast = ctx.broadcast(header);
+
+        final JavaPairRDD<GATKRead, SAMRecordWritable> finalOut = out.mapPartitions(tuple2Iterator -> {
+            SparkBAMOutputFormat.setHeader(broadcast.getValue());
+            return new IteratorIterable<>(tuple2Iterator);
+        }).mapToPair(t -> t);
+
+        finalOut.saveAsNewAPIHadoopFile(outputFile, GATKRead.class, SAMRecordWritable.class, SparkBAMOutputFormat.class);
+        RenameHadoopSingleShard(outputFile);
+    }
+
+    private static void RenameHadoopSingleShard(String outputFile) throws IOException {
+        // At this point, the file is in outputFile/part-r-0000. We move it out of that dir and into it's own well-named
+        // file.  This will not work if the last step was a merge (assuming saveAsNewAPIHadoopFile doesn't cause the
+        // last step to be a reduce).
+        Configuration conf = new Configuration();
+        FileSystem fs = FileSystem.get(conf);
+        String ouputParentDir = outputFile.substring(0, outputFile.lastIndexOf("/") + 1);
+        // First, check for the _SUCCESS file.
+        String successFile = outputFile + "/_SUCCESS";
+        if (!fs.exists(new Path(successFile))) {
+            throw new GATKException("unable to find " + successFile + " file");
+        }
+        String tmpPath = ouputParentDir + "tmp" + System.currentTimeMillis();
+        fs.rename(new Path(outputFile + "/part-r-00000"), new Path(tmpPath));
+        fs.delete(new Path(outputFile), true);
+        fs.rename(new Path(tmpPath), new Path(outputFile));
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSource.java
@@ -1,0 +1,112 @@
+package org.broadinstitute.hellbender.engine.spark.datasources;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.cloud.genomics.utils.ReadUtils;
+import htsjdk.samtools.SAMException;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.GoogleGenomicsReadToGATKReadAdapter;
+import org.seqdoop.hadoop_bam.AnySAMInputFormat;
+import org.seqdoop.hadoop_bam.SAMRecordWritable;
+import org.seqdoop.hadoop_bam.util.SAMHeaderReader;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Loads the reads from disk either serially (using samReaderFactory) or in parallel using Hadoop-BAM.
+ * The parallel code is a modified version of the example writing code from Hadoop-BAM.
+ */
+public class ReadsSparkSource {
+    private final JavaSparkContext ctx;
+    public ReadsSparkSource(JavaSparkContext ctx) {
+        this.ctx = ctx;
+    }
+
+
+    /**
+     * Loads Reads using Hadoop-BAM. For local files, bam must have the fully-qualified path,
+     * i.e., file:///path/to/bam.bam.
+     * @param bam file to load
+     * @param intervals intervals of reads to include.
+     * @return RDD of (Google Read-backed) GATKReads from the file.
+     */
+    public JavaRDD<GATKRead> getParallelReads(final String bam, final List<SimpleInterval> intervals) {
+        Configuration conf = new Configuration();
+        conf.set("mapred.max.split.size", "2097152");
+
+        JavaPairRDD<LongWritable, SAMRecordWritable> rdd2 = ctx.newAPIHadoopFile(
+                bam, AnySAMInputFormat.class, LongWritable.class, SAMRecordWritable.class,
+                conf);
+
+        return rdd2.map(v1 -> {
+            SAMRecord sam = v1._2().get();
+            if (samRecordOverlaps(sam, intervals)) {
+                try {
+                    // TODO: Try using the SAMRecord without the header (#875)
+                    Read read = ReadUtils.makeRead(sam);
+                    if (read == null) {
+                        throw new GATKException("null read, initial sam: " + sam);
+                    }
+                    return GoogleGenomicsReadToGATKReadAdapter.sparkReadAdapter(read);
+                } catch (SAMException e) {
+                    // Do nothing.
+                }
+            }
+            return null;
+
+        }).filter(v1 -> v1 != null);
+    }
+
+    /**
+     * Loads Reads using Hadoop-BAM. For local files, bam must have the fully-qualified path,
+     * i.e., file:///path/to/bam.bam. This excludes unmapped reads.
+     * @param bam file to load
+     * @return RDD of (SAMRecord-backed) GATKReads from the file.
+     */
+    public JavaRDD<GATKRead> getParallelReads(final String bam) {
+        final SAMFileHeader readsHeader = getHeader(ctx, bam);
+        List<SimpleInterval> intervals = IntervalUtils.getAllIntervalsForReference(readsHeader.getSequenceDictionary());
+        return getParallelReads(bam, intervals);
+    }
+
+    /**
+     * Loads the header using Hadoop-BAM.
+     * @param filePath path to the bam.
+     * @return the header for the bam.
+     */
+    public static SAMFileHeader getHeader(final JavaSparkContext ctx, final String filePath) {
+        final SAMFileHeader samFileHeader;
+        try {
+             samFileHeader = SAMHeaderReader.readSAMHeaderFrom(new Path(filePath), ctx.hadoopConfiguration());
+        } catch (IOException e) {
+            throw new GATKException("unable to loader header: " + e);
+        }
+        return samFileHeader;
+    }
+
+    /**
+     * Tests if a given SAMRecord overlaps any interval in a collection.
+     */
+    //TODO: remove this method when https://github.com/broadinstitute/hellbender/issues/559 is fixed
+    private static boolean samRecordOverlaps(final SAMRecord record, final List<SimpleInterval> intervals ) {
+        if (intervals == null || intervals.isEmpty()) {
+            return true;
+        }
+        for (SimpleInterval interval : intervals) {
+            if (interval.overlaps(record)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSource.java
@@ -1,0 +1,60 @@
+package org.broadinstitute.hellbender.engine.spark.datasources;
+
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.variant.Variant;
+import org.broadinstitute.hellbender.utils.variant.VariantContextVariantAdapter;
+import org.seqdoop.hadoop_bam.VCFInputFormat;
+import org.seqdoop.hadoop_bam.VariantContextWritable;
+
+import java.util.List;
+
+/**
+ * VariantsSparkSource loads Variants from files serially (using FeatureDataSource<VariantContext>) or in parallel
+ * using Hadoop-BAM.
+ */
+public final class VariantsSparkSource {
+    private final JavaSparkContext ctx;
+
+    public VariantsSparkSource(JavaSparkContext ctx) {
+        this.ctx = ctx;
+    }
+
+    /**
+     * Loads variants in parallel using Hadoop-BAM works for vcfs and bcfs.
+     * @param vcfs files to load variants from.
+     * @return JavaRDD<Variant> of variants from all files.
+     */
+    public JavaRDD<Variant> getParallelVariants(final List<String> vcfs) {
+        JavaRDD<Variant> rddVariants = ctx.emptyRDD();
+        for (String vcf : vcfs) {
+            JavaRDD<Variant> variants = getParallelVariants(vcf);
+            rddVariants.union(variants);
+        }
+        return rddVariants;
+    }
+
+    /**
+     * Loads variants in parallel using Hadoop-BAM for vcfs and bcfs.
+     * @param vcf file to load variants from.
+     * @return JavaRDD<Variant> of variants from all files.
+     */
+    public JavaRDD<Variant> getParallelVariants(final String vcf) {
+        JavaPairRDD<LongWritable, VariantContextWritable> rdd2 = ctx.newAPIHadoopFile(
+                vcf, VCFInputFormat.class, LongWritable.class, VariantContextWritable.class,
+                new Configuration());
+        return rdd2.map(v1 -> {
+            VariantContext variant = v1._2().get();
+            if (variant.getCommonInfo() == null) {
+                throw new GATKException("no common info");
+            }
+            return VariantContextVariantAdapter.sparkVariantAdapter(variant);
+        });
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -1,0 +1,133 @@
+package org.broadinstitute.hellbender.tools.spark.pipelines;
+
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.genomics.dataflow.utils.GCSOptions;
+import htsjdk.samtools.SAMFileHeader;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.broadcast.Broadcast;
+import org.broadinstitute.hellbender.cmdline.Argument;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
+import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalIntervalArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReadContextData;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceDataflowSource;
+import org.broadinstitute.hellbender.engine.spark.AddContextDataToReadSpark;
+import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
+import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSink;
+import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
+import org.broadinstitute.hellbender.engine.spark.datasources.VariantsSparkSource;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.tools.dataflow.pipelines.BaseRecalibratorDataflow;
+import org.broadinstitute.hellbender.tools.recalibration.RecalibrationTables;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.variant.Variant;
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.util.List;
+
+
+@CommandLineProgramProperties(
+        summary = "Takes aligned reads (likely from BWA) and runs MarkDuplicates and BQSR. The final result is analysis-ready reads.",
+        oneLineSummary = "Takes aligned reads (likely from BWA) and runs MarkDuplicates and BQSR. The final result is analysis-ready reads.",
+        usageExample = "Hellbender ReadsPipelineSpark -I single.bam -R referenceURL -BQSRKnownVariants variants.vcf -O file:///tmp/output.bam",
+        programGroup = SparkProgramGroup.class
+)
+
+/**
+ * ReadsPreprocessingPipeline is our standard pipeline that takes aligned reads (likely from BWA) and runs MarkDuplicates
+ * and BQSR. The final result is analysis-ready reads.
+ */
+public class ReadsPipelineSpark extends SparkCommandLineProgram {
+    private static final long serialVersionUID = 1L;
+
+    @Argument(doc = "uri for the input bam, either a local file path or a gs:// bucket path",
+            shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.INPUT_LONG_NAME,
+            optional = false)
+    protected String bam;
+
+    @Argument(doc = "the output bam", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
+            fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
+    protected String output;
+
+    @Argument(doc = "the reference name", shortName = StandardArgumentDefinitions.REFERENCE_SHORT_NAME,
+            fullName = StandardArgumentDefinitions.REFERENCE_LONG_NAME, optional = false)
+    protected String referenceURL;
+
+    @Argument(doc = "the known variants", shortName = "BQSRKnownVariants", fullName = "baseRecalibrationKnownVariants", optional = true)
+    protected List<String> baseRecalibrationKnownVariants;
+
+    @ArgumentCollection
+    protected IntervalArgumentCollection intervalArgumentCollection = new OptionalIntervalArgumentCollection();
+
+    @Override
+    protected void runPipeline(final JavaSparkContext ctx) {
+        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
+        SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam);
+        final List<SimpleInterval> intervals = intervalArgumentCollection.intervalsSpecified() ? intervalArgumentCollection.getIntervals(readsHeader.getSequenceDictionary())
+                : IntervalUtils.getAllIntervalsForReference(readsHeader.getSequenceDictionary());
+        JavaRDD<GATKRead> initialReads = readSource.getParallelReads(bam, intervals);
+
+        JavaRDD<GATKRead> markedReads = initialReads.map(new MarkDuplicatesStub());
+        VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
+        JavaRDD<Variant> bqsrKnownVariants = variantsSparkSource.getParallelVariants(baseRecalibrationKnownVariants);
+
+        GCSOptions options = PipelineOptionsFactory.as(GCSOptions.class);
+        options.setApiKey(apiKey);
+
+        final ReferenceDataflowSource referenceDataflowSource = new ReferenceDataflowSource(options, referenceURL, BaseRecalibratorDataflow.BQSR_REFERENCE_WINDOW_FUNCTION);
+
+        // TODO: Look into broadcasting the reference to all of the workers. This would make AddContextDataToReadSpark
+        // TODO: and ApplyBQSRStub simpler (#855).
+        JavaPairRDD<GATKRead, ReadContextData> rddReadContext = AddContextDataToReadSpark.add(markedReads, referenceDataflowSource, bqsrKnownVariants);
+
+        JavaRDD<RecalibrationTables> tables = rddReadContext.map(new BaseRecalibratorStub());
+        RecalibrationTables nestedIntegerArrays = null;
+        if (tables != null) {
+            nestedIntegerArrays = tables.collect().get(0);
+        }
+        final Broadcast<RecalibrationTables> broadcast = ctx.broadcast(nestedIntegerArrays);
+
+        // ApplyBQSRStub.
+        JavaRDD<GATKRead> finalReads = markedReads.map(v1 -> {
+            RecalibrationTables value = broadcast.getValue();
+            return v1;
+        });
+
+        try {
+            ReadsSparkSink.writeReads(ctx, output, finalReads, readsHeader, false);
+        } catch (IOException e) {
+            throw new GATKException("unable to write bam: " + e);
+        }
+    }
+
+    @Override
+    protected String getProgramName() {
+        return "ReadsPipelineSpark";
+    }
+
+    private static class MarkDuplicatesStub implements Function<GATKRead, GATKRead> {
+        private final static long serialVersionUID = 1L;
+        @Override
+        public GATKRead call(GATKRead v1) throws Exception {
+            return v1;
+        }
+    }
+
+    private static class BaseRecalibratorStub implements Function<Tuple2<GATKRead,ReadContextData>, RecalibrationTables> {
+        private final static long serialVersionUID = 1L;
+        @Override
+        public RecalibrationTables call(Tuple2<GATKRead, ReadContextData> v1) throws Exception {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GoogleGenomicsReadToGATKReadAdapter.java
@@ -47,6 +47,16 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead {
     }
 
     /**
+     * Produces a GoogleGenomicsReadToGATKReadAdapter with a 0L,0L UUID. Spark doesn't need the UUIDs
+     * and loading the reads twice (which can happen when caching is missing) prevents joining.
+     * @param genomicsRead Read to adapt
+     * @return adapted Read
+     */
+    public static GATKRead sparkReadAdapter(final Read genomicsRead) {
+        return new GoogleGenomicsReadToGATKReadAdapter(genomicsRead, new UUID(0L, 0L));
+    }
+
+    /**
      * Constructor that allows an explicit UUID to be passed in -- only meant
      * for internal use and test class use, which is why it's package protected.
      */
@@ -203,7 +213,7 @@ public final class GoogleGenomicsReadToGATKReadAdapter implements GATKRead {
     public int getUnclippedEnd() {
         final int end = getEnd();
         return end == ReadConstants.UNSET_POSITION ? ReadConstants.UNSET_POSITION :
-                                                     SAMUtils.getUnclippedEnd(getEnd(), getCigar());
+                SAMUtils.getUnclippedEnd(getEnd(), getCigar());
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadUtils.java
@@ -270,7 +270,7 @@ public final class ReadUtils {
         if ( read.isReverseStrand() ) {
             samFlags |= SAM_READ_STRAND_FLAG;
         }
-        if ( read.mateIsReverseStrand() ) {
+        if ( ! read.mateIsUnmapped() && read.mateIsReverseStrand() ) {
             samFlags |= SAM_MATE_STRAND_FLAG;
         }
         if ( read.isFirstOfPair() ) {

--- a/src/main/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/variant/VariantContextVariantAdapter.java
@@ -25,6 +25,23 @@ public class VariantContextVariantAdapter implements Variant, Serializable {
         this.uuid = uuid;
     }
 
+    VariantContextVariantAdapter(VariantContext vc, UUID uuid) {
+        this.variantContext = vc;
+        this.uuid = uuid;
+    }
+
+    /**
+     * Produces a VariantContextVariantAdapter with a 0L,0L UUID. Spark doesn't need the UUIDs
+     * and loading the variants twice (which can happen when caching is missing) prevents joining.
+     * @param vc VariantContext to adapt
+     * @return adapted VariantContext.
+     */
+    public static Variant sparkVariantAdapter(VariantContext vc) {
+        return new VariantContextVariantAdapter(vc, new UUID(0L, 0L));
+    }
+
+
+
     @Override
     public String getContig() { return variantContext.getContig(); }
     @Override

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsPreprocessingPipelineTestData.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/ReadsPreprocessingPipelineTestData.java
@@ -35,7 +35,8 @@ public class ReadsPreprocessingPipelineTestData {
     private final List<KV<VariantShard, Variant>> kvVariantShardVariant;
     private final List<KV<GATKRead, ReferenceBases>> kvReadsRefBases;
     private final List<KV<GATKRead, Variant>> kvReadVariant;
-    private final List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant;
+    private final List<KV<GATKRead, Iterable<Variant>>> kvReadiVariantBroken; // The dataflow version is currently broken (Issue #795).
+    private final List<KV<GATKRead, Iterable<Variant>>> kvReadiVariantFixed;
     private final List<KV<GATKRead, ReadContextData>> kvReadContextData;
 
 
@@ -102,8 +103,8 @@ public class ReadsPreprocessingPipelineTestData {
                 new SkeletonVariant(new SimpleInterval("1", 210, 220), false, true, new UUID(1002, 1002)),
                 new SkeletonVariant(new SimpleInterval("1", ReferenceShard.REFERENCE_SHARD_SIZE,
                         ReferenceShard.REFERENCE_SHARD_SIZE), true, false, new UUID(1003, 1003)),
-                new SkeletonVariant(new SimpleInterval("1", 3*ReferenceShard.REFERENCE_SHARD_SIZE - 2,
-                        3*ReferenceShard.REFERENCE_SHARD_SIZE + 2), false, true, new UUID(1004, 1004)),
+                new SkeletonVariant(new SimpleInterval("1", 3 * ReferenceShard.REFERENCE_SHARD_SIZE - 2,
+                        3 * ReferenceShard.REFERENCE_SHARD_SIZE + 2), false, true, new UUID(1004, 1004)),
                 new SkeletonVariant(new SimpleInterval("2", ReferenceShard.REFERENCE_SHARD_SIZE,
                         ReferenceShard.REFERENCE_SHARD_SIZE), false, true, new UUID(1005, 1005))
         );
@@ -112,8 +113,8 @@ public class ReadsPreprocessingPipelineTestData {
                 KV.of(new VariantShard(0, "1"), reads.get(0)),
                 KV.of(new VariantShard(0, "1"), reads.get(1)),
                 KV.of(new VariantShard(shardRatio, "1"), reads.get(2)),
-                KV.of(new VariantShard(3*shardRatio - 1, "1"), reads.get(3)),     // The second to last read spans
-                KV.of(new VariantShard(3*shardRatio, "1"), reads.get(3)),     // two shards.
+                KV.of(new VariantShard(3 * shardRatio - 1, "1"), reads.get(3)),     // The second to last read spans
+                KV.of(new VariantShard(3 * shardRatio, "1"), reads.get(3)),     // two shards.
                 KV.of(new VariantShard(shardRatio, "2"), reads.get(4))
         );
 
@@ -125,6 +126,7 @@ public class ReadsPreprocessingPipelineTestData {
                 KV.of(new VariantShard(3*shardRatio, "1"), variants.get(3)),       // two shards.
                 KV.of(new VariantShard(shardRatio, "2"), variants.get(4))
         );
+
         kvReadVariant = Arrays.asList(
                 KV.of(reads.get(1), variants.get(0)),
                 KV.of(reads.get(1), variants.get(1)),
@@ -133,25 +135,37 @@ public class ReadsPreprocessingPipelineTestData {
                 KV.of(reads.get(3), variants.get(3)),     // why there are two of them (2,3).
                 KV.of(reads.get(4), variants.get(4))
         );
+        final KV<GATKRead, Variant> readNullVariant = KV.of(reads.get(0), null);
 
         Iterable<Variant> variant10 = Lists.newArrayList(kvReadVariant.get(1).getValue(), kvReadVariant.get(0).getValue());
         Iterable<Variant> variant2 = Lists.newArrayList(kvReadVariant.get(2).getValue());
         Iterable<Variant> variant3 = Lists.newArrayList(kvReadVariant.get(3).getValue());
         Iterable<Variant> variant4 = Lists.newArrayList(kvReadVariant.get(5).getValue());
+        Iterable<Variant> nullVariant = Lists.newArrayList(readNullVariant.getValue());
 
-        kvReadiVariant = Arrays.asList(
+        // The dataflow version is currently broken (Issue #795). This is only an issue at this point.
+        // The bug is effectively masked at the point of the larger transforms.
+        kvReadiVariantBroken = Arrays.asList(
                 KV.of(kvReadVariant.get(0).getKey(), variant10),
                 KV.of(kvReadVariant.get(2).getKey(), variant2),
                 KV.of(kvReadVariant.get(3).getKey(), variant3),
                 KV.of(kvReadVariant.get(5).getKey(), variant4)
         );
 
+        kvReadiVariantFixed = Arrays.asList(
+                KV.of(kvReadVariant.get(0).getKey(), variant10),
+                KV.of(kvReadVariant.get(2).getKey(), variant2),
+                KV.of(kvReadVariant.get(3).getKey(), variant3),
+                KV.of(kvReadVariant.get(5).getKey(), variant4),
+                KV.of(reads.get(0), nullVariant)
+        );
+
         kvReadContextData = Arrays.asList(
                 KV.of(kvReadsRefBases.get(0).getKey(), new ReadContextData(kvReadsRefBases.get(0).getValue(), Lists.newArrayList())),
-                KV.of(kvReadsRefBases.get(1).getKey(), new ReadContextData(kvReadsRefBases.get(1).getValue(), kvReadiVariant.get(0).getValue())),
-                KV.of(kvReadsRefBases.get(2).getKey(), new ReadContextData(kvReadsRefBases.get(2).getValue(), kvReadiVariant.get(1).getValue())),
-                KV.of(kvReadsRefBases.get(3).getKey(), new ReadContextData(kvReadsRefBases.get(3).getValue(), kvReadiVariant.get(2).getValue())),
-                KV.of(kvReadsRefBases.get(4).getKey(), new ReadContextData(kvReadsRefBases.get(4).getValue(), kvReadiVariant.get(3).getValue()))
+                KV.of(kvReadsRefBases.get(1).getKey(), new ReadContextData(kvReadsRefBases.get(1).getValue(), kvReadiVariantBroken.get(0).getValue())),
+                KV.of(kvReadsRefBases.get(2).getKey(), new ReadContextData(kvReadsRefBases.get(2).getValue(), kvReadiVariantBroken.get(1).getValue())),
+                KV.of(kvReadsRefBases.get(3).getKey(), new ReadContextData(kvReadsRefBases.get(3).getValue(), kvReadiVariantBroken.get(2).getValue())),
+                KV.of(kvReadsRefBases.get(4).getKey(), new ReadContextData(kvReadsRefBases.get(4).getValue(), kvReadiVariantBroken.get(3).getValue()))
         );
     }
 
@@ -251,8 +265,11 @@ public class ReadsPreprocessingPipelineTestData {
         return kvReadsRefBases;
     }
 
-    public List<KV<GATKRead, Iterable<Variant>>> getKvReadiVariant() {
-        return kvReadiVariant;
+    /**
+     * The dataflow version is currently broken (Issue #795).
+     */
+    public List<KV<GATKRead, Iterable<Variant>>> getKvReadiVariantBroken() {
+        return kvReadiVariantBroken;
     }
 
     public List<KV<GATKRead, Variant>> getKvReadVariant() {
@@ -280,5 +297,9 @@ public class ReadsPreprocessingPipelineTestData {
     public static void verifyDivisibilityWithRefShard() {
         // We want the ratio between the two shard types to be an int so we can use them more easily for testing.
         Assert.assertEquals(Math.floorMod(ReferenceShard.REFERENCE_SHARD_SIZE, VariantShard.VARIANT_SHARDSIZE), 0);
+    }
+
+    public List<KV<GATKRead, Iterable<Variant>>> getKvReadiVariantFixed() {
+        return kvReadiVariantFixed;
     }
 }

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/RemoveDuplicateReadVariantPairsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/RemoveDuplicateReadVariantPairsUnitTest.java
@@ -66,7 +66,9 @@ public final class RemoveDuplicateReadVariantPairsUnitTest extends BaseTest {
                     KV.of(dupes.get(5).getKey().getUUID(), variant5)
             );
 
-            List<KV<GATKRead, Iterable<Variant>>> finalExpected = testData.getKvReadiVariant();
+            // The 'final' results are currently wrong because of Issue #795. Keeping current
+            // functionality until #795 is resolved.
+            List<KV<GATKRead, Iterable<Variant>>> finalExpected = testData.getKvReadiVariantBroken();
             data[i] = new Object[]{dupes, kvUUIDUUID, kvUUIDiUUID, kvUUIDiVariant, finalExpected};
         }
         return data;

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/AddContextDataToReadUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/AddContextDataToReadUnitTest.java
@@ -50,7 +50,7 @@ public final class AddContextDataToReadUnitTest extends BaseTest {
             List<KV<GATKRead, ReferenceBases>> kvReadRefBases = testData.getKvReadsRefBases();
             List<SimpleInterval> intervals = testData.getAllIntervals();
             List<Variant> variantList = testData.getVariants();
-            List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant = testData.getKvReadiVariant();
+            List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant = testData.getKvReadiVariantBroken();
             List<KV<GATKRead, ReadContextData>> kvReadContextData = testData.getKvReadContextData();
             data[i] = new Object[]{reads, variantList, kvReadRefBases, kvReadContextData, intervals, kvReadiVariant};
         }

--- a/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/KeyVariantsByReadUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/dataflow/transforms/composite/KeyVariantsByReadUnitTest.java
@@ -35,7 +35,7 @@ public final class KeyVariantsByReadUnitTest extends BaseTest {
 
             List<GATKRead> reads = testData.getReads();
             List<Variant> variantList = testData.getVariants();
-            List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant = testData.getKvReadiVariant();
+            List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant = testData.getKvReadiVariantBroken();
 
             data[i] = new Object[]{reads, variantList, kvReadiVariant};
         }

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
@@ -1,0 +1,83 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.collect.Lists;
+import htsjdk.samtools.SAMRecord;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReadContextData;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceDataflowSource;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.test.FakeReferenceSource;
+import org.broadinstitute.hellbender.utils.variant.Variant;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+public class AddContextDataToReadSparkUnitTest extends BaseTest {
+    @DataProvider(name = "bases")
+    public Object[][] bases() {
+        Object[][] data = new Object[2][];
+        List<Class<?>> classes = Arrays.asList(Read.class, SAMRecord.class);
+        for (int i = 0; i < classes.size(); ++i) {
+            Class<?> c = classes.get(i);
+            ReadsPreprocessingPipelineTestData testData = new ReadsPreprocessingPipelineTestData(c);
+
+            List<GATKRead> reads = testData.getReads();
+            List<SimpleInterval> intervals = testData.getAllIntervals();
+            List<Variant> variantList = testData.getVariants();
+            List<KV<GATKRead, ReadContextData>> expectedReadContextData = testData.getKvReadContextData();
+            data[i] = new Object[]{reads, variantList, expectedReadContextData, intervals};
+        }
+        return data;
+    }
+
+    @Test(dataProvider = "bases")
+    public void addContextDataTest(List<GATKRead> reads, List<Variant> variantList,
+                                   List<KV<GATKRead, ReadContextData>> expectedReadContextData,
+                                   List<SimpleInterval> intervals) throws IOException {
+        JavaSparkContext ctx = SparkTestUtils.getTestContext();
+
+        JavaRDD<GATKRead> rddReads = ctx.parallelize(reads);
+        JavaRDD<Variant> rddVariants = ctx.parallelize(variantList);
+
+        ReferenceDataflowSource mockSource = mock(ReferenceDataflowSource.class, withSettings().serializable());
+        for (SimpleInterval i : intervals) {
+            when(mockSource.getReferenceBases(any(PipelineOptions.class), eq(i))).thenReturn(FakeReferenceSource.bases(i));
+        }
+        when(mockSource.getReferenceWindowFunction()).thenReturn(RefWindowFunctions.IDENTITY_FUNCTION);
+
+        JavaPairRDD<GATKRead, ReadContextData> rddActual = AddContextDataToReadSpark.add(rddReads, mockSource, rddVariants);
+        Map<GATKRead, ReadContextData> actual = rddActual.collectAsMap();
+
+        Assert.assertEquals(actual.size(), expectedReadContextData.size());
+        for (KV<GATKRead, ReadContextData> kv : expectedReadContextData) {
+            ReadContextData readContextData = actual.get(kv.getKey());
+            Assert.assertNotNull(readContextData);
+            Assert.assertTrue(CollectionUtils.isEqualCollection(Lists.newArrayList(readContextData.getOverlappingVariants()),
+                    Lists.newArrayList(kv.getValue().getOverlappingVariants())));
+            Assert.assertEquals(readContextData.getOverlappingReferenceBases(), kv.getValue().getOverlappingReferenceBases());
+        }
+
+        ctx.close();
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBasesSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBasesSparkUnitTest.java
@@ -1,0 +1,72 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.values.KV;
+import htsjdk.samtools.SAMRecord;
+import junit.framework.TestCase;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceDataflowSource;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
+import org.broadinstitute.hellbender.utils.test.FakeReferenceSource;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+public class JoinReadsWithRefBasesSparkUnitTest extends TestCase {
+    @DataProvider(name = "bases")
+    public Object[][] bases(){
+        Object[][] data = new Object[2][];
+        List<Class<?>> classes = Arrays.asList(Read.class, SAMRecord.class);
+        for (int i = 0; i < classes.size(); ++i) {
+            Class<?> c = classes.get(i);
+            ReadsPreprocessingPipelineTestData testData = new ReadsPreprocessingPipelineTestData(c);
+
+            List<GATKRead> reads = testData.getReads();
+            List<SimpleInterval> intervals = testData.getAllIntervals();
+            List<KV<GATKRead, ReferenceBases>> kvReadRefBases = testData.getKvReadsRefBases();
+            data[i] = new Object[]{reads, kvReadRefBases, intervals};
+        }
+        return data;
+    }
+
+    @Test(dataProvider = "bases")
+    public void refBasesTest(List<GATKRead> reads, List<KV<GATKRead, ReferenceBases>> kvReadRefBases,
+                             List<SimpleInterval> intervals) throws IOException {
+        JavaSparkContext ctx = SparkTestUtils.getTestContext();
+
+        JavaRDD<GATKRead> rddReads = ctx.parallelize(reads);
+
+        ReferenceDataflowSource mockSource = mock(ReferenceDataflowSource.class, withSettings().serializable());
+        for (SimpleInterval i : intervals) {
+            when(mockSource.getReferenceBases(any(PipelineOptions.class), eq(i))).thenReturn(FakeReferenceSource.bases(i));
+        }
+        when(mockSource.getReferenceWindowFunction()).thenReturn(RefWindowFunctions.IDENTITY_FUNCTION);
+
+        JavaPairRDD<GATKRead, ReferenceBases> rddResult = JoinReadsWithRefBases.addBases(mockSource, rddReads);
+        Map<GATKRead, ReferenceBases> result = rddResult.collectAsMap();
+
+        for (KV<GATKRead, ReferenceBases> kv : kvReadRefBases) {
+            ReferenceBases referenceBases = result.get(kv.getKey());
+            Assert.assertNotNull(referenceBases);
+            Assert.assertEquals(kv.getValue(),referenceBases);
+        }
+        ctx.close();
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariantsSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariantsSparkUnitTest.java
@@ -1,0 +1,61 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import htsjdk.samtools.SAMRecord;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData;
+import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
+import org.broadinstitute.hellbender.engine.spark.datasources.VariantsSparkSource;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.variant.Variant;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+public class JoinReadsWithVariantsSparkUnitTest extends BaseTest {
+    @DataProvider(name = "pairedReadsAndVariants")
+    public Object[][] pairedReadsAndVariants(){
+        Object[][] data = new Object[2][];
+        List<Class<?>> classes = Arrays.asList(Read.class, SAMRecord.class);
+        for (int i = 0; i < classes.size(); ++i) {
+            Class<?> c = classes.get(i);
+            ReadsPreprocessingPipelineTestData testData = new ReadsPreprocessingPipelineTestData(c);
+
+            List<GATKRead> reads = testData.getReads();
+            List<Variant> variantList = testData.getVariants();
+            List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant = testData.getKvReadiVariantFixed();
+            data[i] = new Object[]{reads, variantList, kvReadiVariant};
+        }
+        return data;
+    }
+
+    @Test(dataProvider = "pairedReadsAndVariants")
+    public void pairReadsAndVariantsTest(List<GATKRead> reads, List<Variant> variantList, List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant) {
+        JavaSparkContext ctx = SparkTestUtils.getTestContext();
+
+        JavaRDD<GATKRead> rddReads = ctx.parallelize(reads);
+        JavaRDD<Variant> rddVariants = ctx.parallelize(variantList);
+        JavaPairRDD<GATKRead, Iterable<Variant>> actual = JoinReadsWithVariants.join(rddReads, rddVariants);
+        Map<GATKRead, Iterable<Variant>> gatkReadIterableMap = actual.collectAsMap();
+
+        Assert.assertEquals(gatkReadIterableMap.size(), kvReadiVariant.size());
+        for (KV<GATKRead, Iterable<Variant>> kv : kvReadiVariant) {
+            List<Variant> variants = Lists.newArrayList(gatkReadIterableMap.get(kv.getKey()));
+            Assert.assertTrue(!variants.isEmpty());
+            HashSet<Variant> hashVariants = new HashSet<>(variants);
+            final Iterable<Variant> iVariants = kv.getValue();
+            HashSet<Variant> expectedHashVariants = Sets.newHashSet(iVariants);
+            Assert.assertEquals(hashVariants, expectedHashVariants);
+        }
+        ctx.close();
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkTestUtils.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SparkTestUtils.java
@@ -1,0 +1,18 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+
+public class SparkTestUtils {
+    /**
+     * getTestContext creates a (Java) SparkContext and uses the in-memory master and (2) workers.
+     * It also does the other stuff we expect (Kryo + kryo registrator). No prerequisites for use.
+     * @return new JavaSparkContext.
+     */
+    public static JavaSparkContext getTestContext() {
+        SparkConf sparkConf = new SparkConf().setAppName("TestContext")
+                .setMaster("local[2]").set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+                .set("spark.kryo.registrator", "org.broadinstitute.hellbender.engine.spark.GATKRegistrator");
+        return new JavaSparkContext(sparkConf);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -1,0 +1,57 @@
+package org.broadinstitute.hellbender.engine.spark.datasources;
+
+
+import htsjdk.samtools.SAMFileHeader;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.spark.SparkTestUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+
+public class ReadsSparkSinkUnitTest extends BaseTest {
+    @DataProvider(name = "loadReads")
+    public Object[][] loadReads() {
+        String dir = "src/test/resources/org/broadinstitute/hellbender/tools/BQSR/";
+        return new Object[][]{
+                {dir + "HiSeq.1mb.1RG.2k_lines.alternate.bam", "ReadsSparkSinkUnitTest1.bam"},
+                {dir + "expected.HiSeq.1mb.1RG.2k_lines.bqsr.DIQ.alternate.bam", "ReadsSparkSinkUnitTest2.bam"},
+        };
+    }
+
+    @Test(dataProvider = "loadReads")
+    public void readsSinkTest(String inputBam, String outputFile) throws IOException {
+        new File(outputFile).deleteOnExit();
+        JavaSparkContext ctx = SparkTestUtils.getTestContext();
+
+        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
+        JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam);
+        SAMFileHeader header = ReadsSparkSource.getHeader(ctx, inputBam);
+
+        ReadsSparkSink.writeReads(ctx, outputFile, rddParallelReads, header, true);
+
+        JavaRDD<GATKRead> rddParallelReads2 = readSource.getParallelReads(outputFile);
+        final List<GATKRead> writtenReads = rddParallelReads2.collect();
+
+        final ReadCoordinateComparator comparator = new ReadCoordinateComparator(header);
+        // Assert that the reads are sorted.
+        final int size = writtenReads.size();
+        for (int i = 0; i < size-1; ++i) {
+            final GATKRead smaller = writtenReads.get(i);
+            final GATKRead larger = writtenReads.get(i + 1);
+            Assert.assertTrue(comparator.compare(smaller, larger) < 0);
+        }
+        Assert.assertEquals(rddParallelReads.count(), rddParallelReads2.count());
+
+        ctx.stop();
+    }
+
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
@@ -1,0 +1,65 @@
+package org.broadinstitute.hellbender.engine.spark.datasources;
+
+import com.google.common.collect.Lists;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.ReadsDataSource;
+import org.broadinstitute.hellbender.engine.spark.SparkTestUtils;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+
+public class ReadsSparkSourceUnitTest extends BaseTest {
+    @DataProvider(name = "loadReads")
+    public Object[][] loadReads() {
+        String dir = "src/test/resources/org/broadinstitute/hellbender/tools/BQSR/";
+        return new Object[][]{
+                {dir + "HiSeq.1mb.1RG.2k_lines.alternate.bam"},
+                {dir + "expected.HiSeq.1mb.1RG.2k_lines.bqsr.DIQ.alternate.bam"},
+        };
+    }
+
+    @Test(dataProvider = "loadReads")
+    public void readsSparkSourceTest(String bam) {
+        JavaSparkContext ctx = SparkTestUtils.getTestContext();
+
+        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
+        JavaRDD<GATKRead> rddSerialReads = getSerialReads(ctx, bam);
+        JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(bam);
+
+        List<GATKRead> serialReads = rddSerialReads.collect();
+        List<GATKRead> parallelReads = rddParallelReads.collect();
+        Assert.assertEquals(serialReads.size(), parallelReads.size());
+
+        ctx.stop();
+    }
+
+    /**
+     * Loads Reads using samReaderFactory, then calling ctx.parallelize.
+     * @param bam file to load
+     * @return RDD of (SAMRecord-backed) GATKReads from the file.
+     */
+    public JavaRDD<GATKRead> getSerialReads(final JavaSparkContext ctx, final String bam) {
+        final SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam);
+        List<SimpleInterval> intervals = IntervalUtils.getAllIntervalsForReference(readsHeader.getSequenceDictionary());
+        final SamReaderFactory samReaderFactory = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT);
+
+        ReadsDataSource bam2 = new ReadsDataSource(new File(bam), samReaderFactory);
+        bam2.setIntervalsForTraversal(intervals);
+        List<GATKRead> records = Lists.newArrayList();
+        for ( GATKRead read : bam2 ) {
+            records.add(read);
+        }
+        return ctx.parallelize(records);
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSourceUnitTest.java
@@ -1,0 +1,80 @@
+package org.broadinstitute.hellbender.engine.spark.datasources;
+
+import com.beust.jcommander.internal.Lists;
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.FeatureCodec;
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.engine.FeatureDataSource;
+import org.broadinstitute.hellbender.engine.FeatureManager;
+import org.broadinstitute.hellbender.engine.spark.SparkTestUtils;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
+import org.broadinstitute.hellbender.utils.variant.Variant;
+import org.broadinstitute.hellbender.utils.variant.VariantContextVariantAdapter;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class VariantsSparkSourceUnitTest extends BaseTest {
+    @DataProvider(name = "loadVariants")
+    public Object[][] loadVariants() {
+        return new Object[][]{
+                {hg19_chr1_1M_dbSNP},
+                {hg19_chr1_1M_dbSNP_modified},
+        };
+    }
+
+    @Test(dataProvider = "loadVariants")
+    public void pairReadsAndVariantsTest(String vcf) {
+        JavaSparkContext ctx = SparkTestUtils.getTestContext();
+
+        VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
+        JavaRDD<Variant> rddSerialVariants =
+                getSerialVariants(ctx, vcf);
+        JavaRDD<Variant> rddParallelVariants =
+                variantsSparkSource.getParallelVariants(vcf);
+
+        List<Variant> serialVariants = rddSerialVariants.collect();
+        List<Variant> parallelVariants = rddParallelVariants.collect();
+        Assert.assertEquals(parallelVariants, serialVariants);
+
+        ctx.stop();
+    }
+
+    /**
+     * Loads variants using FeatureDataSource<VariantContext>.
+     * @param vcf file to load
+     * @return JavaRDD of Variants.
+     */
+    static JavaRDD<Variant> getSerialVariants(final JavaSparkContext ctx, final String vcf) {
+        List<Variant> records = Lists.newArrayList();
+        try ( final FeatureDataSource<VariantContext> dataSource = new FeatureDataSource<>(new File(vcf), getCodecForVariantSource(vcf), null, 0) ) {
+            records.addAll(wrapQueryResults(dataSource.iterator()));
+        }
+        return ctx.parallelize(records);
+    }
+
+    @SuppressWarnings("unchecked")
+    static FeatureCodec<VariantContext, ?> getCodecForVariantSource( final String variantSource ) {
+        final FeatureCodec<? extends Feature, ?> codec = FeatureManager.getCodecForFile(new File(variantSource));
+        if ( !VariantContext.class.isAssignableFrom(codec.getFeatureType()) ) {
+            throw new UserException(variantSource + " is not in a format that produces VariantContexts");
+        }
+        return (FeatureCodec<VariantContext, ?>)codec;
+    }
+
+    static List<Variant> wrapQueryResults( final Iterator<VariantContext> queryResults ) {
+        final List<Variant> wrappedResults = new ArrayList<>();
+        while ( queryResults.hasNext() ) {
+            wrappedResults.add(VariantContextVariantAdapter.sparkVariantAdapter(queryResults.next()));
+        }
+        return wrappedResults;
+    }
+}


### PR DESCRIPTION
A few things worth mentioning.

1) This skeleton is mostly a direct port of the existing Dataflow pipeline.
2) I had to modify some test data because there is a (masked) bug in the Dataflow code, see #795.
3) Serialization was a slight pain and I had to bump the kryo version to the latest 2.x, as well as add two custom Serializers. If there's a cleaner way to handle any of that I'm all ears.
4) I'm using Hadoop-bam for reading and writing reads and variants.
5) There are unit tests for all code except for the skeleton itself. I've run it on a cluster on my machine successfully, but haven't written the tests (which will take a little while to design and get right).
