### PR TITLE
fixing dataflow/spark bqsr concurrency issues

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/dataflow/DataflowCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/dataflow/DataflowCommandLineProgram.java
@@ -13,7 +13,6 @@ import com.google.cloud.dataflow.sdk.runners.DataflowPipelineRunner;
 import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner;
 import com.google.cloud.dataflow.sdk.runners.PipelineRunner;
 import com.google.cloud.genomics.dataflow.utils.GCSOptions;
-import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.common.annotations.VisibleForTesting;
 import org.broadinstitute.hellbender.cmdline.Argument;
@@ -140,7 +139,7 @@ public abstract class DataflowCommandLineProgram extends CommandLineProgram impl
 
     @Argument(doc = "The Google Compute Engine machine type that Dataflow will use when spinning up worker VMs",
          fullName = "workerMachineType", optional=true)
-    protected String workerMachineType = "n1-standard-1";
+    protected String workerMachineType = "n1-standard-4";
 
     @Argument(fullName = "sparkMaster", doc="URL of the Spark Master to submit jobs to when using the Spark pipeline runner.", optional = true)
     protected String sparkMaster;

--- a/src/main/java/org/broadinstitute/hellbender/tools/recalibration/ReadCovariates.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/recalibration/ReadCovariates.java
@@ -25,14 +25,19 @@ public final class ReadCovariates {
      * keeps the total number of cached arrays to less than LRU_CACHE_SIZE.
      *
      */
-    private static final LRUCache<Integer, int[][][]> keysCache = new LRUCache<>(LRU_CACHE_SIZE);
+    private static final ThreadLocal<LRUCache<Integer, int[][][]>> keysCache = new ThreadLocal<LRUCache<Integer, int[][][]>>(){
+        @Override
+        protected LRUCache<Integer, int[][][]> initialValue() {
+            return new LRUCache<>(LRU_CACHE_SIZE);
+        }
+    };
 
     /**
      * The keys cache is only valid for a single covariate count.  Normally this will remain constant for the analysis.
      * If running multiple analyses (or the unit test suite), it's necessary to clear the cache.
      */
     public static void clearKeysCache() {
-        keysCache.clear();
+        keysCache.get().clear();
     }
 
     /**
@@ -46,7 +51,7 @@ public final class ReadCovariates {
     private int currentCovariateIndex = 0;
 
     public ReadCovariates(final int readLength, final int numberOfCovariates) {
-        final LRUCache<Integer, int[][][]> cache = keysCache;
+        final LRUCache<Integer, int[][][]> cache = keysCache.get();
         final int[][][] cachedKeys = cache.get(readLength);
         if ( cachedKeys == null ) {
             // There's no cached value for read length so we need to create a new int[][][] array


### PR DESCRIPTION
wrapping ReadCovariate.keyCache in a ThreadLocal to prevent multithreading issues
changing worker type for dataflow to 4-core
