### PR TITLE
Remove protective copying operations from the spark BQSR

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/ApplyBQSRSparkFn.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/ApplyBQSRSparkFn.java
@@ -15,8 +15,7 @@ public class ApplyBQSRSparkFn {
         return reads.map(read -> {
             RecalibrationReport report = reportBroadcast.getValue();
             BQSRReadTransformer transformer = new BQSRReadTransformer(readsHeader, report, args);
-            // TODO: remove protective copy?
-            return transformer.apply(read.copy());
+            return transformer.apply(read);
         });
     }
 }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/BaseRecalibratorSparkFn.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/BaseRecalibratorSparkFn.java
@@ -45,7 +45,7 @@ public class BaseRecalibratorSparkFn {
             return new ArrayList<>(Arrays.asList(bqsr.getRecalibrationTables()));
         });
 
-        final RecalibrationTables combinedTables = unmergedTables.reduce(RecalibrationTables::safeCombine);
+        final RecalibrationTables combinedTables = unmergedTables.reduce(RecalibrationTables::inPlaceCombine);
         BaseRecalibrationEngine.finalizeRecalibrationTables(combinedTables);
 
         try {

--- a/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationTables.java
+++ b/src/main/java/org/broadinstitute/hellbender/utils/recalibration/RecalibrationTables.java
@@ -149,6 +149,13 @@ public final class RecalibrationTables implements Serializable, Iterable<NestedI
         return this;
     }
 
+    /**
+     * Combines the two tables into a new table (allocating a new table in the process)
+     *
+     * @param left first table to combine
+     * @param right second table to combine
+     * @return a new table with the merged contents of left and right
+     */
     public static RecalibrationTables safeCombine(final RecalibrationTables left, final RecalibrationTables right){
         Utils.nonNull(left);
         Utils.nonNull(right);
@@ -157,6 +164,20 @@ public final class RecalibrationTables implements Serializable, Iterable<NestedI
         newTable.combine(left);
         newTable.combine(right);
         return newTable;
+    }
+
+    /**
+     * Combines the right table into the left table, in-place (without making a copy)
+     *
+     * @param left first table to combine
+     * @param right second table to combine
+     * @return modified version of left with the contents of right incorporated into it
+     */
+    public static RecalibrationTables inPlaceCombine(final RecalibrationTables left, final RecalibrationTables right){
+        Utils.nonNull(left);
+        Utils.nonNull(right);
+
+        return left.combine(right);
     }
 
     //XXX this should not be accessible by index


### PR DESCRIPTION
Turns out these may not be needed in spark (unlike in dataflow).
Let's get expert confirmation that this is the case, however,
before merging.