### PR TITLE
Put Spark tests in a 'spark' group so they don't conflict with Spark Dataflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ env:
   - CLOUD=mandatory
   - CLOUD=todo
   - CLOUD=false
-  - DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=mandatory
-  - DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=false
+  - DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=false SPARK=false
   global:
   #gradle needs this
   - TERM=dumb
@@ -33,8 +32,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=false
-    - env: DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=mandatory
+    - env: DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=false SPARK=false
     - env: CLOUD=todo
 cache:
   directories:

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ jacoco {
 compileJava {
   options.compilerArgs = ['-proc:none', '-Xlint:all','-Werror']
 }
-compileTestJava { 
+compileTestJava {
   options.compilerArgs = ['-proc:none', '-Xlint:all','-Werror']
 }
 
@@ -206,6 +206,7 @@ task testAll(type: Test){
 test {
     String CI = "$System.env.CI"
     String CLOUD = "$System.env.CLOUD"
+    String SPARK = "$System.env.SPARK"
     useTestNG{
         if (CLOUD =="mandatory") {
             // run only the cloud tests
@@ -220,6 +221,10 @@ test {
         } else {
             // run only the local tests
             excludeGroups 'cloud', 'bucket', 'cloud_todo', 'bucket_todo'
+        }
+        if (SPARK == "false") {
+            // exclude Spark (but not Spark Dataflow, see DATAFLOW_RUNNER env variable) if explicitly requested
+            excludeGroups 'spark'
         }
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
@@ -51,7 +51,7 @@ public class AddContextDataToReadSparkUnitTest extends BaseTest {
         return data;
     }
 
-    @Test(dataProvider = "bases")
+    @Test(dataProvider = "bases", groups = "spark")
     public void addContextDataTest(List<GATKRead> reads, List<Variant> variantList,
                                    List<KV<GATKRead, ReadContextData>> expectedReadContextData,
                                    List<SimpleInterval> intervals) throws IOException {

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBasesSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBasesSparkUnitTest.java
@@ -45,7 +45,7 @@ public class JoinReadsWithRefBasesSparkUnitTest extends TestCase {
         return data;
     }
 
-    @Test(dataProvider = "bases")
+    @Test(dataProvider = "bases", groups = "spark")
     public void refBasesTest(List<GATKRead> reads, List<KV<GATKRead, ReferenceBases>> kvReadRefBases,
                              List<SimpleInterval> intervals) throws IOException {
         JavaSparkContext ctx = SparkTestUtils.getTestContext();

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariantsSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariantsSparkUnitTest.java
@@ -38,7 +38,7 @@ public class JoinReadsWithVariantsSparkUnitTest extends BaseTest {
         return data;
     }
 
-    @Test(dataProvider = "pairedReadsAndVariants")
+    @Test(dataProvider = "pairedReadsAndVariants", groups = "spark")
     public void pairReadsAndVariantsTest(List<GATKRead> reads, List<Variant> variantList, List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant) {
         JavaSparkContext ctx = SparkTestUtils.getTestContext();
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -27,7 +27,7 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
         };
     }
 
-    @Test(dataProvider = "loadReads")
+    @Test(dataProvider = "loadReads", groups = "spark")
     public void readsSinkTest(String inputBam, String outputFile) throws IOException {
         new File(outputFile).deleteOnExit();
         JavaSparkContext ctx = SparkTestUtils.getTestContext();

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSourceUnitTest.java
@@ -29,7 +29,7 @@ public class ReadsSparkSourceUnitTest extends BaseTest {
         };
     }
 
-    @Test(dataProvider = "loadReads")
+    @Test(dataProvider = "loadReads", groups = "spark")
     public void readsSparkSourceTest(String bam) {
         JavaSparkContext ctx = SparkTestUtils.getTestContext();
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSourceUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/VariantsSparkSourceUnitTest.java
@@ -31,7 +31,7 @@ public class VariantsSparkSourceUnitTest extends BaseTest {
         };
     }
 
-    @Test(dataProvider = "loadVariants")
+    @Test(dataProvider = "loadVariants", groups = "spark")
     public void pairReadsAndVariantsTest(String vcf) {
         JavaSparkContext ctx = SparkTestUtils.getTestContext();
 


### PR DESCRIPTION
The Spark Dataflow tests started failing after the Spark code merge. The problem is that Spark Dataflow uses a shared SparkContext, while the new Spark codes uses a context per test, and there is an odd interaction where calling `stop()` on a context sets its static SparkEnv to null, which then causes the Spark Dataflow shared context to fail.

This fix puts all of the new Spark tests into a `spark` group, so they don't run together. A longer term fix is to have a single shared Spark Context for both Spark and Spark Dataflow. (See discussion here: https://issues.apache.org/jira/browse/SPARK-2243) This will require some changes to Spark Dataflow.

I also removed the Travis `DATAFLOW_RUNNER=SparkPipelineRunner CLOUD=mandatory` combination, which we talked about removing before since it's not a very meaningful combination.

