### PR TITLE
Fixes to run (pure) Spark commands on a cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,11 +132,11 @@ dependencies {
         exclude module: 'jul-to-slf4j'
         exclude module: 'javax.servlet'
         exclude module: 'servlet-api'
-        exclude module: 'kryo'
     }
 
-    compile 'com.esotericsoftware.kryo:kryo:2.24.0' // We need the latest 2.x version for de.javakaffee:kryo-serializers
-    compile 'de.javakaffee:kryo-serializers:0.26'
+    compile('de.javakaffee:kryo-serializers:0.26') {
+        exclude module: 'kryo' // use Spark's version
+    }
 
     //needed for DataflowAssert
     testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
     id "de.undercouch.download" version "1.2"
 }
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import de.undercouch.gradle.tasks.download.Download
 
 apply plugin: 'java'
@@ -280,24 +281,29 @@ task fatJar(type: Jar) {
     with jar
 }
 
-shadowJar {
+configurations {
+    sparkConfiguration {
+        extendsFrom runtime
+        // exclude Hadoop and Spark dependencies, since they are provided when running with Spark
+        // (ref: http://unethicalblogger.com/2015/07/15/gradle-goodness-excluding-depends-from-shadow.html)
+        exclude group: 'org.apache.hadoop'
+        exclude module: 'spark-core_2.10'
+    }
+}
+
+task sparkJar(type: ShadowJar) {
     manifest {
         attributes 'Implementation-Title': 'Hellbender',
                 'Implementation-Version': version,
                 'Main-Class': 'org.broadinstitute.hellbender.Main'
     }
+    configurations = [project.configurations.sparkConfiguration]
+    from(project.sourceSets.main.output)
     baseName = project.name + '-all'
     classifier = 'spark'
     mergeServiceFiles()
     relocate 'com.google.common', 'org.broadinstitute.hellbender.relocated.com.google.common'
     zip64 true
-    dependencies {
-        // exclude Hadoop dependencies, since they are provided when running with Spark
-        // TODO: improve this, since it doesn't take transitive dependencies into account
-        // see https://github.com/broadinstitute/hellbender/issues/836
-        exclude(dependency('org.apache.hadoop:.*:.*'))
-        exclude(dependency('org.xerial.snappy:snappy-java:.*'))
-    }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
There were a couple of things I needed to do to get the new Spark code running on a cluster:

i. Go back to using Spark's version of Kryo.

Using a different version of Kryo is not actually needed (2.21 used by Spark passes the tests), and actually caused errors on the cluster when run with `--conf spark.driver.userClassPathFirst=true` (which is needed to avoid other library conflicts, like with jopt-simple).

ii. Exclude Spark from the JAR file to avoid library conflicts.

It's normal to exclude Spark and Hadoop from JAR files since they are supplied by `spark-submit`. Since Gradle doesn't have a 'provided' dependency (see https://github.com/broadinstitute/hellbender/issues/836), I had to do a bit of a workaround with the `shadowJar` target, which is now `sparkJar`. 

Here's the command I ran:

```bash
NAMENODE=...
SPARK_MASTER=yarn-client
HELLBENDER_HOME=...
spark-submit \
       --master $SPARK_MASTER \
       --conf spark.driver.userClassPathFirst=true \
       --conf spark.executor.userClassPathFirst=true \
       --conf spark.io.compression.codec=lzf \
       build/libs/hellbender-all-*-spark.jar ReadsPipelineSpark \
         --input hdfs://$NAMENODE/user/$USER/bam/NA12878.chr17_69k_70k.dictFix.bam \
         --output hdfs://$NAMENODE/user/$USER/out/spark-reads-pipeline \
         --reference hdfs://$NAMENODE/user/$USER/fasta/human_g1k_v37.chr17_1Mb.fasta \
         --baseRecalibrationKnownVariants $HELLBENDER_HOME/src/test/resources/org/broadinstitute/hellbender/tools/BQSR/dbsnp_132.b37.excluding_sites_after_129.chr17_69k_70k.vcf \
         --sparkMaster $SPARK_MASTER 
```