### PR TITLE
Initial ADAM Parquet I/O support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,10 @@ dependencies {
     compile ('com.google.cloud.genomics:google-genomics-utils:v1beta2-0.30') {
         exclude module: 'guava-jdk5'
     }
+
+    compile 'org.bdgenomics.bdg-formats:bdg-formats:0.5.0'
+    compile 'org.bdgenomics.adam:adam-core_2.10:0.17.1'
+
     // we don't need this guy. Plus, it asks for the latest version
     // of com.google.http-client:google-http-client-jackson2,
     // which is a problem when we have a SNAPSHOT version.

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -5,6 +5,7 @@ import com.google.api.services.genomics.model.Read;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.bdgenomics.adam.serialization.ADAMKryoRegistrator;
 
 import java.util.Collections;
 
@@ -13,7 +14,14 @@ import java.util.Collections;
  * and UnmodifiableCollectionsSerializer from a bug in the version of Kryo we're on.
  */
 public class GATKRegistrator implements KryoRegistrator {
-    @SuppressWarnings("unchecked")
+
+    private ADAMKryoRegistrator ADAMregistrator;
+
+    public GATKRegistrator() {
+        this.ADAMregistrator = new ADAMKryoRegistrator();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public void registerClasses(Kryo kryo) {
 
@@ -29,5 +37,26 @@ public class GATKRegistrator implements KryoRegistrator {
         // SAMRecordToGATKReadAdapterSerializer is not currently being used until we are sure that headers are being
         // properly handled (https://github.com/broadinstitute/hellbender/issues/900)
         //kryo.register(SAMRecordToGATKReadAdapter.class, new SAMRecordToGATKReadAdapterSerializer());
+
+        // register the ADAM data types using Avro serialization, including:
+        //     AlignmentRecord
+        //     Genotype
+        //     Variant
+        //     DatabaseVariantAnnotation
+        //     NucleotideContigFragment
+        //     Contig
+        //     StructuralVariant
+        //     VariantCallingAnnotations
+        //     VariantEffect
+        //     DatabaseVariantAnnotation
+        //     Dbxref
+        //     Feature
+        //     ReferencePosition
+        //     ReferencePositionPair
+        //     SingleReadBucket
+        //     IndelRealignmentTarget
+        //     TargetSet
+        //     ZippedTargetSet
+        ADAMregistrator.registerClasses(kryo);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -28,6 +28,7 @@ import org.broadinstitute.hellbender.tools.recalibration.RecalibrationTables;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import org.broadinstitute.hellbender.utils.variant.Variant;
 import scala.Tuple2;
 
@@ -103,7 +104,7 @@ public class ReadsPipelineSpark extends SparkCommandLineProgram {
         });
 
         try {
-            ReadsSparkSink.writeReads(ctx, output, finalReads, readsHeader, false);
+            ReadsSparkSink.writeReads(ctx, output, finalReads, readsHeader, ReadsWriteFormat.SHARDED);
         } catch (IOException e) {
             throw new GATKException("unable to write bam: " + e);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortBamSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortBamSpark.java
@@ -13,6 +13,7 @@ import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
+import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import scala.Tuple2;
 
 import java.io.IOException;
@@ -49,7 +50,8 @@ public final class SortBamSpark extends SparkCommandLineProgram {
                 .keys();
         try {
             readsHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
-            ReadsSparkSink.writeReads(ctx, outputFile, sortedReads, readsHeader, parallelism == 1);
+            ReadsSparkSink.writeReads(
+                    ctx, outputFile, sortedReads, readsHeader, parallelism == 1 ? ReadsWriteFormat.SINGLE : ReadsWriteFormat.SHARDED);
         } catch (IOException e) {
             throw new GATKException("unable to write bam: " + e);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -19,6 +19,7 @@ import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.IntervalUtils;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import org.broadinstitute.hellbender.utils.read.markduplicates.DuplicationMetrics;
 import org.broadinstitute.hellbender.utils.read.markduplicates.OpticalDuplicateFinder;
 
@@ -80,7 +81,7 @@ public final class MarkDuplicatesSpark extends SparkCommandLineProgram {
         final JavaRDD<GATKRead> finalReads = mark(reads, readsHeader, finder);
 
         try {
-            ReadsSparkSink.writeReads(ctx, output, finalReads, readsHeader, true);
+            ReadsSparkSink.writeReads(ctx, output, finalReads, readsHeader, ReadsWriteFormat.SINGLE);
         } catch (IOException e) {
             throw new GATKException("unable to write bam: " + e);
         }

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/BDGAlignmentRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/BDGAlignmentRecordToGATKReadAdapter.java
@@ -1,0 +1,66 @@
+package org.broadinstitute.hellbender.utils.read;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import org.bdgenomics.adam.converters.AlignmentRecordConverter;
+import org.bdgenomics.adam.models.SAMFileHeaderWritable;
+import org.bdgenomics.formats.avro.AlignmentRecord;
+
+import java.util.UUID;
+
+/**
+ * Implementation of the {@link GATKRead} interface for the {@link AlignmentRecord} class.
+ *
+ * The AlignmentRecord class is the Avro-based data model used in the Big Data Genomics project (aka ADAM).  It is also
+ * designed to capture the main functionality of a BAM file.  The schema can be found in the bdg-formats repo:
+ * https://github.com/bigdatagenomics/bdg-formats
+ *
+ * Utilities for converting to/from a SAMRecord can be found in the adam-core Maven artifact, built from the main ADAM
+ * repo:
+ * https://github.com/bigdatagenomics/adam
+ *
+ * Because it is an Avro model, it admits an efficient on-wire serialized format and is also compatible with the Parquet
+ * columnar storage format.
+ *
+ * This adapter wraps an {@link AlignmentRecord} by first converting to a {@link SAMRecord} and then passing through
+ * to {@link SAMRecordToGATKReadAdapter}.
+ */
+public final class BDGAlignmentRecordToGATKReadAdapter extends SAMRecordToGATKReadAdapter {
+    private static final long serialVersionUID = 1L;
+
+    private final AlignmentRecord alignmentRecord;
+
+    public BDGAlignmentRecordToGATKReadAdapter( final AlignmentRecord alignmentRecord) {
+        this(alignmentRecord, null);
+    }
+
+    public BDGAlignmentRecordToGATKReadAdapter( final AlignmentRecord alignmentRecord, final SAMFileHeader header) {
+        this(alignmentRecord, header, UUID.randomUUID());
+    }
+
+    /**
+     * Constructor that allows an explicit UUID to be passed in -- only meant
+     * for internal use and test class use, which is why it's package protected.
+     */
+    BDGAlignmentRecordToGATKReadAdapter( final AlignmentRecord alignmentRecord, final SAMFileHeader header, final UUID uuid ) {
+        super(new AlignmentRecordConverter().convert(alignmentRecord, SAMFileHeaderWritable.apply(header)), uuid);
+        this.alignmentRecord = alignmentRecord;
+    }
+
+    /**
+     * Produces a BDGAlignmentRecordToGATKReadAdapter with a 0L,0L UUID. Spark doesn't need the UUIDs
+     * and loading the reads twice (which can happen when caching is missing) prevents joining.
+     * @param record Read to adapt
+     * @param header SAMFileHeaderWritable corresponding to the underlying SAMRecord object
+     * @return adapted Read
+     */
+    public static GATKRead sparkReadAdapter(final AlignmentRecord record, final SAMFileHeader header) {
+        return new BDGAlignmentRecordToGATKReadAdapter(record, header, new UUID(0L, 0L));
+    }
+
+    public static GATKRead sparkReadAdapter(final AlignmentRecord record) {
+        return new BDGAlignmentRecordToGATKReadAdapter(record, null, new UUID(0L, 0L));
+    }
+
+    public AlignmentRecord convertToBDGAlignmentRecord() { return alignmentRecord; }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/GATKReadToBDGAlignmentRecordConverter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/GATKReadToBDGAlignmentRecordConverter.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.hellbender.utils.read;
+
+import htsjdk.samtools.SAMFileHeader;
+import org.apache.spark.api.java.function.Function;
+import org.bdgenomics.formats.avro.AlignmentRecord;
+import org.bdgenomics.adam.converters.SAMRecordConverter;
+import org.bdgenomics.adam.models.SequenceDictionary;
+import org.bdgenomics.adam.models.RecordGroupDictionary;
+
+
+import java.io.Serializable;
+
+/**
+ * Converts a GATKRead to a BDG AlignmentRecord
+ */
+public class GATKReadToBDGAlignmentRecordConverter {
+    private static final SAMRecordConverter converter = new SAMRecordConverter();
+
+    private SAMFileHeader header;
+    private SequenceDictionary dict;
+    private RecordGroupDictionary readGroups;
+
+    public GATKReadToBDGAlignmentRecordConverter(SAMFileHeader header) {
+        this.header = header;
+        this.dict = SequenceDictionary.fromSAMSequenceDictionary(header.getSequenceDictionary());
+        this.readGroups = RecordGroupDictionary.fromSAMHeader(header);
+    }
+
+    public static AlignmentRecord convert( final GATKRead gatkRead, final SAMFileHeader header ) {
+        SequenceDictionary dict = SequenceDictionary.fromSAMSequenceDictionary(header.getSequenceDictionary());
+        RecordGroupDictionary readGroups = RecordGroupDictionary.fromSAMHeader(header);
+        return GATKReadToBDGAlignmentRecordConverter.convert(gatkRead, header, dict, readGroups);
+    }
+
+    public static AlignmentRecord convert(
+            final GATKRead gatkRead, final SAMFileHeader header, final SequenceDictionary dict, final RecordGroupDictionary readGroups ) {
+        return converter.convert(gatkRead.convertToSAMRecord(header), dict, readGroups);
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/ReadsWriteFormat.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/ReadsWriteFormat.java
@@ -1,0 +1,23 @@
+package org.broadinstitute.hellbender.utils.read;
+
+/**
+ * Possible output formats when writing reads.
+ *
+ * (Currently used only in the context of Spark.)
+ */
+public enum ReadsWriteFormat {
+    /**
+     * Write reads to a single BAM file
+     */
+    SINGLE,
+
+    /**
+     * Write reads to a sharded set of BAM files
+     */
+    SHARDED,
+
+    /**
+     * Write reads to a sharded set of ADAM-formatted Parquet files
+     */
+    ADAM
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -19,7 +19,7 @@ import java.util.UUID;
  * but care must be exercised if the underlying read has been exposed somewhere before
  * wrapping.
  */
-public final class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
+public class SAMRecordToGATKReadAdapter implements GATKRead, Serializable {
     private static final long serialVersionUID = 1L;
 
     private final SAMRecord samRecord;

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/datasources/ReadsSparkSinkUnitTest.java
@@ -2,11 +2,13 @@ package org.broadinstitute.hellbender.engine.spark.datasources;
 
 
 import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.engine.spark.SparkContextFactory;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
+import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -14,20 +16,30 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 
 
 public class ReadsSparkSinkUnitTest extends BaseTest {
-    @DataProvider(name = "loadReads")
-    public Object[][] loadReads() {
-        String dir = "src/test/resources/org/broadinstitute/hellbender/tools/BQSR/";
+    private static String testDataDir = publicTestDir + "org/broadinstitute/hellbender/";
+
+    @DataProvider(name = "loadReadsBAM")
+    public Object[][] loadReadsBAM() {
         return new Object[][]{
-                {dir + "HiSeq.1mb.1RG.2k_lines.alternate.bam", "ReadsSparkSinkUnitTest1.bam"},
-                {dir + "expected.HiSeq.1mb.1RG.2k_lines.bqsr.DIQ.alternate.bam", "ReadsSparkSinkUnitTest2.bam"},
+                {testDataDir + "engine/dataflow/ReadsSource/HiSeq.1mb.1RG.2k_lines.bam", "ReadsSparkSinkUnitTest1.bam"},
+                {testDataDir + "tools/BQSR/expected.HiSeq.1mb.1RG.2k_lines.bqsr.DIQ.alternate.bam", "ReadsSparkSinkUnitTest2.bam"},
         };
     }
 
-    @Test(dataProvider = "loadReads", groups = "spark")
+    @DataProvider(name = "loadReadsADAM")
+    public Object[][] loadReadsADAM() {
+        return new Object[][]{
+                {testDataDir + "engine/dataflow/ReadsSource/HiSeq.1mb.1RG.2k_lines.bam", "ReadsSparkSinkUnitTest1_ADAM"},
+                {testDataDir + "tools/BQSR/expected.HiSeq.1mb.1RG.2k_lines.bqsr.DIQ.alternate.bam", "ReadsSparkSinkUnitTest2_ADAM"},
+        };
+    }
+
+    @Test(dataProvider = "loadReadsBAM", groups = "spark")
     public void readsSinkTest(String inputBam, String outputFile) throws IOException {
         new File(outputFile).deleteOnExit();
         JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
@@ -36,7 +48,7 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
         JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam);
         SAMFileHeader header = ReadsSparkSource.getHeader(ctx, inputBam);
 
-        ReadsSparkSink.writeReads(ctx, outputFile, rddParallelReads, header, true);
+        ReadsSparkSink.writeReads(ctx, outputFile, rddParallelReads, header, ReadsWriteFormat.SINGLE);
 
         JavaRDD<GATKRead> rddParallelReads2 = readSource.getParallelReads(outputFile);
         final List<GATKRead> writtenReads = rddParallelReads2.collect();
@@ -52,4 +64,38 @@ public class ReadsSparkSinkUnitTest extends BaseTest {
         Assert.assertEquals(rddParallelReads.count(), rddParallelReads2.count());
     }
 
+    @Test(dataProvider = "loadReadsADAM", groups = "spark")
+    public void readsSinkADAMTest(String inputBam, String outputFile) throws IOException {
+        new File(outputFile).deleteOnExit();
+        JavaSparkContext ctx = SparkContextFactory.getTestSparkContext();
+
+        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
+        JavaRDD<GATKRead> rddParallelReads = readSource.getParallelReads(inputBam);
+        SAMFileHeader header = ReadsSparkSource.getHeader(ctx, inputBam);
+
+        ReadsSparkSink.writeReads(ctx, outputFile, rddParallelReads, header, ReadsWriteFormat.ADAM);
+
+        JavaRDD<GATKRead> rddParallelReads2 = readSource.getADAMReads(outputFile, header);
+        Assert.assertEquals(rddParallelReads.count(), rddParallelReads2.count());
+
+        // Test the round trip
+        List<GATKRead> samList = rddParallelReads.collect();
+        List<GATKRead> adamList = rddParallelReads2.collect();
+        Comparator<GATKRead> comparator = new ReadCoordinateComparator(header);
+        samList.sort(comparator);
+        adamList.sort(comparator);
+        for (int i = 0; i < samList.size(); i++) {
+            SAMRecord expected = samList.get(i).convertToSAMRecord(header);
+            SAMRecord observed = adamList.get(i).convertToSAMRecord(header);
+            // manually test equality of some fields, as there are issues with roundtrip BAM -> ADAM -> BAM
+            // see https://github.com/bigdatagenomics/adam/issues/823
+            Assert.assertEquals(expected.getReadName(), observed.getReadName());
+            Assert.assertEquals(expected.getAlignmentStart(), observed.getAlignmentStart());
+            Assert.assertEquals(expected.getAlignmentEnd(), observed.getAlignmentEnd());
+            Assert.assertEquals(expected.getFlags(), observed.getFlags());
+            Assert.assertEquals(expected.getMappingQuality(), observed.getMappingQuality());
+            Assert.assertEquals(expected.getMateAlignmentStart(), observed.getMateAlignmentStart());
+            Assert.assertEquals(expected.getCigar(), observed.getCigar());
+        }
+    }
 }


### PR DESCRIPTION
Add support for reading/writing Parquet via ADAM/BDG `AlignmentRecord` type.

Not ready for merge.