### PR TITLE
Make getReadsFromHadoopBam consistent with the local case

### DIFF
--- a/src/test/java/org/broadinstitute/hellbender/utils/dataflow/DataflowUtilsUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/dataflow/DataflowUtilsUnitTest.java
@@ -68,7 +68,7 @@ public final class DataflowUtilsUnitTest extends BaseTest {
     public void testGetReadsFromHadoopBam() {
         List<SimpleInterval> intervals = Arrays.asList(new SimpleInterval("chr7:1-202"), new SimpleInterval("chr8:2-202"));
         File inputFile = new File(getToolTestDataDir(), "example_reads.bam");
-        List<GATKRead> expected = getReadsFromFile(intervals, inputFile, true);
+        List<GATKRead> expected = getReadsFromFile(intervals, inputFile, false);
 
         Pipeline p = GATKTestPipeline.create();
         DataflowUtils.registerGATKCoders(p);

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/markduplicates/MarkDuplicatesDataflowTester.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/markduplicates/MarkDuplicatesDataflowTester.java
@@ -12,4 +12,10 @@ public final class MarkDuplicatesDataflowTester extends AbstractMarkDuplicatesTe
 
     @Override
     protected CommandLineProgram getProgram() { return new MarkDuplicatesDataflow(); }
+
+    @Override
+    protected void addArgs() {
+        super.addArgs();
+        addDataflowRunnerArgs(args);
+    }
 }

--- a/src/test/java/org/broadinstitute/hellbender/utils/read/testers/SamFileTester.java
+++ b/src/test/java/org/broadinstitute/hellbender/utils/read/testers/SamFileTester.java
@@ -22,7 +22,7 @@ public abstract class SamFileTester extends CommandLineProgramTest {
     private boolean noMateCigars = false;
     private boolean deleteOnExit = true;
     private boolean useStandardInputNames = false;
-    private final List<String> args = new ArrayList<>();
+    protected final List<String> args = new ArrayList<>();
 
     public SamFileTester(final int readLength, final boolean deleteOnExit, final int defaultChromosomeLength, final DuplicateScoringStrategy.ScoringStrategy duplicateScoringStrategy) {
         this.deleteOnExit = deleteOnExit;
@@ -270,8 +270,13 @@ public abstract class SamFileTester extends CommandLineProgramTest {
           addArg("--INPUT", input.getAbsolutePath());
           addArg("--OUTPUT", output.getAbsolutePath());
         }
+        addArgs();
         runCommandLine(args);
         test();
+    }
+
+    protected void addArgs() {
+        // subclasses may override to add more arguments
     }
 
     private File createInputFile() {


### PR DESCRIPTION
DataflowUtils#getReadsFromLocalBams will return unmapped reads if they have a start position that overlaps an interval, but the Hadoop version will filter them out. This change fixes this inconsistency, and makes the MarkDuplicates dataflow tests use the Spark Dataflow runner if it's specified on the command line (it used to ignore the setting).

The change to the MarkDuplicates test also uncovered another problem where some tests failed with "Mate unmapped flag should not be set for unpaired read". I fixed this by moving from `com.google.cloud.genomics.utils.ReadUtils.makeRead` and `GoogleGenomicsReadToGATKReadAdapter` (which are lossy, and presumably caused the failures) to `SAMRecordToGATKReadAdapter`. 