### PR TITLE
Remove one shuffle by processing fragments and paired ends together.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/PairedEnds.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/PairedEnds.java
@@ -40,6 +40,10 @@ public class PairedEnds implements OpticalDuplicateFinder.PhysicalLocation {
     return ReadsKey.keyForPairedEnds(header, first, second);
   }
 
+  public String keyForFragment(final SAMFileHeader header) {
+    return ReadsKey.keyForFragment(header, first);
+  }
+
   public GATKRead first() {
     return first;
   }

--- a/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/ReadsKey.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/ReadsKey.java
@@ -9,10 +9,21 @@ import org.broadinstitute.hellbender.utils.read.ReadUtils;
  */
 public final class ReadsKey {
 
+    public static final String FRAGMENT_PREFIX = "f|";
+
+    private static final String PAIRED_ENDS_PREFIX = "p|";
+
     /**
      * Makes a unique key for the fragment.
      */
     public static String keyForFragment(final SAMFileHeader header, final GATKRead read) {
+        return FRAGMENT_PREFIX + subkeyForFragment(header, read);
+    }
+
+    /**
+     * Makes a unique key for the fragment (excluding the prefix).
+     */
+    private static String subkeyForFragment(final SAMFileHeader header, final GATKRead read) {
         final String library = ReadUtils.getLibrary(read, header);
 
         return String.format(
@@ -27,13 +38,13 @@ public final class ReadsKey {
      * Makes a unique key for the paired reads.
      */
     public static String keyForPairedEnds(final SAMFileHeader header, final GATKRead first, final GATKRead second) {
-        final String key = keyForFragment(header, first);
+        final String key = subkeyForFragment(header, first);
         if (second == null) {
-            return key;
+            return PAIRED_ENDS_PREFIX + key;
         }
 
         return String.format(
-                "%s|%d|%d|%s",
+                PAIRED_ENDS_PREFIX + "%s|%d|%d|%s",
                 key,
                 ReadUtils.getReferenceIndex(second, header),
                 ReadUtils.getStrandedUnclippedStart(second),
@@ -48,5 +59,12 @@ public final class ReadsKey {
                 "%s|%s",
                 read.getReadGroup(),
                 read.getName());
+    }
+
+    /**
+     * Returns true if the key is a fragment key.
+     */
+    public static boolean isFragment(String key) {
+        return key.startsWith(FRAGMENT_PREFIX);
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -60,12 +60,11 @@ public final class MarkDuplicatesSpark extends SparkCommandLineProgram {
     public static JavaRDD<GATKRead> mark(final JavaRDD<GATKRead> reads, final SAMFileHeader header,
                                          final OpticalDuplicateFinder opticalDuplicateFinder, final int parallelism) {
 
-        JavaRDD<GATKRead> fragments = reads.filter(v1 -> !isNonPrimary(v1));
+        JavaRDD<GATKRead> primaryReads = reads.filter(v1 -> !isNonPrimary(v1));
         JavaRDD<GATKRead> nonPrimaryReads = reads.filter(v1 -> isNonPrimary(v1));
-        JavaRDD<GATKRead> pairsTransformed = MarkDuplicatesSparkUtils.transformReads(header, opticalDuplicateFinder, fragments, parallelism);
+        JavaRDD<GATKRead> primaryReadsTransformed = MarkDuplicatesSparkUtils.transformReads(header, opticalDuplicateFinder, primaryReads, parallelism);
 
-        JavaRDD<GATKRead> fragmentsTransformed = MarkDuplicatesSparkUtils.transformFragments(header, fragments, parallelism);
-        return fragmentsTransformed.union(pairsTransformed).union(nonPrimaryReads);
+        return primaryReadsTransformed.union(nonPrimaryReads);
     }
 
     private static boolean isNonPrimary(GATKRead read) {

--- a/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/ReadsKeyTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/dataflow/transforms/markduplicates/ReadsKeyTest.java
@@ -21,7 +21,7 @@ public final class ReadsKeyTest {
         final boolean reverseStrand = false;
         read.setIsReverseStrand(reverseStrand);
         final String strandStr = reverseStrand ? "r": "f";
-        final String key = "-" + "|" + refIndex + "|" + alignmentStart + "|" + strandStr;
+        final String key = ReadsKey.FRAGMENT_PREFIX + "-" + "|" + refIndex + "|" + alignmentStart + "|" + strandStr;
 
         return new Object[][]{
                 new Object[]{header, read, key},


### PR DESCRIPTION
This is not ready to be merged since 4 tests are failing (MarkDuplicatesSparkIntegrationTest#testMarkDuplicatesSparkIntegrationTestLocal).

The thing that is different about these tests is that they have paired reads where the read names differ for the two reads in a pair. So handling these as fragments *after* grouping by read group and name means that the reads are not brought together in the way that they are being in the current version (with the extra shuffle). It's possible there's a fix for this, but I haven't spotted it yet. Extra eyes on this would be welcome.