### PR TITLE
GATKSparkTool: first step towards unifying handling of standard tool inputs in Spark

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
+++ b/src/main/java/org/broadinstitute/hellbender/engine/spark/GATKSparkTool.java
@@ -1,0 +1,263 @@
+package org.broadinstitute.hellbender.engine.spark;
+
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
+import com.google.cloud.genomics.dataflow.utils.GCSOptions;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceDictionary;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
+import org.broadinstitute.hellbender.cmdline.argumentcollections.*;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.RefWindowFunctions;
+import org.broadinstitute.hellbender.engine.dataflow.datasources.ReferenceDataflowSource;
+import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
+import org.broadinstitute.hellbender.exceptions.UserException;
+import org.broadinstitute.hellbender.utils.SequenceDictionaryUtils;
+import org.broadinstitute.hellbender.utils.SimpleInterval;
+import org.broadinstitute.hellbender.utils.read.GATKRead;
+
+import java.util.List;
+
+/**
+ * Base class for GATK spark tools that accept standard kinds of inputs (reads, reference, and/or intervals).
+ * Centralizes handling of tool inputs to enforce consistency, reduce duplicated boilerplate code
+ * in tools, and apply standardized validation (such as sequence dictionary validation).
+ *
+ * Spark tools that do not fit into this pattern should extend SparkCommandLineProgram directly instead of
+ * this class.
+ *
+ * USAGE:
+ *
+ * -Tools must implement {@link #runTool}.
+ *
+ * -Tools should override {@link #requiresReference}, {@link #requiresReads}, and/or {@link #requiresIntervals}
+ *  as appropriate to indicate required inputs.
+ *
+ * -Tools can query whether certain inputs are present via {@link #hasReference}, {@link #hasReads}, and
+ *  {@link #hasIntervals}.
+ *
+ * -Tools can load the reads via {@link #getReads}, access the reference via {@link #getReference}, and
+ *  access the intervals via {@link #getIntervals}. Any intervals specified are automatically applied
+ *  to the reads. Input metadata is available via {@link #getHeaderForReads}, {@link #getReferenceSequenceDictionary},
+ *  and {@link #getBestAvailableSequenceDictionary}.
+ *
+ * -Tools that require a custom reference window function (extra bases of reference context around each read)
+ *  may override {@link #getReferenceWindowFunction} to supply one. This function will be propagated to the
+ *  reference source returned by {@link #getReference}.
+ */
+public abstract class GATKSparkTool extends SparkCommandLineProgram {
+    private static final long serialVersionUID = 1l;
+
+    @ArgumentCollection
+    public final ReferenceInputArgumentCollection referenceArguments = requiresReference() ? new RequiredReferenceInputArgumentCollection() :  new OptionalReferenceInputArgumentCollection();
+
+    @ArgumentCollection
+    public final ReadInputArgumentCollection readArguments = requiresReads() ? new RequiredReadInputArgumentCollection() : new OptionalReadInputArgumentCollection();
+
+    @ArgumentCollection
+    protected IntervalArgumentCollection intervalArgumentCollection = requiresIntervals() ? new RequiredIntervalArgumentCollection() : new OptionalIntervalArgumentCollection();
+
+    private JavaSparkContext sparkContext;
+    private ReadsSparkSource readsSource;
+    private SAMFileHeader readsHeader;
+    private String readInput;
+    private ReferenceDataflowSource referenceSource;
+    private SAMSequenceDictionary referenceDictionary;
+    private List<SimpleInterval> intervals;
+
+    /**
+     * Does this tool require reference data? Tools that do should override to return true.
+     *
+     * @return true if this tool requires a reference, otherwise false
+     */
+    public boolean requiresReference() {
+        return false;
+    }
+
+    /**
+     * Does this tool require reads? Tools that do should override to return true.
+     *
+     * @return true if this tool requires reads, otherwise false
+     */
+    public boolean requiresReads() {
+        return false;
+    }
+
+    /**
+     * Does this tool require intervals? Tools that do should override to return true.
+     *
+     * @return true if this tool requires intervals, otherwise false
+     */
+    public boolean requiresIntervals() {
+        return false;
+    }
+
+    /**
+     * Is a source of reference data available?
+     *
+     * @return true if a reference is available, otherwise false
+     */
+    public final boolean hasReference() {
+        return referenceSource != null;
+    }
+
+    /**
+     * Are sources of reads available?
+     *
+     * @return true if reads are available, otherwise false
+     */
+    public final boolean hasReads() {
+        return readsSource != null;
+    }
+
+    /**
+     * Are sources of intervals available?
+     *
+     * @return true if intervals are available, otherwise false
+     */
+    public final boolean hasIntervals() {
+        return intervals != null;
+    }
+
+    /**
+     * Window function that controls how much reference context to return for each read when
+     * using the reference source returned by {@link #getReference}. Tools should override
+     * as appropriate. The default function is the identity function (ie., return exactly
+     * the reference bases that span each read).
+     *
+     * @return reference window function used to initialize the reference source
+     */
+    public SerializableFunction<GATKRead, SimpleInterval> getReferenceWindowFunction() {
+        return RefWindowFunctions.IDENTITY_FUNCTION;
+    }
+
+    /**
+     * Returns the "best available" sequence dictionary. This will be the reference sequence dictionary if
+     * there is a reference, otherwise it will be the sequence dictionary constructed from the reads if
+     * there are reads, otherwise it will be null.
+     *
+     * TODO: check interval file(s) as well for a sequence dictionary
+     *
+     * @return best available sequence dictionary given our inputs
+     */
+    public SAMSequenceDictionary getBestAvailableSequenceDictionary() {
+        return hasReference() ? referenceDictionary : (hasReads() ? readsHeader.getSequenceDictionary() : null);
+    }
+
+    /**
+     * @return sequence dictionary for the reference, or null if there is no reference available
+     */
+    public SAMSequenceDictionary getReferenceSequenceDictionary() {
+        return referenceDictionary;
+    }
+
+    /**
+     * @return header for the reads, or null if there are no reads available
+     */
+    public SAMFileHeader getHeaderForReads() {
+        return readsHeader;
+    }
+
+    /**
+     * Loads the reads into a {@link JavaRDD} using the intervals specified. If no intervals
+     * were specified, returns all the reads (both mapped and unmapped).
+     *
+     * @return all reads from our reads input(s) as a {@link JavaRDD}, bounded by intervals if specified.
+     */
+    public JavaRDD<GATKRead> getReads() {
+        // If no intervals were specified (intervals == null), this will return all reads (mapped and unmapped)
+        return readsSource.getParallelReads(readInput, intervals);
+    }
+
+    /**
+     * @return our reference source, or null if no reference is present
+     */
+    public ReferenceDataflowSource getReference() {
+        return referenceSource;
+    }
+
+    /**
+     * @return our intervals, or null if no intervals were specified
+     */
+    public List<SimpleInterval> getIntervals() {
+        return intervals;
+    }
+
+    @Override
+    protected void runPipeline( JavaSparkContext sparkContext ) {
+        this.sparkContext = sparkContext;
+        initializeToolInputs();
+        validateToolInputs();
+        runTool(sparkContext);
+    }
+
+    /**
+     * Initialize standard tool inputs.
+     */
+    private void initializeToolInputs() {
+        initializeReads();
+        initializeReference();
+        initializeIntervals();
+    }
+
+    /**
+     * Initializes our reads source (but does not yet load the reads into a {@link JavaRDD}).
+     * Does nothing if no reads inputs are present.
+     */
+    private void initializeReads() {
+        if ( readArguments.getReadFilesNames().isEmpty() ) {
+            return;
+        }
+
+        if ( readArguments.getReadFilesNames().size() != 1 ) {
+            throw new UserException("Sorry, we only support a single reads input for spark tools for now.");
+        }
+
+        readInput = readArguments.getReadFilesNames().get(0);
+        readsSource = new ReadsSparkSource(sparkContext);
+        readsHeader = ReadsSparkSource.getHeader(sparkContext, readInput);
+    }
+
+    /**
+     * Initializes our reference source. Does nothing if no reference was specified.
+     */
+    private void initializeReference() {
+        final GCSOptions gcsOptions = getAuthenticatedGCSOptions(); // null if we have no api key
+        final String referenceURL = referenceArguments.getReferenceFileName();
+        if ( referenceURL != null ) {
+            referenceSource = new ReferenceDataflowSource(gcsOptions, referenceURL, getReferenceWindowFunction());
+            referenceDictionary = referenceSource.getReferenceSequenceDictionary(readsHeader != null ? readsHeader.getSequenceDictionary() : null);
+        }
+    }
+
+    /**
+     * Loads our intervals using the best available sequence dictionary (as returned by {@link #getBestAvailableSequenceDictionary})
+     * to parse/verify them. Does nothing if no intervals were specified.
+     */
+    private void initializeIntervals() {
+        if ( intervalArgumentCollection.intervalsSpecified() ) {
+            final SAMSequenceDictionary intervalDictionary = getBestAvailableSequenceDictionary();
+            if ( intervalDictionary == null ) {
+                throw new UserException("We require at least one input source that has a sequence dictionary (reference or reads) when intervals are specified");
+            }
+
+            intervals = intervalArgumentCollection.getIntervals(intervalDictionary);
+        }
+    }
+
+    /**
+     * Validates standard tool inputs against each other.
+     */
+    private void validateToolInputs() {
+        if ( hasReference() && hasReads() ) {
+            SequenceDictionaryUtils.validateDictionaries("reference", referenceDictionary, "reads", readsHeader.getSequenceDictionary());
+        }
+    }
+
+    /**
+     * Runs the tool itself after initializing and validating inputs. Must be implemented by subclasses.
+     *
+     * @param ctx our Spark context
+     */
+    protected abstract void runTool( JavaSparkContext ctx );
+}

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/ApplyBQSRSpark.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.hellbender.tools.spark;
 
-import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.genomics.dataflow.utils.GCSOptions;
-import htsjdk.samtools.SAMFileHeader;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -10,35 +8,27 @@ import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalIntervalArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.RequiredReadInputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
-import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSink;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.exceptions.UserException;
 import org.broadinstitute.hellbender.tools.ApplyBQSRArgumentCollection;
-import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
-import org.broadinstitute.hellbender.utils.recalibration.RecalibrationReport;
 import org.broadinstitute.hellbender.tools.spark.transforms.ApplyBQSRSparkFn;
-import org.broadinstitute.hellbender.utils.IntervalUtils;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
+import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
+import org.broadinstitute.hellbender.utils.recalibration.RecalibrationReport;
 
 import java.io.IOException;
-import java.util.List;
 
 @CommandLineProgramProperties(summary="Apply Base Quality Recalibration to a bam file using spark",
         oneLineSummary="apply BQSR on spark",
         programGroup = SparkProgramGroup.class)
-public final class ApplyBQSRSpark extends SparkCommandLineProgram{
+public final class ApplyBQSRSpark extends GATKSparkTool {
     private static final long serialVersionUID = 0l;
 
-    @ArgumentCollection
-    private final RequiredReadInputArgumentCollection readArguments = new RequiredReadInputArgumentCollection();
+    @Override
+    public boolean requiresReads() { return true; }
 
     @Argument(doc = "the output bam", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
@@ -53,33 +43,21 @@ public final class ApplyBQSRSpark extends SparkCommandLineProgram{
     private String bqsrRecalFile;
 
     @ArgumentCollection
-    private IntervalArgumentCollection intervalArgumentCollection = new OptionalIntervalArgumentCollection();
-
-    @ArgumentCollection
     private ApplyBQSRArgumentCollection applyBQSRArgs = new ApplyBQSRArgumentCollection();
 
     @Argument(doc = "If specified, shard the output bam", shortName = "shardedOutput", fullName = "shardedOutput", optional = true)
     private boolean shardedOutput = false;
 
     @Override
-    protected void runPipeline(JavaSparkContext ctx) {
-        if ( readArguments.getReadFilesNames().size() != 1 ) {
-            throw new UserException("This tool only accepts a single bam/sam/cram as input");
-        }
-        final String bam = readArguments.getReadFilesNames().get(0);
-
-        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
-        SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam);
-        final List<SimpleInterval> intervals = intervalArgumentCollection.intervalsSpecified() ? intervalArgumentCollection.getIntervals(readsHeader.getSequenceDictionary())
-                : IntervalUtils.getAllIntervalsForReference(readsHeader.getSequenceDictionary());
-        JavaRDD<GATKRead> initialReads = readSource.getParallelReads(bam, intervals);
+    protected void runTool(JavaSparkContext ctx) {
+        JavaRDD<GATKRead> initialReads = getReads();
 
         final GCSOptions gcsOptions = getAuthenticatedGCSOptions(); // null if we have no api key
         Broadcast<RecalibrationReport> recalibrationReportBroadCast = ctx.broadcast(new RecalibrationReport(BucketUtils.openFile(bqsrRecalFile, gcsOptions)));
-        final JavaRDD<GATKRead> recalibratedReads = ApplyBQSRSparkFn.apply(initialReads, recalibrationReportBroadCast, readsHeader, applyBQSRArgs);
+        final JavaRDD<GATKRead> recalibratedReads = ApplyBQSRSparkFn.apply(initialReads, recalibrationReportBroadCast, getHeaderForReads(), applyBQSRArgs);
 
         try {
-            ReadsSparkSink.writeReads(ctx, output, recalibratedReads, readsHeader, shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE);
+            ReadsSparkSink.writeReads(ctx, output, recalibratedReads, getHeaderForReads(), shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE);
         } catch (IOException e) {
             throw new GATKException("unable to write bam: " + e);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/CountReadsSpark.java
@@ -12,6 +12,7 @@ import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalInterva
 import org.broadinstitute.hellbender.cmdline.argumentcollections.ReadInputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.RequiredReadInputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
 import org.broadinstitute.hellbender.exceptions.UserException;
@@ -27,15 +28,12 @@ import java.io.PrintStream;
 import java.util.List;
 
 @CommandLineProgramProperties(summary = "Counts reads in the input BAM", oneLineSummary = "Counts reads in a BAM file", programGroup = SparkProgramGroup.class)
-public final class CountReadsSpark extends SparkCommandLineProgram {
+public final class CountReadsSpark extends GATKSparkTool {
 
     private static final long serialVersionUID = 1L;
 
-    @ArgumentCollection
-    public ReadInputArgumentCollection readArguments= new RequiredReadInputArgumentCollection();;
-
-    @ArgumentCollection
-    private IntervalArgumentCollection intervalArgumentCollection = new OptionalIntervalArgumentCollection();
+    @Override
+    public boolean requiresReads() { return true; }
 
     @Argument(doc = "uri for the output file: a local file path",
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
@@ -43,23 +41,12 @@ public final class CountReadsSpark extends SparkCommandLineProgram {
     public String out;
 
     @Override
-    protected void runPipeline(final JavaSparkContext ctx) {
-        if ( readArguments.getReadFilesNames().size() != 1 ) {
-            throw new UserException("This tool only accepts a single bam/sam/cram as input");
-        }
-        final String bam = readArguments.getReadFilesNames().get(0);
-        final ReadsSparkSource readSource = new ReadsSparkSource(ctx);
+    protected void runTool(final JavaSparkContext ctx) {
+        final JavaRDD<GATKRead> reads = getReads();
 
-        SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam);
-        /**
-         * If no intervals are provided, we want all reads, mapped and unmapped.
-         */
-        final List<SimpleInterval> intervals = intervalArgumentCollection.intervalsSpecified() ? intervalArgumentCollection.getIntervals(readsHeader.getSequenceDictionary())
-                : null;
-
-        final JavaRDD<GATKRead> reads = readSource.getParallelReads(bam, intervals);
         final long count = reads.count();
         System.out.println(count);
+
         if (out != null){
             final File file = new File(out);
             try(final OutputStream outputStream = BucketUtils.createFile(file.getPath(), null);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/FlagStatSpark.java
@@ -1,25 +1,14 @@
 package org.broadinstitute.hellbender.tools.spark.pipelines;
 
-import htsjdk.samtools.SAMFileHeader;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.cmdline.Argument;
-import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalIntervalArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.ReadInputArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.RequiredReadInputArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.programgroups.DataFlowProgramGroup;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
-import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.tools.FlagStat;
 import org.broadinstitute.hellbender.tools.FlagStat.FlagStatus;
-import org.broadinstitute.hellbender.utils.IntervalUtils;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.dataflow.BucketUtils;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 
@@ -27,18 +16,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.util.List;
 
 @CommandLineProgramProperties(summary ="runs FlagStat on Spark", oneLineSummary = "FlagStat", programGroup = SparkProgramGroup.class)
-public final class FlagStatSpark extends SparkCommandLineProgram {
+public final class FlagStatSpark extends GATKSparkTool {
 
     private static final long serialVersionUID = 1L;
 
-    @ArgumentCollection
-    public ReadInputArgumentCollection readArguments= new RequiredReadInputArgumentCollection();;
-
-    @ArgumentCollection
-    public IntervalArgumentCollection intervalArgumentCollection = new OptionalIntervalArgumentCollection();
+    @Override
+    public boolean requiresReads() { return true; }
 
     @Argument(doc = "uri for the output file: a local file path",
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
@@ -46,24 +31,13 @@ public final class FlagStatSpark extends SparkCommandLineProgram {
     public String out;
 
     @Override
-    protected void runPipeline(final JavaSparkContext ctx) {
-        if ( readArguments.getReadFilesNames().size() != 1 ) {
-            throw new UserException("This tool only accepts a single bam/sam/cram as input");
-        }
-        final String bam = readArguments.getReadFilesNames().get(0);
-        final ReadsSparkSource readSource = new ReadsSparkSource(ctx);
-        SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam);
+    protected void runTool(final JavaSparkContext ctx) {
+        final JavaRDD<GATKRead> reads = getReads();
 
-        /**
-         * If no intervals specified - use all reads, mapped and unmapped.
-         */
-        final List<SimpleInterval> intervals = intervalArgumentCollection.intervalsSpecified() ? intervalArgumentCollection.getIntervals(readsHeader.getSequenceDictionary())
-                : null;
-
-        final JavaRDD<GATKRead> reads = readSource.getParallelReads(bam, intervals);
         final FlagStatus result = reads.aggregate(new FlagStatus(), FlagStatus::add, FlagStatus::merge);
-        final File file = new File(out);
         System.out.println(result);
+
+        final File file = new File(out);
         try(final OutputStream outputStream = BucketUtils.createFile(file.getPath(), null);
             final PrintStream ps = new PrintStream(outputStream)) {
             ps.print(result);

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/PrintReadsSpark.java
@@ -4,40 +4,28 @@ import htsjdk.samtools.SAMFileHeader;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.broadinstitute.hellbender.cmdline.Argument;
-import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalIntervalArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.ReadInputArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.RequiredReadInputArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
-import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSink;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.exceptions.UserException;
-import org.broadinstitute.hellbender.utils.IntervalUtils;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 
 import java.io.IOException;
-import java.util.List;
 
 @CommandLineProgramProperties(summary = "Print reads from the input BAM", oneLineSummary = "Print reads from the input BAM", programGroup = SparkProgramGroup.class)
-public final class PrintReadsSpark extends SparkCommandLineProgram {
+public final class PrintReadsSpark extends GATKSparkTool {
 
     public static final String SHARDED_OUTPUT_LONG_ARG = "shardedOutput";
     public static final String SHARDED_OUTPUT_SHORT_ARG = "shardedOutput";
 
     private static final long serialVersionUID = 1L;
 
-    @ArgumentCollection
-    public ReadInputArgumentCollection readArguments= new RequiredReadInputArgumentCollection();
-
-    @ArgumentCollection
-    public IntervalArgumentCollection intervalArgumentCollection = new OptionalIntervalArgumentCollection();
+    @Override
+    public boolean requiresReads() { return true; }
 
     @Argument(doc = "uri for the output file: a local file path",
             shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME,
@@ -48,30 +36,16 @@ public final class PrintReadsSpark extends SparkCommandLineProgram {
     public boolean shardedOutput = false;
 
     @Override
-    protected void runPipeline(final JavaSparkContext ctx) {
-        if ( readArguments.getReadFilesNames().size() != 1 ) {
-            throw new UserException("This tool only accepts a single bam/sam/cram as input");
-        }
-        final String bam = readArguments.getReadFilesNames().get(0);
-
-        final ReadsSparkSource readSource = new ReadsSparkSource(ctx);
-        final SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam);
-
-        if (readsHeader.getSortOrder() != SAMFileHeader.SortOrder.coordinate){
+    protected void runTool(final JavaSparkContext ctx) {
+        if (getHeaderForReads().getSortOrder() != SAMFileHeader.SortOrder.coordinate){
             //https://github.com/broadinstitute/hellbender/issues/929
             throw new UserException("PrintReadsSpark: Only coordinate-sorted files are currently supported");
         }
 
-        /*
-         * If no intervals are given, we want all reads, mapped and unmapped.
-         */
-        final List<SimpleInterval> intervals =  intervalArgumentCollection.intervalsSpecified() ?
-                intervalArgumentCollection.getIntervals(readsHeader.getSequenceDictionary()) :
-                null;
-        final JavaRDD<GATKRead> reads= readSource.getParallelReads(bam, intervals);
+        final JavaRDD<GATKRead> reads = getReads();
 
         try {
-            ReadsSparkSink.writeReads(ctx, output, reads, readsHeader, shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE);
+            ReadsSparkSink.writeReads(ctx, output, reads, getHeaderForReads(), shardedOutput ? ReadsWriteFormat.SHARDED : ReadsWriteFormat.SINGLE);
         } catch (final IOException e) {
             throw new GATKException("unable to write bam: " + e);
         }

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortBamSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/pipelines/SortBamSpark.java
@@ -7,9 +7,8 @@ import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
-import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSink;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadCoordinateComparator;
@@ -19,31 +18,29 @@ import scala.Tuple2;
 import java.io.IOException;
 
 @CommandLineProgramProperties(summary = "Sorts the input BAM", oneLineSummary = "Sorts a BAM file", programGroup = SparkProgramGroup.class)
-public final class SortBamSpark extends SparkCommandLineProgram {
-
+public final class SortBamSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
+
+    @Override
+    public boolean requiresReads() { return true; }
 
     @Argument(doc="the output file path", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
     protected String outputFile;
-
-    @Argument(doc = "uri for the input bam, either a local file path, hdfs:// path, or a gs:// bucket path",
-            shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.INPUT_LONG_NAME,
-            optional = false)
-    protected String bam;
 
     @Argument(doc="The output parallelism, sets the number of reducers. Defaults to the number of partitions in the input.",
             shortName = "P", fullName = "parallelism", optional = true)
     protected int parallelism = 0;
 
     @Override
-    protected void runPipeline(final JavaSparkContext ctx) {
-        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
-        SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam);
-        JavaRDD<GATKRead> reads = readSource.getParallelReads(bam, null);
+    protected void runTool(final JavaSparkContext ctx) {
+        JavaRDD<GATKRead> reads = getReads();
+
         if (parallelism == 0) { // use the number of partitions in the input
             parallelism = reads.partitions().size();
         }
         System.out.println("Using parallelism of " + parallelism);
+
+        final SAMFileHeader readsHeader = getHeaderForReads();
         ReadCoordinateComparator comparator = new ReadCoordinateComparator(readsHeader);
         JavaRDD<GATKRead> sortedReads = reads
                 .mapToPair(read -> new Tuple2<>(read, null))

--- a/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/spark/transforms/markduplicates/MarkDuplicatesSpark.java
@@ -8,16 +8,11 @@ import org.broadinstitute.hellbender.cmdline.Argument;
 import org.broadinstitute.hellbender.cmdline.ArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.CommandLineProgramProperties;
 import org.broadinstitute.hellbender.cmdline.StandardArgumentDefinitions;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.IntervalArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.argumentcollections.OpticalDuplicatesArgumentCollection;
-import org.broadinstitute.hellbender.cmdline.argumentcollections.OptionalIntervalArgumentCollection;
 import org.broadinstitute.hellbender.cmdline.programgroups.SparkProgramGroup;
-import org.broadinstitute.hellbender.engine.spark.SparkCommandLineProgram;
+import org.broadinstitute.hellbender.engine.spark.GATKSparkTool;
 import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSink;
-import org.broadinstitute.hellbender.engine.spark.datasources.ReadsSparkSource;
 import org.broadinstitute.hellbender.exceptions.GATKException;
-import org.broadinstitute.hellbender.utils.IntervalUtils;
-import org.broadinstitute.hellbender.utils.SimpleInterval;
 import org.broadinstitute.hellbender.utils.read.GATKRead;
 import org.broadinstitute.hellbender.utils.read.ReadsWriteFormat;
 import org.broadinstitute.hellbender.utils.read.markduplicates.DuplicationMetrics;
@@ -25,19 +20,16 @@ import org.broadinstitute.hellbender.utils.read.markduplicates.OpticalDuplicateF
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 @CommandLineProgramProperties(
         summary ="Marks duplicates on spark",
         oneLineSummary ="Mark Duplicates",
         programGroup = SparkProgramGroup.class)
-public final class MarkDuplicatesSpark extends SparkCommandLineProgram {
+public final class MarkDuplicatesSpark extends GATKSparkTool {
     private static final long serialVersionUID = 1L;
 
-    @Argument(doc = "uri for the input bam, either a local file path, a hdfs:// path, or a gs:// bucket path",
-            shortName = StandardArgumentDefinitions.INPUT_SHORT_NAME, fullName = StandardArgumentDefinitions.INPUT_LONG_NAME,
-            optional = false)
-    protected String bam;
+    @Override
+    public boolean requiresReads() { return true; }
 
     @Argument(doc = "the output bam", shortName = StandardArgumentDefinitions.OUTPUT_SHORT_NAME,
             fullName = StandardArgumentDefinitions.OUTPUT_LONG_NAME, optional = false)
@@ -53,9 +45,6 @@ public final class MarkDuplicatesSpark extends SparkCommandLineProgram {
     @Argument(doc="The output parallelism, sets the number of reducers. Defaults to the number of partitions in the input.",
             shortName = "P", fullName = "parallelism", optional = true)
     protected int parallelism = 0;
-
-    @ArgumentCollection
-    protected IntervalArgumentCollection intervalArgumentCollection = new OptionalIntervalArgumentCollection();
 
     public static JavaRDD<GATKRead> mark(final JavaRDD<GATKRead> reads, final SAMFileHeader header,
                                          final OpticalDuplicateFinder opticalDuplicateFinder) {
@@ -77,28 +66,25 @@ public final class MarkDuplicatesSpark extends SparkCommandLineProgram {
     }
 
     @Override
-    protected void runPipeline(final JavaSparkContext ctx) {
-        ReadsSparkSource readSource = new ReadsSparkSource(ctx);
-        SAMFileHeader readsHeader = ReadsSparkSource.getHeader(ctx, bam);
-        final List<SimpleInterval> intervals = intervalArgumentCollection.intervalsSpecified() ? intervalArgumentCollection.getIntervals(readsHeader.getSequenceDictionary())
-                : IntervalUtils.getAllIntervalsForReference(readsHeader.getSequenceDictionary());
-        JavaRDD<GATKRead> reads = readSource.getParallelReads(bam, intervals);
+    protected void runTool(final JavaSparkContext ctx) {
+        JavaRDD<GATKRead> reads = getReads();
+
         if (parallelism == 0) { // use the number of partitions in the input
             parallelism = reads.partitions().size();
         }
         final OpticalDuplicateFinder finder = opticalDuplicatesArgumentCollection.READ_NAME_REGEX != null ?
                 new OpticalDuplicateFinder(opticalDuplicatesArgumentCollection.READ_NAME_REGEX, opticalDuplicatesArgumentCollection.OPTICAL_DUPLICATE_PIXEL_DISTANCE, null) : null;
 
-        final JavaRDD<GATKRead> finalReads = mark(reads, readsHeader, finder, parallelism);
+        final JavaRDD<GATKRead> finalReads = mark(reads, getHeaderForReads(), finder, parallelism);
 
         try {
-            ReadsSparkSink.writeReads(ctx, output, finalReads, readsHeader, parallelism == 1 ? ReadsWriteFormat.SINGLE : ReadsWriteFormat.SHARDED);
+            ReadsSparkSink.writeReads(ctx, output, finalReads, getHeaderForReads(), parallelism == 1 ? ReadsWriteFormat.SINGLE : ReadsWriteFormat.SHARDED);
         } catch (IOException e) {
             throw new GATKException("unable to write bam: " + e);
         }
 
         if (metricsFile != null) {
-            final JavaPairRDD<String, DuplicationMetrics> metrics = MarkDuplicatesSparkUtils.generateMetrics(readsHeader, finalReads);
+            final JavaPairRDD<String, DuplicationMetrics> metrics = MarkDuplicatesSparkUtils.generateMetrics(getHeaderForReads(), finalReads);
             MarkDuplicatesSparkUtils.writeMetricsToFile(metrics, metricsFile);
         }
     }


### PR DESCRIPTION
-Created a new base class for Spark tools, GATKSparkTool, that centrally manages
 and validates standard tool inputs (reads, reference, and intervals). This allows
 us to enforce consistency across tools, delete duplicated boilerplate code from tools
 to load inputs, and perform standard kinds of validation (eg., sequence dictionary
 validation) in one place.

-Tools that don't fit into the pattern established by GATKSparkTool can still extend
 SparkCommandLineProgram directly.

-This is just a first step -- there is still much work to be done to unify our data source
 classes and transparently handle inputs from different sources (GCS, hdfs, files), but
 having inputs centrally managed should make the remaining tasks much easier.