### PR TITLE
Fix performance bug in the FeatureDataSource caching code

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/FeatureDataSource.java
@@ -483,11 +483,11 @@ public final class FeatureDataSource<T extends Feature> implements GATKDataSourc
         // Note that it doesn't matter if we go off the end of the contig in the process, since
         // our reader's query operation is not aware of (and does not care about) contig boundaries.
         // Note: we use addExact to blow up on overflow rather than propagate negative results downstream
-        final int queryStop = Math.addExact(interval.getEnd(), queryLookaheadBases);
+        final SimpleInterval queryInterval = new SimpleInterval(interval.getContig(), interval.getStart(), Math.addExact(interval.getEnd(), queryLookaheadBases));
 
         // Query iterator over our reader will be immediately closed after re-populating our cache
-        try ( CloseableTribbleIterator<T> queryIter = featureReader.query(interval.getContig(), interval.getStart(), queryStop) ) {
-            queryCache.fill(queryIter, interval);
+        try ( CloseableTribbleIterator<T> queryIter = featureReader.query(queryInterval.getContig(), queryInterval.getStart(), queryInterval.getEnd()) ) {
+            queryCache.fill(queryIter, queryInterval);
         }
         catch ( IOException e ) {
             throw new GATKException("Error querying file " + featureFile.getAbsolutePath() + " over interval " + interval, e);


### PR DESCRIPTION
FeatureDataSource was not correctly keeping track of the interval covered
by the contents of its cache, and as a result was producing many more
cache misses than it should have.