### PR TITLE
interval handing in count reads + tests

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
@@ -1,17 +1,22 @@
 package org.broadinstitute.hellbender.tools.spark.pipelines;
 
+import htsjdk.samtools.SAMFileHeader;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalIntervalArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.ReadInputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.RequiredReadInputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
 import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
 import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.IntervalUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
@@ -19,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.List;
 
 @CommandLineProgramProperties(summary = "Counts reads in the input BAM", oneLineSummary = "Counts reads in a BAM file", programGroup = SparkProgramGroup.class)
 public final class CountReadsSpark extends SparkCommandLineProgram {
@@ -27,6 +33,9 @@ public final class CountReadsSpark extends SparkCommandLineProgram {
 
     @ArgumentCollection
     public ReadInputArgumentCollection readArguments= new RequiredReadInputArgumentCollection();;
+
+    @ArgumentCollection
+    private IntervalArgumentCollection intervalArgumentCollection = new OptionalIntervalArgumentCollection();
 
     @Argument(doc = "uri for the output file: a local file path",
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
@@ -40,7 +49,15 @@ public final class CountReadsSpark extends SparkCommandLineProgram {
         }
         final String bam = readArguments.getReadFilesNames().get(0);
         final ReadsSparkSource readSource = new ReadsSparkSource(ctx);
-        final JavaRDD<GATKRead> reads = readSource.getParallelReads(bam, null);
+
+        SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam);
+        /**
+         * If no intervals are provided, we want all reads, mapped and unmapped.
+         */
+        final List<SimpleInterval> intervals = intervalArgumentCollection.intervalsSpecified() ? intervalArgumentCollection.getIntervals(readsHeader.getSequenceDictionary())
+                : null;
+
+        final JavaRDD<GATKRead> reads = readSource.getParallelReads(bam, intervals);
         final long count = reads.count();
         System.out.println(count);
         if (out != null){

--- a/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSparkIntegrationTest.java
+++ b/src/test/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSparkIntegrationTest.java
@@ -4,7 +4,9 @@ import org.apache.commons.io.FileUtils;
 import org.broadinstitute.hellbender.CommandLineProgramTest;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.utils.test.ArgumentsBuilder;
+import org.broadinstitute.hellbender.utils.text.XReadLines;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -29,4 +31,39 @@ public final class CountReadsSparkIntegrationTest extends CommandLineProgramTest
         Assert.assertEquals((int)Integer.valueOf(readIn), 8);
     }
 
+    @DataProvider(name="intervals")
+    public Object[][] intervals(){
+        return new Object[][]{
+                new Object[]{"",8L}, // no intervals specified, see all reads that are aligned and not aligned
+                new Object[]{"-L chr7:1", 3l},
+                new Object[]{"-L chr7:1-20", 4l},
+                new Object[]{"-L chr1", 0l},
+                new Object[]{"-L chr1 -L chr7", 7l},
+                new Object[]{"-XL chr7", 0l},
+                new Object[]{"-XL chr7:2-404", 3l},
+                new Object[]{"-L chr7:1-30 -L chr7:10-15 --interval_set_rule INTERSECTION", 3l},
+                new Object[]{"-L chr7:1 --interval_padding 19", 4l },
+                new Object[]{"-L " + getTestDataDir() + "/chr7_1_20.interval_list", 4l},
+                new Object[]{"-L chr7:1-100 -XL chr7:2-100", 3l},
+                new Object[]{"-L chr7:1-10 -L chr7:5-10 --interval_padding 10 --interval_set_rule INTERSECTION --XL chr7:21-200", 4l }
+        };
+    }
+
+
+    @Test(dataProvider = "intervals")
+    public void testCountReadsWithIntervals(final String interval_args, final long expectedCount) throws Exception {
+        final File ORIG_BAM = new File(getTestDataDir(), "count_reads_sorted.bam");
+        final File outputFile = createTempFile("count_reads_spark","count");
+        ArgumentsBuilder args = new ArgumentsBuilder();
+        args.add("--"+ StandardArgumentDefinitions.INPUT_LONG_NAME); args.add(ORIG_BAM.getAbsolutePath());
+        args.add(interval_args);
+        args.add("--"+StandardArgumentDefinitions.OUTPUT_LONG_NAME); args.add(outputFile);
+
+        this.runCommandLine(args.getArgsArray());
+
+        try(XReadLines output = new XReadLines(outputFile)){
+            Assert.assertEquals((long)Long.valueOf(output.next()), expectedCount);
+        }
+
+    }
 }


### PR DESCRIPTION
Added handling of interval to count reads.
Additional tests are ported from the dataflow side: CountReadsDataflowIntegrationTest
Note that the semantics of no specifying any -L is to count **all** reads, aligned and unaligned.