### PR TITLE
Bake some commonly-used Spark options into SparkCommandLineProgram

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/SparkCommandLineProgram.java
@@ -31,9 +31,11 @@ public abstract class SparkCommandLineProgram extends CommandLineProgram impleme
     @Override
     protected Object doWork() {
         final JavaSparkContext ctx = SparkContextFactory.getSparkContext(getProgramName(), sparkMaster);
-        ctx.getConf().set("spark.driver.userClassPathFirst", "true")
+        ctx.getConf().set("spark.driver.maxResultSize", "0")
+                .set("spark.driver.userClassPathFirst", "true")
                 .set("spark.executor.userClassPathFirst", "true")
-                .set("spark.io.compression.codec", "lzf");
+                .set("spark.io.compression.codec", "lzf")
+                .set("spark.yarn.executor.memoryOverhead", "600");
 
         try{
             runPipeline(ctx);


### PR DESCRIPTION
These are options that we've found it necessary to use in order to
get hellbender tools to play nice with Spark.