### PR TITLE
Fix for ReadsPipelineSpark: do not invoke MarkDuplicatesSpark.mark() with parallelism == 0

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/ReadsPipelineSpark.java
@@ -88,7 +88,7 @@ public class ReadsPipelineSpark extends SparkCommandLineProgram {
                 : IntervalUtils.getAllIntervalsForReference(readsHeader.getSequenceDictionary());
         JavaRDD<GATKRead> initialReads = readSource.getParallelReads(bam, intervals);
 
-        JavaRDD<GATKRead> markedReads = MarkDuplicatesSpark.mark(initialReads, readsHeader, new OpticalDuplicateFinder(), 0);
+        JavaRDD<GATKRead> markedReads = MarkDuplicatesSpark.mark(initialReads, readsHeader, new OpticalDuplicateFinder());
         VariantsSparkSource variantsSparkSource = new VariantsSparkSource(ctx);
 
         // TODO: workaround for known bug in List version of getParallelVariants

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -58,6 +58,11 @@ public final class MarkDuplicatesSpark extends SparkCommandLineProgram {
     protected IntervalArgumentCollection intervalArgumentCollection = new OptionalIntervalArgumentCollection();
 
     public static JavaRDD<GATKRead> mark(final JavaRDD<GATKRead> reads, final SAMFileHeader header,
+                                         final OpticalDuplicateFinder opticalDuplicateFinder) {
+        return mark(reads, header, opticalDuplicateFinder, reads.partitions().size());
+    }
+
+    public static JavaRDD<GATKRead> mark(final JavaRDD<GATKRead> reads, final SAMFileHeader header,
                                          final OpticalDuplicateFinder opticalDuplicateFinder, final int parallelism) {
 
         JavaRDD<GATKRead> primaryReads = reads.filter(v1 -> !isNonPrimary(v1));


### PR DESCRIPTION
This was causing all mapped reads to be discarded.