### PR TITLE
Add a dbsnp 138 vcf snippet with variants from the first 65 mbp of chromosome 1

### DIFF
--- a/src/test/resources/large/.gitattributes
+++ b/src/test/resources/large/.gitattributes
@@ -7,3 +7,5 @@ human_g1k_v37.20.21.dict filter=lfs diff=lfs merge=lfs -text
 human_g1k_v37.20.21.fasta filter=lfs diff=lfs merge=lfs -text
 human_g1k_v37.20.21.fasta.fai filter=lfs diff=lfs merge=lfs -text
 exampleLargeFile.txt filter=lfs diff=lfs merge=lfs -text
+dbsnp_138.b37.1.1-65M.vcf filter=lfs diff=lfs merge=lfs -text
+dbsnp_138.b37.1.1-65M.vcf.idx filter=lfs diff=lfs merge=lfs -text

--- a/src/test/resources/large/dbsnp_138.b37.1.1-65M.vcf
+++ b/src/test/resources/large/dbsnp_138.b37.1.1-65M.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8947c455bad5761570e1c70fc972aff5432b07061f085ef5ad123b3b741d7891
+size 237432747

--- a/src/test/resources/large/dbsnp_138.b37.1.1-65M.vcf.idx
+++ b/src/test/resources/large/dbsnp_138.b37.1.1-65M.vcf.idx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dc0ef4be816c2daca0045668d8143cbf522b723b38e4fa33f1aec0cebab50f5
+size 262025


### PR DESCRIPTION
Requires a "git lfs pull" to access. File size is ~230 MB.