### PR TITLE
Add a Spark Kryo serializer for SAMRecords.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKRegistrator.java
@@ -4,6 +4,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.google.api.services.genomics.model.Read;
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import org.apache.spark.serializer.KryoRegistrator;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
 
 import java.util.Collections;
 
@@ -24,5 +25,9 @@ public class GATKRegistrator implements KryoRegistrator {
         // fix here.
         // We are tracking this issue with (#874)
         kryo.register(Collections.unmodifiableMap(Collections.EMPTY_MAP).getClass(), new UnmodifiableCollectionsSerializer());
+
+        // SAMRecordToGATKReadAdapterSerializer is not currently being used until we are sure that headers are being
+        // properly handled (https://github.com/broadinstitute/hellbender/issues/900)
+        //kryo.register(SAMRecordToGATKReadAdapter.class, new SAMRecordToGATKReadAdapterSerializer());
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializer.java
@@ -1,0 +1,97 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import htsjdk.samtools.*;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+
+public class SAMRecordToGATKReadAdapterSerializer extends Serializer<SAMRecordToGATKReadAdapter> {
+
+    private BAMRecordCodec lazyCodec = new BAMRecordCodec(null, new LazyBAMRecordFactory());
+
+    @Override
+    public void write(Kryo kryo, Output output, SAMRecordToGATKReadAdapter adapter) {
+        SAMRecord record = adapter.getSamRecord();
+        // serialize reference names to avoid having to have a header at read time
+        output.writeString(record.getReferenceName());
+        output.writeString(record.getMateReferenceName());
+        lazyCodec.setOutputStream(output);
+        lazyCodec.encode(record);
+
+        // clear indexing bin after encoding to ensure all SAMRecords compare properly
+        record.setFlags(record.getFlags());
+    }
+
+    @Override
+    public SAMRecordToGATKReadAdapter read(Kryo kryo, Input input, Class<SAMRecordToGATKReadAdapter> type) {
+        final String referenceName = input.readString();
+        final String mateReferenceName = input.readString();
+        lazyCodec.setInputStream(input);
+        final SAMRecord record = lazyCodec.decode();
+
+        // clear indexing bin after decoding to ensure all SAMRecords compare properly
+        record.setFlags(record.getFlags());
+
+        final int referenceIndex = record.getReferenceIndex();
+        final int mateReferenceIndex = record.getMateReferenceIndex();
+        record.setReferenceName(referenceName);
+        record.setMateReferenceName(mateReferenceName);
+
+        // set reference indexes again since setting reference names without a header will unset indexes
+        record.setReferenceIndex(referenceIndex);
+        record.setMateReferenceIndex(mateReferenceIndex);
+
+        return (SAMRecordToGATKReadAdapter) SAMRecordToGATKReadAdapter.sparkReadAdapter(record);
+    }
+
+
+    static class LazyBAMRecordFactory implements SAMRecordFactory {
+        @Override public SAMRecord createSAMRecord(SAMFileHeader hdr) {
+            throw new UnsupportedOperationException(
+                    "LazyBAMRecordFactory can only create BAM records");
+        }
+
+        @Override public BAMRecord createBAMRecord(
+                SAMFileHeader hdr,
+                int referenceSequenceIndex, int alignmentStart,
+                short readNameLength, short mappingQuality,
+                int indexingBin, int cigarLen, int flags, int readLen,
+                int mateReferenceSequenceIndex, int mateAlignmentStart,
+                int insertSize, byte[] variableLengthBlock)
+        {
+            return new LazyBAMRecord(
+                    hdr, referenceSequenceIndex, alignmentStart, readNameLength,
+                    mappingQuality, indexingBin, cigarLen, flags, readLen,
+                    mateReferenceSequenceIndex, mateAlignmentStart, insertSize,
+                    variableLengthBlock);
+        }
+    }
+
+    static class LazyBAMRecord extends BAMRecord {
+        private static final long serialVersionUID = 1L;
+
+        public LazyBAMRecord(
+                SAMFileHeader hdr, int referenceID, int coordinate, short readNameLength,
+                short mappingQuality, int indexingBin, int cigarLen, int flags,
+                int readLen, int mateReferenceID, int mateCoordinate, int insertSize,
+                byte[] restOfData)
+        {
+            super(
+                    hdr, referenceID, coordinate, readNameLength, mappingQuality,
+                    indexingBin, cigarLen, flags, readLen, mateReferenceID,
+                    mateCoordinate, insertSize, restOfData);
+        }
+
+        @Override
+        public void setReferenceIndex(final int referenceIndex) {
+            mReferenceIndex = referenceIndex;
+        }
+
+        @Override
+        public void setMateReferenceIndex(final int referenceIndex) {
+            mMateReferenceIndex = referenceIndex;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/read/SAMRecordToGATKReadAdapter.java
@@ -30,6 +30,16 @@ public final class SAMRecordToGATKReadAdapter implements GATKRead, Serializable 
     }
 
     /**
+     * Produces a SAMRecordToGATKReadAdapter with a 0L,0L UUID. Spark doesn't need the UUIDs
+     * and loading the reads twice (which can happen when caching is missing) prevents joining.
+     * @param samRecord Read to adapt
+     * @return adapted Read
+     */
+    public static GATKRead sparkReadAdapter(final SAMRecord samRecord) {
+        return new SAMRecordToGATKReadAdapter(samRecord, new UUID(0L, 0L));
+    }
+
+    /**
      * Constructor that allows an explicit UUID to be passed in -- only meant
      * for internal use and test class use, which is why it's package protected.
      */
@@ -495,6 +505,10 @@ public final class SAMRecordToGATKReadAdapter implements GATKRead, Serializable 
     @Override
     public SAMRecord convertToSAMRecord( final SAMFileHeader header ) {
         samRecord.setHeader(header);
+        return samRecord;
+    }
+
+    public SAMRecord getSamRecord() {
         return samRecord;
     }
 

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/AddContextDataToReadSparkUnitTest.java
@@ -10,7 +10,6 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
-import org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.ReadContextData;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceDataflowSource;
@@ -40,7 +39,7 @@ public class AddContextDataToReadSparkUnitTest extends BaseTest {
         List<Class<?>> classes = Arrays.asList(Read.class, SAMRecord.class);
         for (int i = 0; i < classes.size(); ++i) {
             Class<?> c = classes.get(i);
-            ReadsPreprocessingPipelineTestData testData = new ReadsPreprocessingPipelineTestData(c);
+            ReadsPreprocessingPipelineSparkTestData testData = new ReadsPreprocessingPipelineSparkTestData(c);
 
             List<GATKRead> reads = testData.getReads();
             List<SimpleInterval> intervals = testData.getAllIntervals();

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBasesSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithRefBasesSparkUnitTest.java
@@ -4,16 +4,15 @@ import com.google.api.services.genomics.model.Read;
 import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.cloud.dataflow.sdk.values.KV;
 import htsjdk.samtools.SAMRecord;
-import junit.framework.TestCase;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions;
 import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceDataflowSource;
 import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
+import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.test.FakeReferenceSource;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -28,14 +27,14 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
-public class JoinReadsWithRefBasesSparkUnitTest extends TestCase {
+public class JoinReadsWithRefBasesSparkUnitTest extends BaseTest {
     @DataProvider(name = "bases")
     public Object[][] bases(){
         Object[][] data = new Object[2][];
         List<Class<?>> classes = Arrays.asList(Read.class, SAMRecord.class);
         for (int i = 0; i < classes.size(); ++i) {
             Class<?> c = classes.get(i);
-            ReadsPreprocessingPipelineTestData testData = new ReadsPreprocessingPipelineTestData(c);
+            ReadsPreprocessingPipelineSparkTestData testData = new ReadsPreprocessingPipelineSparkTestData(c);
 
             List<GATKRead> reads = testData.getReads();
             List<SimpleInterval> intervals = testData.getAllIntervals();

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariantsSparkUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/JoinReadsWithVariantsSparkUnitTest.java
@@ -5,13 +5,9 @@ import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import htsjdk.samtools.SAMRecord;
-import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.broadinstitute.hellbender.engine.dataflow.ReadsPreprocessingPipelineTestData;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
-import org.broadinstitute.hellbender.engine.spark.datasources.VariantsSparkSource;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.test.BaseTest;
 import org.broadinstitute.hellbender.utils.variant.Variant;
@@ -28,11 +24,11 @@ public class JoinReadsWithVariantsSparkUnitTest extends BaseTest {
         List<Class<?>> classes = Arrays.asList(Read.class, SAMRecord.class);
         for (int i = 0; i < classes.size(); ++i) {
             Class<?> c = classes.get(i);
-            ReadsPreprocessingPipelineTestData testData = new ReadsPreprocessingPipelineTestData(c);
+            ReadsPreprocessingPipelineSparkTestData testData = new ReadsPreprocessingPipelineSparkTestData(c);
 
             List<GATKRead> reads = testData.getReads();
             List<Variant> variantList = testData.getVariants();
-            List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant = testData.getKvReadiVariantFixed();
+            List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant = testData.getKvReadiVariant();
             data[i] = new Object[]{reads, variantList, kvReadiVariant};
         }
         return data;

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/ReadsPreprocessingPipelineSparkTestData.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/ReadsPreprocessingPipelineSparkTestData.java
@@ -1,0 +1,195 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.collect.Lists;
+import htsjdk.samtools.SAMRecord;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReadContextData;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceShard;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.VariantShard;
+import org.broadinstitute.hellbender.exceptions.GATKException;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.reference.ReferenceBases;
+import org.broadinstitute.hellbender.utils.test.FakeReferenceSource;
+import org.broadinstitute.hellbender.utils.variant.SkeletonVariant;
+import org.broadinstitute.hellbender.utils.variant.Variant;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * ReadsPreprocessingPipelineTestData contains coordinated test data that can be used in the many transforms that
+ * are a part of the ReadsPreprocessingPipeline.
+ */
+public class ReadsPreprocessingPipelineSparkTestData {
+    private final List<KV<Integer, Integer>> readStartLength;
+
+    private final List<GATKRead> reads;
+    private final List<SimpleInterval> readIntervals;
+    private final List<SimpleInterval> allIntervals;
+    private final List<Variant> variants;
+    private final List<KV<GATKRead, ReferenceBases>> kvReadsRefBases;
+    private final List<KV<GATKRead, Variant>> kvReadVariant;
+    private final List<KV<GATKRead, Iterable<Variant>>> kvReadiVariant;
+    private final List<KV<GATKRead, ReadContextData>> kvReadContextData;
+
+
+    /**
+     * ReadsPreprocessingPipelineTestData holds a bunch of connected data for testing classes that work with
+     * reads, variants, references bases and pairing those types together.
+     * @param clazz The class to be used to back the GATKRead, either Read.class, or SAMRecord.class.
+     */
+    public ReadsPreprocessingPipelineSparkTestData(Class<?> clazz) {
+        readStartLength = Arrays.asList(KV.of(100, 50), KV.of(140, 100),
+                KV.of(ReferenceShard.REFERENCE_SHARD_SIZE, 10),
+                KV.of(3*ReferenceShard.REFERENCE_SHARD_SIZE - 1, 10));
+
+        reads = Lists.newArrayList(
+                makeRead("1", readStartLength.get(0), 1, clazz),
+                makeRead("1", readStartLength.get(1), 2, clazz),
+                makeRead("1", readStartLength.get(2), 3, clazz),
+                makeRead("1", readStartLength.get(3), 4, clazz),
+                makeRead("2", readStartLength.get(2), 5, clazz)
+                );
+
+        readIntervals = Lists.newArrayList(
+                makeInterval("1", readStartLength.get(0)),
+                makeInterval("1", readStartLength.get(1)),
+                makeInterval("1", readStartLength.get(2)),
+                makeInterval("1", readStartLength.get(3)),
+                makeInterval("2", readStartLength.get(2))
+                );
+
+        // The first two reads are mapped onto the same reference shard. The ReferenceBases returned should
+        // be from the start of the first read [rStartLength.get(0).getKey()] to the end
+        // the second [rStartLength.get(1).getKey() + rStartLength.get(1).getValue()-1].
+        SimpleInterval spannedReadInterval =
+                new SimpleInterval("1", readStartLength.get(0).getKey(), readStartLength.get(1).getKey() + readStartLength.get(1).getValue()-1);
+
+        allIntervals = Lists.newArrayList(readIntervals.iterator());
+        allIntervals.add(spannedReadInterval);
+
+        kvReadsRefBases = Arrays.asList(
+                KV.of(reads.get(0), getBases("1", reads.get(0).getStart(), reads.get(0).getEnd())),
+                KV.of(reads.get(1), getBases("1", reads.get(1).getStart(), reads.get(1).getEnd())),
+                KV.of(reads.get(2), getBases("1", reads.get(2).getStart(), reads.get(2).getEnd())),
+                KV.of(reads.get(3), getBases("1", reads.get(3).getStart(), reads.get(3).getEnd())),
+                KV.of(reads.get(4), getBases("2", reads.get(4).getStart(), reads.get(4).getEnd()))
+        );
+
+        variants = Lists.newArrayList(
+                new SkeletonVariant(new SimpleInterval("1", 170, 180), true, false, new UUID(1001, 1001)),
+                new SkeletonVariant(new SimpleInterval("1", 210, 220), false, true, new UUID(1002, 1002)),
+                new SkeletonVariant(new SimpleInterval("1", ReferenceShard.REFERENCE_SHARD_SIZE,
+                        ReferenceShard.REFERENCE_SHARD_SIZE), true, false, new UUID(1003, 1003)),
+                new SkeletonVariant(new SimpleInterval("1", 3 * ReferenceShard.REFERENCE_SHARD_SIZE - 2,
+                        3 * ReferenceShard.REFERENCE_SHARD_SIZE + 2), false, true, new UUID(1004, 1004)),
+                new SkeletonVariant(new SimpleInterval("2", ReferenceShard.REFERENCE_SHARD_SIZE,
+                        ReferenceShard.REFERENCE_SHARD_SIZE), false, true, new UUID(1005, 1005))
+        );
+
+        kvReadVariant = Arrays.asList(
+                KV.of(reads.get(1), variants.get(0)),
+                KV.of(reads.get(1), variants.get(1)),
+                KV.of(reads.get(2), variants.get(2)),
+                KV.of(reads.get(3), variants.get(3)),    // The read and variant span two variant shards, that's
+                KV.of(reads.get(3), variants.get(3)),     // why there are two of them (2,3).
+                KV.of(reads.get(4), variants.get(4))
+        );
+        final KV<GATKRead, Variant> readNullVariant = KV.of(reads.get(0), null);
+
+        Iterable<Variant> variant10 = Lists.newArrayList(kvReadVariant.get(1).getValue(), kvReadVariant.get(0).getValue());
+        Iterable<Variant> variant2 = Lists.newArrayList(kvReadVariant.get(2).getValue());
+        Iterable<Variant> variant3 = Lists.newArrayList(kvReadVariant.get(3).getValue());
+        Iterable<Variant> variant4 = Lists.newArrayList(kvReadVariant.get(5).getValue());
+        Iterable<Variant> nullVariant = Lists.newArrayList(readNullVariant.getValue());
+
+        kvReadiVariant = Arrays.asList(
+                KV.of(kvReadVariant.get(0).getKey(), variant10),
+                KV.of(kvReadVariant.get(2).getKey(), variant2),
+                KV.of(kvReadVariant.get(3).getKey(), variant3),
+                KV.of(kvReadVariant.get(5).getKey(), variant4),
+                KV.of(reads.get(0), nullVariant)
+        );
+
+        kvReadContextData = Arrays.asList(
+                KV.of(kvReadsRefBases.get(0).getKey(), new ReadContextData(kvReadsRefBases.get(0).getValue(), Lists.newArrayList())),
+                KV.of(kvReadsRefBases.get(1).getKey(), new ReadContextData(kvReadsRefBases.get(1).getValue(), kvReadiVariant.get(0).getValue())),
+                KV.of(kvReadsRefBases.get(2).getKey(), new ReadContextData(kvReadsRefBases.get(2).getValue(), kvReadiVariant.get(1).getValue())),
+                KV.of(kvReadsRefBases.get(3).getKey(), new ReadContextData(kvReadsRefBases.get(3).getValue(), kvReadiVariant.get(2).getValue())),
+                KV.of(kvReadsRefBases.get(4).getKey(), new ReadContextData(kvReadsRefBases.get(4).getValue(), kvReadiVariant.get(3).getValue()))
+        );
+    }
+
+    /**
+     * makeRead creates a read backed by either SAMRecord or Google model Read.
+     * @param startLength the key is the start of the read, the value is the length.
+     * @param i name, note that if a different i is used, then two otherwise identical reads are not equal.
+     * @param clazz either Google model Read or SAMRecord
+     * @return a new GAKTRead with either a Google model backed or SAMRecord backed read.
+     */
+    public static GATKRead makeRead(String contig, KV<Integer, Integer> startLength, int i, Class<?> clazz) {
+        return makeRead(contig, startLength.getKey(), startLength.getValue(),i, clazz);
+    }
+
+    /**
+     * makeRead creates a read backed by either SAMRecord or Google model Read.
+     * @param start start position of the read
+     * @param length length of the read
+     * @param i name, note that if a different i is used, then two otherwise identical reads are not equal.
+     * @param clazz either Google model Read or SAMRecord
+     * @return a new GAKTRead with either a Google model backed or SAMRecord backed read.
+     */
+    public static GATKRead makeRead(String contig, int start, int length, int i, Class<?> clazz) {
+        if (clazz == Read.class) {
+            return ArtificialReadUtils.createGoogleBackedReadWithUUID(new UUID(0, 0), Integer.toString(i), contig, start, length);
+        } else if (clazz == SAMRecord.class) {
+            return ArtificialReadUtils.createSamBackedReadWithUUID(new UUID(0, 0), Integer.toString(i), contig, start, length);
+        } else {
+            throw new GATKException("invalid GATKRead type");
+        }
+    }
+
+    private SimpleInterval makeInterval(String contig, KV<Integer, Integer> startLength) {
+        return new SimpleInterval(contig, startLength.getKey(), startLength.getKey() + startLength.getValue() - 1);
+    }
+
+    private ReferenceBases getBases(String contig, int start, int end) {
+        return FakeReferenceSource.bases(new SimpleInterval(contig, start, end));
+    }
+
+    public List<SimpleInterval> getAllIntervals() {
+        return allIntervals;
+    }
+
+    public List<GATKRead> getReads() {
+        return reads;
+    }
+
+    public List<KV<GATKRead, ReferenceBases>> getKvReadsRefBases() {
+        return kvReadsRefBases;
+    }
+
+    public List<Variant> getVariants() {
+        return variants;
+    }
+
+    public List<KV<GATKRead, ReadContextData>> getKvReadContextData() {
+        return kvReadContextData;
+    }
+
+    @Test
+    public static void verifyDivisibilityWithRefShard() {
+        // We want the ratio between the two shard types to be an int so we can use them more easily for testing.
+        Assert.assertEquals(Math.floorMod(ReferenceShard.REFERENCE_SHARD_SIZE, VariantShard.VARIANT_SHARDSIZE), 0);
+    }
+
+    public List<KV<GATKRead, Iterable<Variant>>> getKvReadiVariant() {
+        return kvReadiVariant;
+    }
+}

--- a/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/engine/spark/SAMRecordToGATKReadAdapterSerializerUnitTest.java
@@ -1,0 +1,49 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.esotericsoftware.kryo.Kryo;
+import org.apache.spark.SparkConf;
+import org.apache.spark.serializer.KryoRegistrator;
+import org.apache.spark.serializer.KryoSerializer;
+import org.apache.spark.serializer.SerializerInstance;
+import org.broadinstitute.hellbender.utils.read.ArtificialReadUtils;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.SAMRecordToGATKReadAdapter;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
+
+import java.util.UUID;
+
+public class SAMRecordToGATKReadAdapterSerializerUnitTest {
+
+    public static class TestGATKRegistrator implements KryoRegistrator {
+        @SuppressWarnings("unchecked")
+        @Override
+        public void registerClasses(Kryo kryo) {
+            kryo.register(SAMRecordToGATKReadAdapter.class, new SAMRecordToGATKReadAdapterSerializer());
+        }
+    }
+
+    @Test
+    public void test() {
+        SparkConf conf = new SparkConf().set("spark.kryo.registrator",
+                "org.broadinstitute.hellbender.engine.spark.SAMRecordToGATKReadAdapterSerializerUnitTest$TestGATKRegistrator");
+        KryoSerializer kryoSerializer = new KryoSerializer(conf);
+        SerializerInstance sparkSerializer = kryoSerializer.newInstance();
+
+        // check round trip with header set
+        GATKRead read = ArtificialReadUtils.createSamBackedReadWithUUID(new UUID(0, 0), "read1", "1", 100, 50);
+        check(sparkSerializer, read);
+
+        // check round trip with no header
+        ((SAMRecordToGATKReadAdapter) read).getSamRecord().setHeader(null);
+        check(sparkSerializer, read);
+    }
+
+    private void check(SerializerInstance ser, GATKRead read) {
+        final ClassTag<GATKRead> tag = ClassTag$.MODULE$.apply(SAMRecordToGATKReadAdapter.class);
+        Assert.assertEquals(ser.deserialize(ser.serialize(read, tag), tag), read);
+    }
+}


### PR DESCRIPTION
This improves the serialized size considerably, which has a very big effect on the amount of data going through the shuffle.

* SAMRecordToGATKReadAdapterSerializer uses BAMRecordCodec for a compact serialization format.
* Record headers are not needed since GATKRead is intended to abstract them away. Note that the reference name is serialized separately so it can be preserved.
* ReadsPreprocessingPipelineSparkTestData creates reads with zero UUIDs since they are not used in Spark.