### PR TITLE
fixing double running of gradle check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ before_install:
 - $GCLOUD/gcloud config set project broad-dsde-dev
 - $GCLOUD/gcloud auth activate-service-account --key servicekey.json
 - R --version
-install: travis_wait gradle check
 after_success:
 - gradle jacocoTestReport coveralls
 after_failure:

--- a/build.gradle
+++ b/build.gradle
@@ -226,7 +226,7 @@ test {
     minHeapSize = "1G"
     maxHeapSize = "2G"
 
-    if (CI == "true") {
+    if (CI == "true" && CLOUD == "false" ) {
         int count = 0
         // listen to events in the test execution lifecycle
         testLogging {


### PR DESCRIPTION
after the addition of travis_wait gradle check travis was executing gradle check twice
with ./gradlew and one with gradle.  This was happening because it was being run onces explicitly in the install phase and once implicitly in the script phase

this was causing some strange issues

instead of using travis_wait, I made the dataflow cloud tests output status information as they go
this similarly prevents travis from timing out due to lack of output, but doesn't need the travis_wait
if we add any really long running dataflow tests, or really highly spammy ones we'll have to revisit this