### PR TITLE
Hiding apiKey from output

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/CommandLineProgramTest.java
@@ -32,7 +32,7 @@ public abstract class CommandLineProgramTest extends BaseTest {
      * For testing support.  Given a name of a Main CommandLineProgram and it's arguments, builds the arguments appropriate for calling the
      * program through Main
      *
-     * @param args
+     * @param args List<String> of command line arguments
      * @return String[] of command line arguments
      */
     public String[] makeCommandLineArgs(final List<String> args) {

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/Argument.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/Argument.java
@@ -72,5 +72,11 @@ public @interface Argument {
      */
     boolean special() default false;
 
+    /**
+     * Are the contents of this argument private and should be kept out of logs.
+     * Examples of sensitive arguments are encryption and api keys.
+     */
+    boolean sensitive() default false;
+
 
 }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineParser.java
@@ -787,6 +787,7 @@ public final class CommandLineParser {
         final Set<String> mutuallyExclusive;
         final Object parent;
         final boolean isSpecial;
+        final boolean isSensitive;
 
         public ArgumentDefinition(final Field field, final Argument annotation, final Object parent){
             this.field = field;
@@ -799,6 +800,7 @@ public final class CommandLineParser {
 
             this.isCommon = annotation.common();
             this.isSpecial = annotation.special();
+            this.isSensitive = annotation.sensitive();
 
             this.mutuallyExclusive = new HashSet<>(Arrays.asList(annotation.mutex()));
 
@@ -870,7 +872,11 @@ public final class CommandLineParser {
          */
         private String prettyNameValue(Object value) {
             if(value != null){
-                return String.format("--%s %s", getLongName(), value);
+                if (isSensitive){
+                    return String.format("--%s ***********", getLongName());
+                } else {
+                    return String.format("--%s %s", getLongName(), value);
+                }
             }
             return "";
         }

--- a/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/cmdline/CommandLineProgram.java
@@ -1,24 +1,23 @@
 package org.broadinstitute.hellbender.cmdline;
 
-import htsjdk.samtools.util.Log;
-import org.broadinstitute.hellbender.utils.LoggingUtils;
-
 import htsjdk.samtools.metrics.Header;
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.metrics.StringHeader;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.broadinstitute.hellbender.utils.LoggingUtils;
 
 import java.io.File;
 import java.net.InetAddress;
 import java.text.DecimalFormat;
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/DataflowCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/DataflowCommandLineProgram.java
@@ -78,7 +78,7 @@ public abstract class DataflowCommandLineProgram extends CommandLineProgram impl
     protected File clientSecret;
 
     @Argument(doc = "API Key for google cloud authentication",
-            shortName = "apiKey", fullName = "apiKey", optional=true, mutex={"client_secret"})
+            shortName = "apiKey", fullName = "apiKey", optional=true, mutex={"client_secret"}, sensitive = true)
     protected String apiKey = null;
 
     @Argument(doc = "Number of Dataflow workers to use (or auto if unset).",

--- a/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/test/BaseTest.java
@@ -86,7 +86,7 @@ public abstract class BaseTest {
      *  name of the google cloud project that stores the data and will run the code, probably broad-dsde-dev
      *  @return HELLBENDER_TEST_PROJECT env. var if defined, throws otherwise.
      */
-    public String getDataflowTestProject() {
+    public static String getDataflowTestProject() {
         return getNonNullEnvironmentVariable("HELLBENDER_TEST_PROJECT");
     }
 
@@ -94,7 +94,7 @@ public abstract class BaseTest {
      * API key for HELLBENDER_TEST_PROJECT
      * @return HELLBENDER_TEST_APIKEY env. var if defined, throws otherwise.
      */
-    public String getDataflowTestApiKey() {
+    public static String getDataflowTestApiKey() {
         return getNonNullEnvironmentVariable("HELLBENDER_TEST_APIKEY");
     }
 
@@ -102,7 +102,7 @@ public abstract class BaseTest {
      * A writeable folder on the project's GCS, where java files will be staged for execution
      * @return HELLBENDER_TEST_STAGING env. var if defined, throws otherwise.
      */
-    public String getDataflowTestStaging() {
+    public static String getDataflowTestStaging() {
         return getNonNullEnvironmentVariable("HELLBENDER_TEST_STAGING");
     }
 
@@ -110,11 +110,11 @@ public abstract class BaseTest {
      *  A GCS path where the test inputs are stored
      *  @return HELLBENDER_TEST_INPUTS env. var if defined, throws otherwise.
      */
-    public String getDataflowTestInputPath() {
+    public static String getDataflowTestInputPath() {
         return getNonNullEnvironmentVariable("HELLBENDER_TEST_INPUTS");
     }
 
-    private String getNonNullEnvironmentVariable(String envVarName) {
+    private static String getNonNullEnvironmentVariable(String envVarName) {
         String value = System.getenv(envVarName);
         if (null == value) {
             throw new UserException("For this test, please define environment variable \""+envVarName+"\"");
@@ -128,7 +128,7 @@ public abstract class BaseTest {
      *         {@link #getDataflowTestProject}, and {@link #getDataflowTestStaging}, suitable
      *         for use in a hellbender command line.
      */
-    public List<String> getStandardDataflowArgumentsFromEnvironment() {
+    public static List<String> getStandardDataflowArgumentsFromEnvironment() {
         return Arrays.asList("--apiKey", getDataflowTestApiKey(),
                              "--project", getDataflowTestProject(),
                              "--staging", getDataflowTestStaging());
@@ -142,7 +142,7 @@ public abstract class BaseTest {
      *
      * @return a PipelineOptions object containing our API key
      */
-    public PipelineOptions getAuthenticatedPipelineOptions() {
+    public static PipelineOptions getAuthenticatedPipelineOptions() {
         final GCSOptions popts = PipelineOptionsFactory.as(GCSOptions.class);
         popts.setApiKey(getDataflowTestApiKey());
         return popts;

--- a/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/cmdline/CommandLineParserTest.java
@@ -202,6 +202,36 @@ public final class CommandLineParserTest {
                         "--version false");
     }
 
+    private static class WithSensitiveValues {
+
+        @Argument(sensitive = true)
+        public String secretValue;
+
+        @Argument
+        public String openValue;
+    }
+
+    @Test
+    public void testGetCommandLineWithSensitiveArgument(){
+        final String supersecret = "supersecret";
+        final String unclassified = "unclassified";
+        final String[] args = {
+                "--secretValue", supersecret,
+                "--openValue", unclassified
+        };
+        final WithSensitiveValues sv = new WithSensitiveValues();
+        final CommandLineParser clp = new CommandLineParser(sv);
+        Assert.assertTrue(clp.parseArguments(System.err, args));
+
+        final String commandLine = clp.getCommandLine();
+
+        Assert.assertTrue(commandLine.contains(unclassified));
+        Assert.assertFalse(commandLine.contains(supersecret));
+
+        Assert.assertEquals(sv.openValue, unclassified);
+        Assert.assertEquals(sv.secretValue, supersecret);
+    }
+
     @Test
     public void testDefault() {
         final String[] args = {

--- a/src/test/java/org/broadinstitute/hellbender/tools/IntegrationTestSpec.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/IntegrationTestSpec.java
@@ -96,7 +96,6 @@ public final class IntegrationTestSpec {
      * @param tmpFiles              the temp file corresponding to the expectedFileNames list
      * @param args                  the argument list
      * @param expectedException     the expected exception or null
-     * @return a pair of file and string lists
      */
     private void executeTest(String testName, CommandLineProgramTest testClass, File outputFileLocation, List<String> expectedFileNames, List<File> tmpFiles, String args, Class<?> expectedException) throws IOException {
         if (outputFileLocation != null) {
@@ -123,12 +122,8 @@ public final class IntegrationTestSpec {
         boolean gotAnException = false;
         try {
             final String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss"));
-            final String cmdline = String.join(" ", command);
-            System.out.println(String.format("[%s] Executing test %s:%s with GATK arguments: %s", now, testClass.getClass().getSimpleName(), testName, cmdline));
-            // also write the command line to the HTML log for convenient follow-up
-            // do the replaceAll so paths become relative to the current
-            BaseTest.log(cmdline.replaceAll(BaseTest.publicTestDirRoot, ""));
-            Object result = testClass.runCommandLine(command);
+            System.out.println(String.format("[%s] Executing test %s:%s", now, testClass.getClass().getSimpleName(), testName));
+            testClass.runCommandLine(command);
         } catch (Exception e) {
             gotAnException = true;
             if (expectedException == null) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/BaseRecalibratorDataflowIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/pipelines/BaseRecalibratorDataflowIntegrationTest.java
@@ -60,7 +60,8 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
                     " " + args +
                     (knownSites.isEmpty() ? "": " -BQSRKnownVariants " + knownSites) +
                     " --RECAL_TABLE_FILE %s" +
-                    " -sortAllCols";
+                    " -sortAllCols" +
+                    " --apiKey " + getDataflowTestApiKey();
         }
 
         @Override
@@ -105,7 +106,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
     @DataProvider(name = "BQSRTest")
     public Object[][] createBQSRTestData() {
         // we need an API key to get to the reference
-        final String apiArgs = "--apiKey " + getDataflowTestApiKey() + " --project " + getDataflowTestProject() + " ";
+        final String apiArgs = " --project " + getDataflowTestProject() + " ";
         final String localResources =  getResourceDir();
         final String hg19Ref = "EMWV_ZfLxrDY-wE";
         final String GRCh37Ref = RefAPISource.GRCH37_REF_ID;
@@ -127,7 +128,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
 
     @DataProvider(name = "BQSRTestBucket")
     public Object[][] createBQSRTestDataBucket() {
-        final String apiArgs = "--apiKey " + getDataflowTestApiKey() + " --project " + getDataflowTestProject();
+        final String apiArgs = " --project " + getDataflowTestProject();
         final String GRCh37Ref = RefAPISource.GRCH37_REF_ID;
         final String localResources =  getResourceDir();
         final String HiSeqBamCloud = getCloudInputs() + "CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.bam";
@@ -141,7 +142,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
 
     @DataProvider(name = "BQSRTestCloud")
     public Object[][] createBQSRTestDataCloud() {
-        final String cloudArgs = "--runner BLOCKING --apiKey " + getDataflowTestApiKey() + " --project " + getDataflowTestProject() + " --staging " + getDataflowTestStaging();
+        final String cloudArgs = "--runner BLOCKING --project " + getDataflowTestProject() + " --staging " + getDataflowTestStaging();
         final String GRCh37Ref = RefAPISource.GRCH37_REF_ID;
         final String localResources =  getResourceDir();
         final String HiSeqBamCloud = getCloudInputs() + "CEUTrio.HiSeq.WGS.b37.ch20.1m-1m1k.NA12878.bam";
@@ -186,7 +187,6 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
     // TODO: enable this once we figure out how to read bams without requiring them to be indexed.
     @Test(description = "This is to test https://github.com/broadinstitute/hellbender/issues/322", groups = {"cloud"}, enabled = false)
     public void testPlottingWorkflow() throws IOException {
-        final String cloudArgs = "--apiKey " + getDataflowTestApiKey() + " ";
         final String resourceDir = getTestDataDir() + "/" + "BQSR" + "/";
         final String GRCh37Ref = RefAPISource.GRCH37_REF_ID; // that's the "full" version
         final String dbSNPb37 =  getResourceDir() + "dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf";
@@ -195,8 +195,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
         final File actualHiSeqBam_recalibrated = createTempFile("actual.NA12878.chr17_69k_70k.dictFix.recalibrated", ".bam");
 
         final String tablePre = createTempFile("gatk4.pre.cols", ".table").getAbsolutePath();
-        final String argPre = cloudArgs
-                + " -apiref " + RefAPISource.URL_PREFIX + GRCh37Ref + " -BQSRKnownVariants " + dbSNPb37 + " -I " + HiSeqBam
+        final String argPre = " -apiref " + RefAPISource.URL_PREFIX + GRCh37Ref + " -BQSRKnownVariants " + dbSNPb37 + " -I " + HiSeqBam
                 + " -RECAL_TABLE_FILE " + tablePre + " --sort_by_all_columns true";
         new BaseRecalibratorDataflow().instanceMain(Utils.escapeExpressions(argPre));
 
@@ -204,8 +203,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
         new ApplyBQSR().instanceMain(Utils.escapeExpressions(argApply));
 
         final File actualTablePost = createTempFile("gatk4.post.cols", ".table");
-        final String argsPost = cloudArgs
-                + " -apiref " + RefAPISource.URL_PREFIX + GRCh37Ref + " -BQSRKnownVariants " + dbSNPb37 + " -I " + actualHiSeqBam_recalibrated.getAbsolutePath()
+        final String argsPost = " -apiref " + RefAPISource.URL_PREFIX + GRCh37Ref + " -BQSRKnownVariants " + dbSNPb37 + " -I " + actualHiSeqBam_recalibrated.getAbsolutePath()
                 + " -RECAL_TABLE_FILE " + actualTablePost.getAbsolutePath() + " --sort_by_all_columns true";
         // currently fails with:
         // org.broadinstitute.hellbender.exceptions.UserException: A USER ERROR has occurred: Traversal by intervals was requested but some input files are not indexed.
@@ -225,7 +223,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
     @Test(groups = {"cloud"})
     public void testBQSRFailWithoutDBSNP() throws IOException {
         final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
-        final String apiArgs = "--apiKey " + getDataflowTestApiKey() + " --project " + getDataflowTestProject() + " ";
+        final String apiArgs = " --project " + getDataflowTestProject() + " ";
         final String localResources =  getResourceDir();
 
         final String GRCh37Ref = RefAPISource.GRCH37_REF_ID; // that's the "full" version
@@ -243,7 +241,7 @@ public final class BaseRecalibratorDataflowIntegrationTest extends CommandLinePr
     @Test(groups = {"cloud"})
     public void testBQSRFailWithIncompatibleReference() throws IOException {
         final String resourceDir =  getTestDataDir() + "/" + "BQSR" + "/";
-        final String apiArgs = "--apiKey " + getDataflowTestApiKey() + " --project " + getDataflowTestProject() + " ";
+        final String apiArgs = " --project " + getDataflowTestProject() + " ";
         final String localResources =  getResourceDir();
 
         final String hg19Ref = "EMWV_ZfLxrDY-wE";

--- a/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/UtilsUnitTest.java
@@ -1,22 +1,21 @@
 package org.broadinstitute.hellbender.utils;
 
-import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.Log.LogLevel;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Level;
-import org.broadinstitute.hellbender.Main;
-import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.utils.io.IOUtils;
-import org.broadinstitute.hellbender.utils.LoggingUtils;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
 
 import static java.util.Arrays.asList;
 


### PR DESCRIPTION
Arguments may now define `sensitive`.  Sensitive arguments will be printed as **** instead of as their value.
Removed output of raw command line from IntegrationTestSpec.  The censored command line is output by the command line program itself.

These changes are far from bulletproof.  Sensitive arguments may be leaked stack traces or errors, but it should fix the worst offenders.