### PR TITLE
Exclude unnecessary transitive dependencies from ADAM.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,13 @@ dependencies {
     }
 
     compile 'org.bdgenomics.bdg-formats:bdg-formats:0.5.0'
-    compile 'org.bdgenomics.adam:adam-core_2.10:0.17.1'
+    compile('org.bdgenomics.adam:adam-core_2.10:0.17.1') {
+        exclude group: 'org.slf4j'
+        exclude group: 'org.apache.hadoop'
+        exclude group: 'org.scala-lang'
+        exclude module: 'kryo'
+        exclude module: 'hadoop-bam'
+    }
 
     // we don't need this guy. Plus, it asks for the latest version
     // of com.google.http-client:google-http-client-jackson2,
@@ -292,6 +298,7 @@ configurations {
         // (ref: http://unethicalblogger.com/2015/07/15/gradle-goodness-excluding-depends-from-shadow.html)
         exclude group: 'org.apache.hadoop'
         exclude module: 'spark-core_2.10'
+        exclude group: 'org.slf4j'
     }
 }
 
@@ -308,6 +315,7 @@ task sparkJar(type: ShadowJar) {
     mergeServiceFiles()
     relocate 'com.google.common', 'org.broadinstitute.hellbender.relocated.com.google.common'
     zip64 true
+    exclude 'log4j.properties' // from adam jar as it clashes with hellbender's log4j2.xml
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
The ADAM jar was pulling in dependencies that should not be in the sparkJar since they stop it working on a cluster.